### PR TITLE
Reorder clock IDs to match implementation

### DIFF
--- a/design/WASI-core.md
+++ b/design/WASI-core.md
@@ -1109,6 +1109,11 @@ Used by [`__wasi_subscription_t`](#subscription), [`__wasi_clock_res_get()`](#cl
 
 Possible values:
 
+- <a href="#clockid.realtime" name="clockid.realtime"></a>**`__WASI_CLOCK_REALTIME`**
+
+    The clock measuring real time. Time value
+    zero corresponds with 1970-01-01T00:00:00Z.
+
 - <a href="#clockid.monotonic" name="clockid.monotonic"></a>**`__WASI_CLOCK_MONOTONIC`**
 
     The store-wide monotonic clock, which is defined as a
@@ -1122,11 +1127,6 @@ Possible values:
 
     The CPU-time clock associated with the current
     process.
-
-- <a href="#clockid.realtime" name="clockid.realtime"></a>**`__WASI_CLOCK_REALTIME`**
-
-    The clock measuring real time. Time value
-    zero corresponds with 1970-01-01T00:00:00Z.
 
 - <a href="#clockid.thread_cputime_id" name="clockid.thread_cputime_id"></a>**`__WASI_CLOCK_THREAD_CPUTIME_ID`**
 


### PR DESCRIPTION
We had  a small bug in our implementation because we assumed that the order listed in the docs was the order of the enumeration starting at 0.  This PR makes that assumption correct