### PR TITLE
WatIDL - strawman text format for wasm interfaces 

### DIFF
--- a/watidl/wasi-core.watidl
+++ b/watidl/wasi-core.watidl
@@ -1,5 +1,5 @@
 (type $size_t u64)
-(type $string_arrary (array string))
+(type $string_array (array string))
 
 (interface $wasi (export "__wasi")
 	(type $iovec_t_array (array $iovec_t))
@@ -650,7 +650,7 @@
 
 (interface $fd extends $wasi
 	;; Relative offset within a file.
-	(type $filedelta_t i64)
+	(type $filedelta_t s64)
 
 	;; The position relative to which to set the offset of the file descriptor.
 	(type $whence_t

--- a/watidl/wasi-core.watidl
+++ b/watidl/wasi-core.watidl
@@ -308,7 +308,7 @@
     ;; The maximum lag (exclusive) that the returned time value may have, compared to its actual value.
     (param $precision $timestamp_t)
     ;; The time value of the clock.
-    (result $time $wasi.timestamp_t)
+    (result $time $timestamp_t)
   ) 
 )
 
@@ -460,7 +460,7 @@
   ;; Provide file advisory information on a file descriptor.
   ;; Note: This is similar to posix_fadvise in POSIX.
   (func (export "advise")
-    (param $this $fd_ref)
+    (method $fd_ref)
     (param $offset $filesize_t) ;; The offset within the file to which the advisory applies.
     (param $len $filesize_t) ;; The length of the region to which the advisory applies.
     (param $advice $advice_t) ;; The advice.
@@ -502,7 +502,7 @@
   (func (export "fdstat_set_flags")
     (method $fd_ref) 
     ;; The desired values of the file descriptor flags.
-    (param $flags $wasi.fdflags)
+    (param $flags $fdflags)
   )
 
   ;;  Adjust the rights associated with a file descriptor.
@@ -510,15 +510,15 @@
   (func (export "fdstat_set_rights") 
     (method $fd_ref) 
     ;; The desired rights of the file descriptor.
-    (param $fs_rights_base $wasi.rights_t)
-    (param $fs_rights_inheriting $wasi.rights_t)
+    (param $fs_rights_base $rights_t)
+    (param $fs_rights_inheriting $rights_t)
   )
 
   ;; Return the attributes of an open file.
   (func (export "filestat_get")
     (method $fd_ref) 
     ;; The buffer where the file's attributes are stored.
-    (result $fs_rights_base $wasi.rights_t)
+    (result $fs_rights_base $rights_t)
   )
 
   ;; Adjust the size of an open file. If this increases the file's size, the extra bytes are filled with zeros.
@@ -534,11 +534,11 @@
   (func (export "filestat_set_times")
     (method $fd_ref) 
     ;; The desired values of the data access timestamp.
-    (param $st_atim $wasi.timestamp_t)
+    (param $st_atim $timestamp_t)
     ;; The desired values of the data modification timestamp.
-    (param $st_mtim $wasi.timestamp_t)
+    (param $st_mtim $timestamp_t)
     ;; A bitmask indicating which timestamps to adjust.
-    (param $fst_flags $wasi.fstflags_t)
+    (param $fst_flags $fstflags_t)
   )
 
   ;; Read from a file descriptor, without using and updating the file descriptor's offset.
@@ -1100,7 +1100,7 @@
   (func (export "send")
     (method $fd_ref)
     ;; List of scatter/gather vectors to which to retrieve data
-    (param $si_data $wasi.ciovec_t_array)
+    (param $si_data $ciovec_t_array)
     ;; Message flags.
     (param $si_flags $siflags_t)
     ;; Number of bytes transmitted.

--- a/watidl/wasi-core.watidl
+++ b/watidl/wasi-core.watidl
@@ -1,27 +1,12 @@
-
 (interface $wasi
   (type $size_t u64)
   (type $string_array (array string))
-  (type $iovec_t_array (array $iovec_t))
-  (type $ciovec_t_array (array $ciovec_t))
 
-  ;; A region of memory for scatter/gather reads.
-  (type $iovec_t
-    (struct
-      ;; The address and length of the buffer to be filled.
-      (field $buf data)
-      (field $buf_len data)
-    )
-  )
-
-  ;; A region of memory for scatter/gather writes.
-  (type $ciovec_t
-    (struct
-      ;; The address and length of the buffer to be written.
-      (field $buf data)
-      (field $buf_len data)
-    )
-  )
+  ;; Non-negative file size or length of a region within a file.
+  (type $filesize_t u64)
+  
+  ;; Timestamp in nanoseconds.
+  (type $timestamp_t u64) 
 
   ;;Identifiers for clocks.
   (type $clockid_t 
@@ -199,245 +184,6 @@
     )
   )
 
-
-  ;; File descriptor flags.
-  (type $fdflags_t
-    (struct
-      ;; Append mode: Data written to the file is always appended to the file's end.
-      (field $FDFLAG_APPEND Bool)
-      ;; Write according to synchronized I/O data integrity completion. Only the data stored in the file is synchronized.
-      (field $FDFLAG_DSYNC Bool)
-      ;; Non-blocking mode.
-      (field $FDFLAG_NONBLOCK Bool)
-      ;; Synchronized read I/O operations.
-      (field $FDFLAG_RSYNC Bool)
-      ;; Write according to synchronized I/O file integrity completion. In addition to synchronizing the data stored in the file, the implementation may also synchronously update the file's metadata.
-      (field $FDFLAG_SYNC Bool)
-    )
-  )
-
-  ;; File descriptor attributes.
-  (type $fdstat_t 
-    ;; File type.
-    (field $fs_filetype $filetype_t)
-    ;; File descriptor flags.
-    (field $fs_flags $fdflags_t)
-    ;; Rights that apply to this file descriptor.
-    (field $fs_rights_base $rights_t)
-    ;; Maximum set of rights that may be installed on new file descriptors that are created through this file descriptor, e.g., through __wasi_path_open().
-    (field $fs_rights_inheriting $rights_t)
-  )
-
-  ;; Non-negative file size or length of a region within a file.
-  (type $filesize_t u64)
-
-  ;; Identifier for a device containing a file system. Can be used in combination with __wasi_inode_t to uniquely identify a file or directory in the filesystem.
-  (type $device_t u64)
-
-  ;; File attributes.
-  (type $filestat_t
-    (struct
-      ;; Device ID of device containing the file.
-      (field $st_dev $device_t)
-      ;; File serial number.
-      (field $st_ino $inode_t)
-      ;; File type.
-      (field $st_filetype $filetype_t)
-      ;; Number of hard links to the file.
-      (field $st_nlink $linkcount_t)
-      ;; For regular files, the file size in bytes. For symbolic links, the length in bytes of the pathname contained in the symbolic link.
-      (field $st_size $filesize_t)
-      ;; Last data access timestamp.
-      (field $st_atim $timestamp_t)
-      ;; Last data modification timestamp.
-      (field $st_mtim $timestamp_t)
-      ;; Last file status change timestamp.
-      (field $st_ctim $timestamp_t)
-    )
-  )
-
-  ;; The type of a file descriptor or file.
-  (type $filetype_t
-    (enum
-      ;; The type of the file descriptor or file is unknown or is different from any of the other types specified.
-      $FILETYPE_UNKNOWN
-      ;; The file descriptor or file refers to a block device inode.
-      $FILETYPE_BLOCK_DEVICE
-      ;; The file descriptor or file refers to a character device inode.
-      $FILETYPE_CHARACTER_DEVICE
-      ;; The file descriptor or file refers to a directory inode.
-      $FILETYPE_DIRECTORY
-      ;; The file descriptor or file refers to a regular file inode.
-      $FILETYPE_REGULAR_FILE
-      ;; The file descriptor or file refers to a datagram socket.
-      $FILETYPE_SOCKET_DGRAM
-      ;; The file descriptor or file refers to a byte-stream socket.
-      $FILETYPE_SOCKET_STREAM
-      ;; The file refers to a symbolic link inode.
-      $FILETYPE_SYMBOLIC_LINK
-    )
-  )
-
-  ;; Which file time attributes to adjust.
-  (type $fstflags_t
-    (struct 
-      ;; Adjust the last data access timestamp to the value stored in __wasi_filestat_t::st_atim.
-      (field $FILESTAT_SET_ATIM Bool)
-      ;; Adjust the last data access timestamp to the time of clock __WASI_CLOCK_REALTIME.
-      (field $FILESTAT_SET_ATIM_NOW Bool)
-      ;; Adjust the last data modification timestamp to the value stored in __wasi_filestat_t::st_mtim.
-      (field $FILESTAT_SET_MTIM Bool)
-      ;; Adjust the last data modification timestamp to the time of clock __WASI_CLOCK_REALTIME.
-      (field $FILESTAT_SET_MTIM_NOW Bool)
-    )
-  )
-
-  ;; File serial number that is unique within its file system.
-  (type $inode_t u64)
-
-  ;; Number of hard links to an inode.
-  (type $linkcount_t u32)
-
-  ;; Signal condition.
-  (type $signal_t
-    (enum
-      ;; Process abort signal.
-      ;; Action: Terminates the process.
-      $SIGABRT
-      ;; Alarm clock.
-      ;; Action: Terminates the process.
-      $SIGALRM
-      ;; Access to an undefined portion of a memory object.
-      ;; Action: Terminates the process.
-      $SIGBUS
-      ;; Child process terminated, stopped, or continued.
-      ;; Action: Ignored.
-      $SIGCHLD
-      ;; Continue executing, if stopped.
-      ;; Action: Continues executing, if stopped.
-      $SIGCONT
-      ;; Erroneous arithmetic operation.
-      ;; Action: Terminates the process.
-      $SIGFPE
-      ;; Hangup.
-      ;; Action: Terminates the process.
-      $SIGHUP
-      ;; Illegal instruction.
-      ;; Action: Terminates the process.
-      $SIGILL
-      ;; Terminate interrupt signal.
-      ;; Action: Terminates the process.
-      $SIGINT
-      ;; Kill.
-      ;; Action: Terminates the process.
-      $SIGKILL
-      ;; Write on a pipe with no one to read it.
-      ;; Action: Ignored.
-      $SIGPIPE
-      ;; Terminal quit signal.
-      ;; Action: Terminates the process.
-      $SIGQUIT
-      ;; Invalid memory reference.
-      ;; Action: Terminates the process.
-      $SIGSEGV
-      ;; Stop executing.
-      ;; Action: Stops executing.
-      $SIGSTOP
-      ;; Bad system call.
-      ;; Action: Terminates the process.
-      $SIGSYS
-      ;; Termination signal.
-      ;; Action: Terminates the process.
-      $SIGTERM
-      ;; Trace/breakpoint trap.
-      ;; Action: Terminates the process.
-      $SIGTRAP
-      ;; Terminal stop signal.
-      ;; Action: Stops executing.
-      $SIGTSTP
-      ;; Background process attempting read.
-      ;; Action: Stops executing.
-      $SIGTTIN
-      ;; Background process attempting write.
-      ;; Action: Stops executing.
-      $SIGTTOU
-      ;; High bandwidth data is available at a socket.
-      ;; Action: Ignored.
-      $SIGURG
-      ;; User-defined signal 1.
-      ;; Action: Terminates the process.
-      $SIGUSR1
-      ;; User-defined signal 2.
-      ;; Action: Terminates the process.
-      $SIGUSR2
-      ;; Virtual timer expired.
-      ;; Action: Terminates the process.
-      $SIGVTALRM
-      ;; CPU time limit exceeded.
-      ;; Action: Terminates the process.
-      $SIGXCPU
-      ;; File size limit exceeded.
-      ;; Action: Terminates the process.
-      $SIGXFSZ
-    )
-  )
-
-  ;; Flags determining how to interpret the timestamp provided in __wasi_subscription_t::u.clock.timeout.
-  (type $subclockflags_t
-    (struct
-      ;; If set, treat the timestamp provided in __wasi_subscription_t::u.clock.timeout as an absolute timestamp of clock __wasi_subscription_t::u.clock.clock_id.
-      ;; If clear, treat the timestamp provided in __wasi_subscription_t::u.clock.timeout relative to the current time value of clock __wasi_subscription_t::u.clock.clock_id.
-      (field $SUBSCRIPTION_CLOCK_ABSTIME Bool)
-    )
-  )
-
-  ;; Subscription to an event.
-  (type $subscription_t
-    (struct
-      ;; User-provided value that is attached to the subscription in the implementation and returned through __wasi_event_t::userdata.
-      (field $userdata $userdata_t)
-      ;; The type of the event to which to subscribe.
-      (field $type $eventtype_t)
-      (field 
-        (type
-          (union
-            ;; When type is __WASI_EVENTTYPE_CLOCK
-            (field $clock
-              (type 
-                (struct
-                  ;; The user-defined unique identifier of the clock.
-                  (field $identifier $userdata_t)
-                  ;; The clock against which to compare the timestamp.
-                  (field $clock_id $clockid_t)
-                  ;; The absolute or relative timestamp.
-                  (field $timeout $timestamp_t)
-                  ;; The amount of time that the implementation may wait additionally to coalesce with other events.
-                  ;; Flags specifying whether the timeout is absolute or relative
-                  (field $precision $timestamp_t)
-                )
-              )
-            )
-            ;; When type is __WASI_EVENTTYPE_FD_READ or __WASI_EVENTTYPE_FD_WRITE:
-            (field $fd_readwrite
-              (type
-                (struct
-                  ;; The file descriptor on which to wait for it to become ready for reading or writing.
-                  (field $file_descriptor $fd_ref)
-                )
-              )
-            )
-          )
-        )
-      )
-    )
-  )
-
-  ;; Timestamp in nanoseconds.
-  (type $timestamp_t u64) 
-
-  ;; User-provided value that may be attached to objects that is retained when extracted from the implementation.
-  (type $userdata_t u64)
-
   ;; File descriptor rights, determining which actions may be performed.
   (type $rights_t
     (struct
@@ -550,17 +296,17 @@
   ;; Note: This is similar to clock_getres in POSIX.
   (func (export "res_get")
     ;; The clock for which to return the resolution.
-    (param $clock_id $wasi.clockid_t)
+    (param $clock_id $clockid_t)
     ;; The resolution of the clock.
-    (result $resolution $wasi.timestamp_t)
+    (result $resolution $timestamp_t)
   ) 
   ;; Return the time value of a clock.
   ;; Note: This is similar to clock_gettime in POSIX.
   (func (export "time_get")
     ;; The clock for which to return the time.
-    (param $clock_id $wasi.clockid_t)
+    (param $clock_id $clockid_t)
     ;; The maximum lag (exclusive) that the returned time value may have, compared to its actual value.
-    (param $precision $wasi.timestamp_t)
+    (param $precision $timestamp_t)
     ;; The time value of the clock.
     (result $time $wasi.timestamp_t)
   ) 
@@ -569,6 +315,27 @@
 (interface $fd extends $wasi
   ;; a reference to a file descriptor
   (type $fd_ref anyref)
+
+  (type $iovec_t_array (array $iovec_t))
+  (type $ciovec_t_array (array $ciovec_t))
+
+  ;; A region of memory for scatter/gather reads.
+  (type $iovec_t
+    (struct
+      ;; The address and length of the buffer to be filled.
+      (field $buf data)
+      (field $buf_len data)
+    )
+  )
+
+  ;; A region of memory for scatter/gather writes.
+  (type $ciovec_t
+    (struct
+      ;; The address and length of the buffer to be written.
+      (field $buf data)
+      (field $buf_len data)
+    )
+  )
 
   ;; Relative offset within a file.
   (type $filedelta_t s64)
@@ -620,7 +387,75 @@
     )
   )
 
+  ;; File descriptor flags.
+  (type $fdflags_t
+    (struct
+      ;; Append mode: Data written to the file is always appended to the file's end.
+      (field $FDFLAG_APPEND Bool)
+      ;; Write according to synchronized I/O data integrity completion. Only the data stored in the file is synchronized.
+      (field $FDFLAG_DSYNC Bool)
+      ;; Non-blocking mode.
+      (field $FDFLAG_NONBLOCK Bool)
+      ;; Synchronized read I/O operations.
+      (field $FDFLAG_RSYNC Bool)
+      ;; Write according to synchronized I/O file integrity completion. In addition to synchronizing the data stored in the file, the implementation may also synchronously update the file's metadata.
+      (field $FDFLAG_SYNC Bool)
+    )
+  )
 
+  ;; File descriptor attributes.
+  (type $fdstat_t 
+    ;; File type.
+    (field $fs_filetype $filetype_t)
+    ;; File descriptor flags.
+    (field $fs_flags $fdflags_t)
+    ;; Rights that apply to this file descriptor.
+    (field $fs_rights_base $rights_t)
+    ;; Maximum set of rights that may be installed on new file descriptors that are created through this file descriptor, e.g., through __wasi_path_open().
+    (field $fs_rights_inheriting $rights_t)
+  )
+
+  ;; Identifier for a device containing a file system. Can be used in combination with __wasi_inode_t to uniquely identify a file or directory in the filesystem.
+  (type $device_t u64)
+
+  ;; The type of a file descriptor or file.
+  (type $filetype_t
+    (enum
+      ;; The type of the file descriptor or file is unknown or is different from any of the other types specified.
+      $FILETYPE_UNKNOWN
+      ;; The file descriptor or file refers to a block device inode.
+      $FILETYPE_BLOCK_DEVICE
+      ;; The file descriptor or file refers to a character device inode.
+      $FILETYPE_CHARACTER_DEVICE
+      ;; The file descriptor or file refers to a directory inode.
+      $FILETYPE_DIRECTORY
+      ;; The file descriptor or file refers to a regular file inode.
+      $FILETYPE_REGULAR_FILE
+      ;; The file descriptor or file refers to a datagram socket.
+      $FILETYPE_SOCKET_DGRAM
+      ;; The file descriptor or file refers to a byte-stream socket.
+      $FILETYPE_SOCKET_STREAM
+      ;; The file refers to a symbolic link inode.
+      $FILETYPE_SYMBOLIC_LINK
+    )
+  )
+
+  ;; Which file time attributes to adjust.
+  (type $fstflags_t
+    (struct 
+      ;; Adjust the last data access timestamp to the value stored in __wasi_filestat_t::st_atim.
+      (field $FILESTAT_SET_ATIM Bool)
+      ;; Adjust the last data access timestamp to the time of clock __WASI_CLOCK_REALTIME.
+      (field $FILESTAT_SET_ATIM_NOW Bool)
+      ;; Adjust the last data modification timestamp to the value stored in __wasi_filestat_t::st_mtim.
+      (field $FILESTAT_SET_MTIM Bool)
+      ;; Adjust the last data modification timestamp to the time of clock __WASI_CLOCK_REALTIME.
+      (field $FILESTAT_SET_MTIM_NOW Bool)
+    )
+  )
+
+  ;; File serial number that is unique within its file system.
+  (type $inode_t u64)
 
   ;; Provide file advisory information on a file descriptor.
   ;; Note: This is similar to posix_fadvise in POSIX.
@@ -637,9 +472,9 @@
   (func (export "allocate")
     (method $fd_ref) 
     ;; The offset at which to start the allocation.
-    (param $offset $wasi.filesize_t) 
+    (param $offset $filesize_t) 
     ;; The length of the area that is allocated.
-    (param $len $wasi.filesize_t)
+    (param $len $filesize_t)
   )
 
   ;; Close a file descriptor.
@@ -659,7 +494,7 @@
   (func (export "fdstat_get")
     (method $fd_ref) 
     ;; The buffer where the file descriptor's attributes are stored.
-    (result $wasi.fdstat_t) 
+    (result $fdstat_t) 
   )
 
   ;; Adjust the flags associated with a file descriptor.
@@ -691,7 +526,7 @@
   (func (export "filestat_set_size")
     (method $fd_ref) 
     ;; The desired file size.
-    (param $st_size $wasi.filesize_t)
+    (param $st_size $filesize_t)
   )
 
   ;; Adjust the timestamps of an open file or directory.
@@ -836,6 +671,31 @@
     )
   )
 
+  ;; Number of hard links to an inode.
+  (type $linkcount_t u32)
+
+  ;; File attributes.
+  (type $filestat_t
+    (struct
+      ;; Device ID of device containing the file.
+      (field $st_dev $device_t)
+      ;; File serial number.
+      (field $st_ino $inode_t)
+      ;; File type.
+      (field $st_filetype $filetype_t)
+      ;; Number of hard links to the file.
+      (field $st_nlink $linkcount_t)
+      ;; For regular files, the file size in bytes. For symbolic links, the length in bytes of the pathname contained in the symbolic link.
+      (field $st_size $filesize_t)
+      ;; Last data access timestamp.
+      (field $st_atim $timestamp_t)
+      ;; Last data modification timestamp.
+      (field $st_mtim $timestamp_t)
+      ;; Last file status change timestamp.
+      (field $st_ctim $timestamp_t)
+    )
+  )
+
   ;; Create a directory.
   ;; Note: This is similar to `mkdirat` in POSIX.
   (func (export "create_directory")
@@ -960,6 +820,9 @@
 ) 
 
 (interface $poll
+  ;; User-provided value that may be attached to objects that is retained when extracted from the implementation.
+  (type $userdata_t u64)
+
   ;; An event that occurred.
   (type $event_t
     (struct
@@ -1006,10 +869,60 @@
     )
   )
 
+  ;; Flags determining how to interpret the timestamp provided in __wasi_subscription_t::u.clock.timeout.
+  (type $subclockflags_t
+    (struct
+      ;; If set, treat the timestamp provided in __wasi_subscription_t::u.clock.timeout as an absolute timestamp of clock __wasi_subscription_t::u.clock.clock_id.
+      ;; If clear, treat the timestamp provided in __wasi_subscription_t::u.clock.timeout relative to the current time value of clock __wasi_subscription_t::u.clock.clock_id.
+      (field $SUBSCRIPTION_CLOCK_ABSTIME Bool)
+    )
+  )
+
+  ;; Subscription to an event.
+  (type $subscription_t
+    (struct
+      ;; User-provided value that is attached to the subscription in the implementation and returned through __wasi_event_t::userdata.
+      (field $userdata $userdata_t)
+      ;; The type of the event to which to subscribe.
+      (field $type $eventtype_t)
+      (field 
+        (type
+          (union
+            ;; When type is __WASI_EVENTTYPE_CLOCK
+            (field $clock
+              (type 
+                (struct
+                  ;; The user-defined unique identifier of the clock.
+                  (field $identifier $userdata_t)
+                  ;; The clock against which to compare the timestamp.
+                  (field $clock_id $clockid_t)
+                  ;; The absolute or relative timestamp.
+                  (field $timeout $timestamp_t)
+                  ;; The amount of time that the implementation may wait additionally to coalesce with other events.
+                  ;; Flags specifying whether the timeout is absolute or relative
+                  (field $precision $timestamp_t)
+                )
+              )
+            )
+            ;; When type is __WASI_EVENTTYPE_FD_READ or __WASI_EVENTTYPE_FD_WRITE:
+            (field $fd_readwrite
+              (type
+                (struct
+                  ;; The file descriptor on which to wait for it to become ready for reading or writing.
+                  (field $file_descriptor $fd_ref)
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+
   ;; Concurrently poll for the occurrence of a set of events.
   (func (export "oneoff")
     ;; The events to which to subscribe.
-    (param $in $wasi.subscription_t)
+    (param $in $subscription_t)
     ;; The events that have occurred.
     (param $out $wasi.event_t)
     ;; Both the number of subscriptions and events.
@@ -1022,6 +935,91 @@
 (interface $proc extends $wasi
   ;; Exit code generated by a process when exiting.
   (type $exitcode_t u32)
+
+  ;; Signal condition.
+  (type $signal_t
+    (enum
+      ;; Process abort signal.
+      ;; Action: Terminates the process.
+      $SIGABRT
+      ;; Alarm clock.
+      ;; Action: Terminates the process.
+      $SIGALRM
+      ;; Access to an undefined portion of a memory object.
+      ;; Action: Terminates the process.
+      $SIGBUS
+      ;; Child process terminated, stopped, or continued.
+      ;; Action: Ignored.
+      $SIGCHLD
+      ;; Continue executing, if stopped.
+      ;; Action: Continues executing, if stopped.
+      $SIGCONT
+      ;; Erroneous arithmetic operation.
+      ;; Action: Terminates the process.
+      $SIGFPE
+      ;; Hangup.
+      ;; Action: Terminates the process.
+      $SIGHUP
+      ;; Illegal instruction.
+      ;; Action: Terminates the process.
+      $SIGILL
+      ;; Terminate interrupt signal.
+      ;; Action: Terminates the process.
+      $SIGINT
+      ;; Kill.
+      ;; Action: Terminates the process.
+      $SIGKILL
+      ;; Write on a pipe with no one to read it.
+      ;; Action: Ignored.
+      $SIGPIPE
+      ;; Terminal quit signal.
+      ;; Action: Terminates the process.
+      $SIGQUIT
+      ;; Invalid memory reference.
+      ;; Action: Terminates the process.
+      $SIGSEGV
+      ;; Stop executing.
+      ;; Action: Stops executing.
+      $SIGSTOP
+      ;; Bad system call.
+      ;; Action: Terminates the process.
+      $SIGSYS
+      ;; Termination signal.
+      ;; Action: Terminates the process.
+      $SIGTERM
+      ;; Trace/breakpoint trap.
+      ;; Action: Terminates the process.
+      $SIGTRAP
+      ;; Terminal stop signal.
+      ;; Action: Stops executing.
+      $SIGTSTP
+      ;; Background process attempting read.
+      ;; Action: Stops executing.
+      $SIGTTIN
+      ;; Background process attempting write.
+      ;; Action: Stops executing.
+      $SIGTTOU
+      ;; High bandwidth data is available at a socket.
+      ;; Action: Ignored.
+      $SIGURG
+      ;; User-defined signal 1.
+      ;; Action: Terminates the process.
+      $SIGUSR1
+      ;; User-defined signal 2.
+      ;; Action: Terminates the process.
+      $SIGUSR2
+      ;; Virtual timer expired.
+      ;; Action: Terminates the process.
+      $SIGVTALRM
+      ;; CPU time limit exceeded.
+      ;; Action: Terminates the process.
+      $SIGXCPU
+      ;; File size limit exceeded.
+      ;; Action: Terminates the process.
+      $SIGXFSZ
+    )
+  )
+
 
   ;; Terminate the process normally. An exit code of 0 indicates successful termination of the program. The meanings of other values is dependent on the environment.
   (func (export "exit")
@@ -1082,7 +1080,6 @@
       (field $SHUT_WR Bool)
     )
   )
-
 
   ;; Receive a message from a socket.
   ;; Note: This is similar to recv in POSIX, though it also supports reading the data into multiple buffers in the manner of readv.

--- a/watidl/wasi-core.watidl
+++ b/watidl/wasi-core.watidl
@@ -1,0 +1,1076 @@
+(type $size_t u64)
+(type $string_arrary (array string))
+
+(interface $wasi (export "__wasi")
+	(type $iovec_t_array (array $iovec_t))
+	(type $ciovec_t_array (array $ciovec_t))
+	;; File or memory access pattern advisory information.
+	(type $advice_t
+		(enum
+			;; The application expects that it will not access the specified data in the near future.
+			$ADVICE_DONTNEED
+			;; The application expects to access the specified data once and then not reuse it thereafter.
+			$ADVICE_NOREUSE
+			;; The application has no advice to give on its behavior with respect to the specified data.
+			$ADVICE_NORMAL
+			;; The application expects to access the specified data in a random order.
+			$ADVICE_RANDOM
+			;; The application expects to access the specified data sequentially from lower offsets to higher offsets.
+			$ADVICE_SEQUENTIAL
+			;; The application expects to access the specified data in the near future.
+			$ADVICE_WILLNEED
+		)
+	)
+
+	;; A region of memory for scatter/gather reads.
+	(type $iovec_t
+		(struct
+			;; The address and length of the buffer to be filled.
+			(field $buf data)
+			(field $buf_len data)
+		)
+	)
+
+	;; A region of memory for scatter/gather writes.
+	(type $ciovec_t
+		(struct
+			;; The address and length of the buffer to be written.
+			(field $buf data)
+			(field $buf_len data)
+		)
+	)
+
+	;;Identifiers for clocks.
+	(type $clockid_t 
+		(enum
+			;; The store-wide monotonic clock, which is defined as a clock measuring real time, whose value cannot be adjusted and which cannot have negative clock jumps.
+      ;; The epoch of this clock is undefined. The absolute time value of this clock therefore has no meaning.
+			$CLOCK_MONOTONIC
+			;; The CPU-time clock associated with the current process.
+			$CLOCK_PROCESS_CPUTIME_ID
+			;; The clock measuring real time. Time value zero corresponds with 1970-01-01T00:00:00Z.
+			$CLOCK_REALTIME
+			;; The CPU-time clock associated with the current thread.
+			$CLOCK_THREAD_CPUTIME_ID
+		)
+	)
+
+	;; Identifier for a device containing a file system. Can be used in combination with __wasi_inode_t to uniquely identify a file or directory in the filesystem.
+	(type $device_t u64)
+
+	;; A reference to the offset of a directory entry.
+	(type $dircookie_t u64)
+
+	;; A directory entry.
+	(type $dirent_t 
+		(struct
+			;; The offset of the next directory entry stored in this directory.
+			(field $d_next $dircookie_t)
+			;; The serial number of the file referred to by this directory entry.
+			(field $d_ino $inode_t)
+			;; The length of the name of the directory entry.
+			(field $d_namlen u32)
+			;; The type of the file referred to by this directory entry.
+			(field $d_type $filetype_t)
+		)
+	)
+
+	;; Error codes returned by functions.
+  ;; Not all of these error codes are returned by the functions provided by this API; some are used in higher-level library layers, and others are provided merely for alignment with POSIX.
+	(type $errno_t
+		(enum
+			;; No error occurred. System call completed successfully.
+			$ESUCCESS
+			;; Argument list too long.
+			$E2BIG
+			;; Permission denied.
+			$EACCES
+			;; Address in use.
+			$EADDRINUSE
+			;; Address not available.
+			$EADDRNOTAVAIL
+			;; Address family not supported.
+			$EAFNOSUPPORT
+			;; Resource unavailable, or operation would block.
+			$EAGAIN
+			;; Connection already in progress.
+			$EALREADY
+			;; Bad file descriptor.
+			$EBADF
+			;; Bad message.
+			$EBADMSG
+			;; Device or resource busy.
+			$EBUSY
+			;; Operation canceled.
+			$ECANCELED
+			;; No child processes.
+			$ECHILD
+			;; Connection aborted.
+			$ECONNABORTED
+			;; Connection refused.
+			$ECONNREFUSED
+			;; Connection reset.
+			$ECONNRESET
+			;; Resource deadlock would occur.
+			$EDEADLK
+			;; Destination address required.
+			$EDESTADDRREQ
+			;; Mathematics argument out of domain of function.
+			$EDOM
+			;; Reserved.
+			$EDQUOT
+			;; File exists.
+			$EEXIST
+			;; Bad address.
+			$EFAULT
+			;; File too large.
+			$EFBIG
+			;; Host is unreachable.
+			$EHOSTUNREACH
+			;; Identifier removed.
+			$EIDRM
+			;; Illegal byte sequence.
+			$EILSEQ
+			;; Operation in progress.
+			$EINPROGRESS
+			;; Interrupted function.
+			$EINTR
+			;; Invalid argument.
+			$EINVAL
+			;; I/O error.
+			$EIO
+			;; Socket is connected.
+			$EISCONN
+			;; Is a directory.
+			$EISDIR
+			;; Too many levels of symbolic links.
+			$ELOOP
+			;; File descriptor value too large.
+			$EMFILE
+			;; Too many links.
+			$EMLINK
+			;; Message too large.
+			$EMSGSIZE
+			;; Reserved.
+			$EMULTIHOP
+			;; Filename too long.
+			$ENAMETOOLONG
+			;; Network is down.
+			$ENETDOWN
+			;; Connection aborted by network.
+			$ENETRESET
+			;; Network unreachable.
+			$ENETUNREACH
+			;; Too many files open in system.
+			$ENFILE
+			;; No buffer space available.
+			$ENOBUFS
+			;; No such device.
+			$ENODEV
+			;; No such file or directory.
+			$ENOENT
+			;; Executable file format error.
+			$ENOEXEC
+			;; No locks available.
+			$ENOLCK
+			;; Reserved.
+			$ENOLINK
+			;; Not enough space.
+			$ENOMEM
+			;; No message of the desired type.
+			$ENOMSG
+			;; Protocol not available.
+			$ENOPROTOOPT
+			;; No space left on device.
+			$ENOSPC
+			;; Function not supported.
+			$ENOSYS
+			;; The socket is not connected.
+			$ENOTCONN
+			;; Not a directory or a symbolic link to a directory.
+			$ENOTDIR
+			;; Directory not empty.
+			$ENOTEMPTY
+			;; State not recoverable.
+			$ENOTRECOVERABLE
+			;; Not a socket.
+			$ENOTSOCK
+			;; Not supported, or operation not supported on socket.
+			$ENOTSUP
+			;; Inappropriate I/O control operation.
+			$ENOTTY
+			;; No such device or address.
+			$ENXIO
+			;; Value too large to be stored in data type.
+			$EOVERFLOW
+			;; Previous owner died.
+			$EOWNERDEAD
+			;; Operation not permitted.
+			$EPERM
+			;; Broken pipe.
+			$EPIPE
+			;; Protocol error.
+			$EPROTO
+			;; Protocol not supported.
+			$EPROTONOSUPPORT
+			;; Protocol wrong type for socket.
+			$EPROTOTYPE
+			;; Result too large.
+			$ERANGE
+			;; Read-only file system.
+			$EROFS
+			;; Invalid seek.
+			$ESPIPE
+			;; No such process.
+			$ESRCH
+			;; Reserved.
+			$ESTALE
+			;; Connection timed out.
+			$ETIMEDOUT
+			;; Text file busy.
+			$ETXTBSY
+			;; Cross-device link.
+			$EXDEV
+			;; Extension: Capabilities insufficient.
+			$ENOTCAPABLE
+		)
+	)
+
+	;; An event that occurred.
+	(type $event_t
+		(struct
+			;; User-provided value that got attached to __wasi_subscription_t::userdata.
+			(field $userdata $userdata_t)
+			;; If non-zero, an error that occurred while processing the subscription request.
+			(field $error $errno_t)
+			;; The type of the event that occurred.
+			(field $type $eventtype_t)
+			(field $u 
+				(type union
+					;; When type is __WASI_EVENTTYPE_FD_READ or __WASI_EVENTTYPE_FD_WRITE:
+					(field $fd_readwrite
+						(type stuct
+							;; The number of bytes available for reading or writing.
+							(field $nbytes $filesize_t)
+							;; The state of the file descriptor.
+							(field $flags $eventrwflags_t)
+						)
+					)
+					(field $else Null)
+				)
+			)
+		)
+	)
+
+	;; The state of the file descriptor subscribed to with __WASI_EVENTTYPE_FD_READ or __WASI_EVENTTYPE_FD_WRITE.
+	(type $eventrwflags_t
+		(struct
+			;; The peer of this socket has closed or disconnected.
+			(field $EVENT_FD_READWRITE_HANGUP Bool)
+		)
+	)
+
+	;; Type of a subscription to an event or its occurrence.
+	(type $eventtype_t
+		(struct
+			;; The time value of clock __wasi_subscription_t::u.clock.clock_id has reached timestamp __wasi_subscription_t::u.clock.timeout.
+			(field $EVENTTYPE_CLOCK Bool)
+			;; File descriptor __wasi_subscription_t::u.fd_readwrite.fd has data available for reading. This event always triggers for regular files.
+			(field $EVENTTYPE_FD_READ Bool)
+			;; File descriptor __wasi_subscription_t::u.fd_readwrite.fd has capacity available for writing. This event always triggers for regular files.
+			(field $EVENTTYPE_FD_WRITE Bool)
+		)
+	)
+
+	;; Exit code generated by a process when exiting.
+	(type $exitcode_t u32)
+
+	;; File descriptor flags.
+	(type $fdflags_t
+		(struct
+			;; Append mode: Data written to the file is always appended to the file's end.
+			(field $FDFLAG_APPEND Bool)
+			;; Write according to synchronized I/O data integrity completion. Only the data stored in the file is synchronized.
+			(field $FDFLAG_DSYNC Bool)
+			;; Non-blocking mode.
+			(field $FDFLAG_NONBLOCK Bool)
+			;; Synchronized read I/O operations.
+			(field $FDFLAG_RSYNC Bool)
+			;; Write according to synchronized I/O file integrity completion. In addition to synchronizing the data stored in the file, the implementation may also synchronously update the file's metadata.
+			(field $FDFLAG_SYNC Bool)
+		)
+	)
+
+	;; File descriptor attributes.
+	(type $fdstat_t 
+		;; File type.
+		(field $fs_filetype $filetype_t)
+		;; File descriptor flags.
+		(field $fs_flags $fdflags_t)
+		;; Rights that apply to this file descriptor.
+		(field $fs_rights_base $rights_t)
+		;; Maximum set of rights that may be installed on new file descriptors that are created through this file descriptor, e.g., through __wasi_path_open().
+		(field $fs_rights_inheriting $rights_t)
+	)
+
+	;; Non-negative file size or length of a region within a file.
+	(type $filesize_t u64)
+
+	;; File attributes.
+	(type $filestat_t
+		(struct
+			;; Device ID of device containing the file.
+			(field $st_dev $device_t)
+			;; File serial number.
+			(field $st_ino $inode_t)
+			;; File type.
+			(field $st_filetype $filetype_t)
+			;; Number of hard links to the file.
+			(field $st_nlink $linkcount_t)
+			;; For regular files, the file size in bytes. For symbolic links, the length in bytes of the pathname contained in the symbolic link.
+			(field $st_size $filesize_t)
+			;; Last data access timestamp.
+			(field $st_atim $timestamp_t)
+			;; Last data modification timestamp.
+			(field $st_mtim $timestamp_t)
+			;; Last file status change timestamp.
+			(field $st_ctim $timestamp_t)
+		)
+	)
+
+	;; The type of a file descriptor or file.
+	(type $filetype_t
+		(enum
+			;; The type of the file descriptor or file is unknown or is different from any of the other types specified.
+			$FILETYPE_UNKNOWN
+			;; The file descriptor or file refers to a block device inode.
+			$FILETYPE_BLOCK_DEVICE
+			;; The file descriptor or file refers to a character device inode.
+			$FILETYPE_CHARACTER_DEVICE
+			;; The file descriptor or file refers to a directory inode.
+			$FILETYPE_DIRECTORY
+			;; The file descriptor or file refers to a regular file inode.
+			$FILETYPE_REGULAR_FILE
+			;; The file descriptor or file refers to a datagram socket.
+			$FILETYPE_SOCKET_DGRAM
+			;; The file descriptor or file refers to a byte-stream socket.
+			$FILETYPE_SOCKET_STREAM
+			;; The file refers to a symbolic link inode.
+			$FILETYPE_SYMBOLIC_LINK
+		)
+	)
+
+	;; Which file time attributes to adjust.
+	(type $fstflags_t
+		(struct 
+			;; Adjust the last data access timestamp to the value stored in __wasi_filestat_t::st_atim.
+			(field $FILESTAT_SET_ATIM Bool)
+			;; Adjust the last data access timestamp to the time of clock __WASI_CLOCK_REALTIME.
+			(field $FILESTAT_SET_ATIM_NOW Bool)
+			;; Adjust the last data modification timestamp to the value stored in __wasi_filestat_t::st_mtim.
+			(field $FILESTAT_SET_MTIM Bool)
+			;; Adjust the last data modification timestamp to the time of clock __WASI_CLOCK_REALTIME.
+			(field $FILESTAT_SET_MTIM_NOW Bool)
+		)
+	)
+
+	;; File serial number that is unique within its file system.
+	(type $inode_t u64)
+
+	;; Number of hard links to an inode.
+	(type $linkcount_t u32)
+
+	;; Signal condition.
+	(type $signal_t
+		(enum
+			;; Process abort signal.
+			;; Action: Terminates the process.
+			$SIGABRT
+			;; Alarm clock.
+			;; Action: Terminates the process.
+			$SIGALRM
+			;; Access to an undefined portion of a memory object.
+			;; Action: Terminates the process.
+			$SIGBUS
+			;; Child process terminated, stopped, or continued.
+			;; Action: Ignored.
+			$SIGCHLD
+			;; Continue executing, if stopped.
+			;; Action: Continues executing, if stopped.
+			$SIGCONT
+			;; Erroneous arithmetic operation.
+			;; Action: Terminates the process.
+			$SIGFPE
+			;; Hangup.
+			;; Action: Terminates the process.
+			$SIGHUP
+			;; Illegal instruction.
+			;; Action: Terminates the process.
+			$SIGILL
+			;; Terminate interrupt signal.
+			;; Action: Terminates the process.
+			$SIGINT
+			;; Kill.
+			;; Action: Terminates the process.
+			$SIGKILL
+			;; Write on a pipe with no one to read it.
+			;; Action: Ignored.
+			$SIGPIPE
+			;; Terminal quit signal.
+			;; Action: Terminates the process.
+			$SIGQUIT
+			;; Invalid memory reference.
+			;; Action: Terminates the process.
+			$SIGSEGV
+			;; Stop executing.
+			;; Action: Stops executing.
+			$SIGSTOP
+			;; Bad system call.
+			;; Action: Terminates the process.
+			$SIGSYS
+			;; Termination signal.
+			;; Action: Terminates the process.
+			$SIGTERM
+			;; Trace/breakpoint trap.
+			;; Action: Terminates the process.
+			$SIGTRAP
+			;; Terminal stop signal.
+			;; Action: Stops executing.
+			$SIGTSTP
+			;; Background process attempting read.
+			;; Action: Stops executing.
+			$SIGTTIN
+			;; Background process attempting write.
+			;; Action: Stops executing.
+			$SIGTTOU
+			;; High bandwidth data is available at a socket.
+			;; Action: Ignored.
+			$SIGURG
+			;; User-defined signal 1.
+			;; Action: Terminates the process.
+			$SIGUSR1
+			;; User-defined signal 2.
+			;; Action: Terminates the process.
+			$SIGUSR2
+			;; Virtual timer expired.
+			;; Action: Terminates the process.
+			$SIGVTALRM
+			;; CPU time limit exceeded.
+			;; Action: Terminates the process.
+			$SIGXCPU
+			;; File size limit exceeded.
+			;; Action: Terminates the process.
+			$SIGXFSZ
+		)
+	)
+
+	;; Flags determining how to interpret the timestamp provided in __wasi_subscription_t::u.clock.timeout.
+	(type $subclockflags_t
+		(struct
+			;; If set, treat the timestamp provided in __wasi_subscription_t::u.clock.timeout as an absolute timestamp of clock __wasi_subscription_t::u.clock.clock_id.
+			;; If clear, treat the timestamp provided in __wasi_subscription_t::u.clock.timeout relative to the current time value of clock __wasi_subscription_t::u.clock.clock_id.
+			(field $SUBSCRIPTION_CLOCK_ABSTIME Bool)
+		)
+	)
+
+	;; Subscription to an event.
+	(type $subscription_t
+		(struct
+			;; User-provided value that is attached to the subscription in the implementation and returned through __wasi_event_t::userdata.
+			(field $userdata $userdata_t)
+			;; The type of the event to which to subscribe.
+			(field $type $eventtype_t)
+			(field 
+				(type
+					(union
+						;; When type is __WASI_EVENTTYPE_CLOCK
+						(field $clock
+							(type 
+								(struct
+									;; The user-defined unique identifier of the clock.
+									(field $identifier $userdata_t)
+									;; The clock against which to compare the timestamp.
+									(field $clock_id $clockid_t)
+									;; The absolute or relative timestamp.
+									(field $timeout $timestamp_t)
+									;; The amount of time that the implementation may wait additionally to coalesce with other events.
+									;; Flags specifying whether the timeout is absolute or relative
+									(field $precision $timestamp_t)
+								)
+							)
+						)
+						;; When type is __WASI_EVENTTYPE_FD_READ or __WASI_EVENTTYPE_FD_WRITE:
+						(field $fd_readwrite
+							(type
+								(struct
+									;; The file descriptor on which to wait for it to become ready for reading or writing.
+									(field $file_descriptor $fd)
+								)
+							)
+						)
+					)
+				)
+			)
+		)
+	)
+
+	;; Timestamp in nanoseconds.
+	(type $timestamp_t u64) 
+
+	;; User-provided value that may be attached to objects that is retained when extracted from the implementation.
+	(type $userdata_t u64)
+
+	;; File descriptor rights, determining which actions may be performed.
+	(type $rights_t
+		(struct
+			;; The right to invoke __wasi_fd_datasync().
+			;; If __WASI_RIGHT_PATH_OPEN is set, includes the right to invoke __wasi_path_open() with __WASI_FDFLAG_DSYNC.
+			(field $RIGHT_FD_DATASYNC Bool)
+			;; The right to invoke __wasi_fd_read() and __wasi_sock_recv().
+			;; If __WASI_RIGHT_FD_SEEK is set, includes the right to invoke __wasi_fd_pread().
+			(field $RIGHT_FD_READ Bool)
+			;; The right to invoke __wasi_fd_seek(). This flag implies __WASI_RIGHT_FD_TELL.
+			(field $RIGHT_FD_SEEK Bool)
+			;; The right to invoke __wasi_fd_fdstat_set_flags().
+			(field $RIGHT_FD_FDSTAT_SET_FLAGS Bool)
+			;; The right to invoke __wasi_fd_sync().
+			;; If __WASI_RIGHT_PATH_OPEN is set, includes the right to invoke __wasi_path_open() with __WASI_FDFLAG_RSYNC and __WASI_FDFLAG_DSYNC.
+			(field $RIGHT_FD_SYNC Bool)
+			;; The right to invoke __wasi_fd_seek() in such a way that the file offset remains unaltered (i.e., __WASI_WHENCE_CUR with offset zero), or to invoke __wasi_fd_tell().
+			(field $RIGHT_FD_TELL Bool)
+			;; The right to invoke __wasi_fd_write() and __wasi_sock_send().
+			;; If __WASI_RIGHT_FD_SEEK is set, includes the right to invoke __wasi_fd_pwrite().
+			(field $RIGHT_FD_WRITE Bool)
+			;; The right to invoke __wasi_fd_advise().
+			(field $RIGHT_FD_ADVISE Bool)
+			;; The right to invoke __wasi_fd_allocate().
+			(field $RIGHT_FD_ALLOCATE Bool)
+			;; The right to invoke __wasi_path_create_directory().
+			(field $RIGHT_PATH_CREATE_DIRECTORY Bool)
+			;; If __WASI_RIGHT_PATH_OPEN is set, the right to invoke __wasi_path_open() with __WASI_O_CREAT.
+			(field $RIGHT_PATH_CREATE_FILE Bool)
+			;; The right to invoke __wasi_path_link() with the file descriptor as the source directory.
+			(field $RIGHT_PATH_LINK_SOURCE Bool)
+			;; The right to invoke __wasi_path_link() with the file descriptor as the target directory.
+			(field $RIGHT_PATH_LINK_TARGET Bool)
+			;; The right to invoke __wasi_path_open().
+			(field $RIGHT_PATH_OPEN Bool)
+			;; The right to invoke __wasi_fd_readdir().
+			(field $RIGHT_FD_READDIR Bool)
+			;; The right to invoke __wasi_path_readlink().
+			(field $RIGHT_PATH_READLINK Bool)
+			;; The right to invoke __wasi_path_rename() with the file descriptor as the source directory.
+			(field $RIGHT_PATH_RENAME_SOURCE Bool)
+			;; The right to invoke __wasi_path_rename() with the file descriptor as the target directory.
+			(field $RIGHT_PATH_RENAME_TARGET Bool)
+			;; The right to invoke __wasi_path_filestat_get().
+			(field $RIGHT_PATH_FILESTAT_GET Bool)
+			;; The right to change a file's size (there is no __wasi_path_filestat_set_size()).
+			;; If __WASI_RIGHT_PATH_OPEN is set, includes the right to invoke __wasi_path_open() with __WASI_O_TRUNC.
+			(field $RIGHT_PATH_FILESTAT_SET_SIZE Bool)
+			;; The right to invoke __wasi_path_filestat_set_times().
+			(field $RIGHT_PATH_FILESTAT_SET_TIMES Bool)
+			;; The right to invoke __wasi_fd_filestat_get().
+			(field $RIGHT_FD_FILESTAT_GET Bool)
+			;; The right to invoke __wasi_fd_filestat_set_size().
+			(field $RIGHT_FD_FILESTAT_SET_SIZE Bool)
+			;; The right to invoke __wasi_fd_filestat_set_times().
+			(field $RIGHT_FD_FILESTAT_SET_TIMES Bool)
+			;; The right to invoke __wasi_path_symlink().
+			(field $RIGHT_PATH_SYMLINK Bool)
+			;; The right to invoke __wasi_path_unlink_file().
+			(field $RIGHT_PATH_UNLINK_FILE Bool)
+			;; The right to invoke __wasi_path_remove_directory().
+			(field $RIGHT_PATH_REMOVE_DIRECTORY Bool)
+			;; If __WASI_RIGHT_FD_READ is set, includes the right to invoke __wasi_poll_oneoff() to subscribe to __WASI_EVENTTYPE_FD_READ.
+			;; If __WASI_RIGHT_FD_WRITE is set, includes the right to invoke __wasi_poll_oneoff() to subscribe to __WASI_EVENTTYPE_FD_WRITE.
+			(field $RIGHT_POLL_FD_READWRITE Bool)
+			;; The right to invoke __wasi_sock_shutdown().
+			(field $RIGHT_SOCK_SHUTDOWN Bool)
+		)
+	)
+
+	;; linear memory used by the program
+	(import "memory" (memory)) 
+	;; the program entry point
+	(import "_start" (func))
+)
+
+(interface $args extends $wasi
+	;; Read command-line argument data.
+	;; The size of the array should match that returned by `wasi_args_sizes_get()`
+	(static func (export "get")
+		(result $argv $string_array)
+	)
+	;; Return command-line argument data sizes.
+	(static func (export "size_get")
+		;; The number of arguments.
+		(result $argc $size_t) 
+		;; The size of the argument string data.
+		(result $argv_buf_size $size_t) 
+	)
+)
+
+(interface $environ extends $wasi
+	;; Read environment variable data.
+	;; The sizes of the buffers should match that returned by environ.sizes_get().
+	(static func (export "get")
+		(result $argv $string_array)
+	)
+	;; Return command-line argument data sizes.
+	(static func (export "size_get")
+		;; The number of arguments.
+		(result $argc $size_t) 
+		;; The size of the argument string data.
+		(result $argv_buf_size $size_t)
+	)
+)
+
+(interface $clocks extends $wasi
+	;; Return the resolution of a clock.
+	;; Implementations are required to provide a non-zero value for supported clocks. For unsupported clocks, return `WASI_EINVAL`
+	;; Note: This is similar to clock_getres in POSIX.
+	(static func (export "res_get")
+		;; The clock for which to return the resolution.
+		(param $clock_id $wasi.clockid_t)
+		;; The resolution of the clock.
+		(result $resolution $wasi.timestamp_t)
+	) 
+	;; Return the time value of a clock.
+	;; Note: This is similar to clock_gettime in POSIX.
+	(static func (export "time_get")
+		;; The clock for which to return the time.
+		(param $clock_id $wasi.clockid_t)
+		;; The maximum lag (exclusive) that the returned time value may have, compared to its actual value.
+		(param $precision $wasi.timestamp_t)
+		;; The time value of the clock.
+		(result $time $wasi.timestamp_t)
+	) 
+)
+
+(interface $fd extends $wasi
+	;; Relative offset within a file.
+	(type $filedelta_t i64)
+
+	;; The position relative to which to set the offset of the file descriptor.
+	(type $whence_t
+		(enum
+			;; Seek relative to current position.
+			$WHENCE_CUR
+			;; Seek relative to end-of-file.
+			$WHENCE_END
+			;; Seek relative to start-of-file.
+			$WHENCE_SET
+		)
+	)
+
+	;; Provide file advisory information on a file descriptor.
+	;; Note: This is similar to posix_fadvise in POSIX.
+	(func (export "advise")
+		(param $offset $wasi.filesize_t) ;; The offset within the file to which the advisory applies.
+		(param $len $wasi.filesize_t) ;; The length of the region to which the advisory applies.
+		(param $advice $wasi.advice_t) ;; The advice.
+	)
+
+
+	;; Force the allocation of space in a file.
+	;; Note: This is similar to posix_fallocate in POSIX.
+	(func (export "allocate")
+		;; The offset at which to start the allocation.
+		(param $offset $wasi.filesize_t) 
+		;; The length of the area that is allocated.
+		(param $len $wasi.filesize_t)
+	)
+
+	;; Close a file descriptor.
+	;; Note: This is similar to close in POSIX. 
+	(func (export "close"))
+
+	;; Synchronize the data of a file to disk.
+	;; Note: This is similar to `fdatasync` in POSIX.
+	(func (export "datasync"))
+
+	;; Get the attributes of a file descriptor.
+	;; Note: This returns similar flags to `fsync(fd, F_GETFL)` in POSIX, as well as additional fields.
+	(func (export "fdstat_get")
+		;; The buffer where the file descriptor's attributes are stored.
+		(result $wasi.fdstat_t) 
+	)
+
+	;; Adjust the flags associated with a file descriptor.
+	;; Note: This is similar to `fcntl(fd, F_SETFL, flags)` in POSIX.
+	(func (export "fdstat_set_flags")
+		;; The desired values of the file descriptor flags.
+		(param $flags $wasi.fdflags)
+	)
+
+	;;  Adjust the rights associated with a file descriptor.
+	;; This can only be used to remove rights, and returns `ENOTCAPABLE` if called in a way that would attempt to add rights
+	(func (export "fdstat_set_rights") 
+		;; The desired rights of the file descriptor.
+		(param $fs_rights_base $wasi.rights_t)
+		(param $fs_rights_inheriting $wasi.rights_t)
+	)
+
+	;; Return the attributes of an open file.
+	(func (export "filestat_get")
+		;; The buffer where the file's attributes are stored.
+		(result $fs_rights_base $wasi.rights_t)
+	)
+
+	;; Adjust the size of an open file. If this increases the file's size, the extra bytes are filled with zeros.
+	;; Note: This is similar to ftruncate in POSIX. 
+	(func (export "filestat_set_size")
+		;; The desired file size.
+		(param $st_size $wasi.filesize_t)
+	)
+
+	;; Adjust the timestamps of an open file or directory.
+	;; Note: This is similar to `futimens` in POSIX.
+	(func (export "filestat_set_times")
+		;; The desired values of the data access timestamp.
+		(param $st_atim $wasi.timestamp_t)
+		;; The desired values of the data modification timestamp.
+		(param $st_mtim $wasi.timestamp_t)
+		;; A bitmask indicating which timestamps to adjust.
+		(param $fst_flags $wasi.fstflags_t)
+	)
+
+	;; Read from a file descriptor, without using and updating the file descriptor's offset.
+	;; Note: This is similar to `preadv` in POSIX.
+	(func (export "pread")
+		;; List of scatter/gather vectors in which to store data.
+		(param $iovs $wasi.iovec_t_array)
+		;; The offset within the file at which to read.
+		(param $offset $wasi.filesize_t)
+		;; The number of bytes read.
+		(result $nread $wasi.size_t)
+	)
+
+	;; Return a description of the given preopened file descriptor.
+	(func (export "prestat_get")
+		;; The buffer where the description is stored.
+		(result $buf $wasi.prestat_t)
+	)
+
+	;; Return a description of the given preopened file descriptor.
+	(func (export "prestat_dir_name")
+		;; A buffer into which to write the preopened directory name.
+		(param $path string)
+	)
+
+	;; Write to a file descriptor, without using and updating the file descriptor's offset.
+	;; Note: This is similar to `pwritev` in POSIX.
+	(func (export "pwrite")
+		;; List of scatter/gather vectors from which to retrieve data.
+		(param $iovs $wasi.iovec_t_array)
+		;; The offset within the file at which to write.
+		(param $offset $wasi.filesize_t)
+		;; The number of bytes written.
+		(result $nwritten $size_t)
+	)
+
+	;; Read from a file descriptor.
+	;; Note: This is similar to `readv` in POSIX.
+	(func (export "read")
+		;; List of scatter/gather vectors to which to store data.
+		(param $iovs $wasi.iovec_t_array)
+		;; The number of bytes read.
+		(result $nread $size_t)
+	)
+
+	;; Read directory entries from a directory.
+	;; When successful, the contents of the output buffer consist of a sequence of directory entries. Each directory entry consists of a dirent_t object, followed by dirent_t::d_namlen bytes holding the name of the directory entry.
+	;; This function fills the output buffer as much as possible, potentially truncating the last directory entry. This allows the caller to grow its read buffer size in case it's too small to fit a single large directory entry, or skip the oversized directory entry.
+	(func (export "readdir")
+		;; The buffer where directory entries are stored
+		(param $buf data)
+		;; The location within the directory to start reading
+		(param $cookie $wasi.dircookie_t)
+		;; The number of bytes stored in the read buffer. If less than the size of the read buffer, the end of the directory has been reached.
+		(result $bufused $size_t)
+	)
+
+	;; Atomically replace a file descriptor by renumbering another file descriptor.
+	;; Due to the strong focus on thread safety, this environment does not provide a mechanism to duplicate or renumber a file descriptor to an arbitrary number, like dup2(). This would be prone to race conditions, as an actual file descriptor with the same number could be allocated by a different thread at the same time.
+ 	;; This function provides a way to atomically renumber file descriptors, which would disappear if dup2() were to be removed entirely.
+	(func (export "renumber")
+		;; The file descriptor to overwrite.
+		(param $to $fd)
+	)
+
+	;; Move the offset of a file descriptor.
+	;; Note: This is similar to lseek in POSIX.
+	(func (export "seek")
+		;; The number of bytes to move.
+		(param $offset $filedelta_t)
+		;; The base from which the offset is relative.
+		(param $whence $whence_t)
+		;; The new offset of the file descriptor, relative to the start of the file.
+		(result $newoffset $filesize_t)
+	)
+
+	;; Synchronize the data and metadata of a file to disk.
+  ;; Note: This is similar to fsync in POSIX.
+	(func (export "sync"))
+
+	;; Return the current offset of a file descriptor.
+	;; Note: This is similar to `lseek(fd, 0, SEEK_CUR)` in POSIX.
+	(func (export "tell")
+		;; The current offset of the file descriptor, relative to the start of the file.
+		(result $offset $filesize_t)
+	)
+
+	;; Write to a file descriptor.
+	;; Note: This is similar to `writev` in POSIX.
+	(func (export "write")
+		;; List of scatter/gather vectors from which to retrieve data.
+		(param $iovs $wasi.iovec_t_array)
+		;; The number of bytes written.
+		(result $nwritten $size_t)
+	)
+)
+
+(interface $path extends $fd
+	;; Flags determining the method of how paths are resolved.
+	(type $lookupflags_t
+		(struct
+			;; As long as the resolved path corresponds to a symbolic link, it is expanded.
+			(field $LOOKUP_SYMLINK_FOLLOW Bool)
+		)
+	)
+
+	;; Open flags used by __wasi_path_open().
+	(type $oflags_t
+		(struct
+			;; Create file if it does not exist.
+			(field $O_CREAT Bool)
+			;; Fail if not a directory.
+			(field $O_DIRECTORY Bool)
+			;; Fail if file already exists.
+			(field $O_EXCL Bool)
+			;; Truncate file to size 0.
+			(field $O_TRUNC Bool)
+		)
+	)
+
+	;; Create a directory.
+	;; Note: This is similar to `mkdirat` in POSIX.
+	(func (export "create_directory")
+		;; The path at which to create the directory.
+		(param $path string)
+	)
+
+	;; Return the attributes of a file or directory.
+  ;; Note: This is similar to stat in POSIX.
+	(func (export "filestat_get")
+		;; Flags determining the method of how the path is resolved.
+		(param $flags $lookupflags_t)
+		;; The path of the file or directory to inspect.
+		(param $path string)
+		;; The buffer where the file's attributes are stored.
+		(result $buf $wasi.filestat_t)
+	)
+
+	;; Adjust the timestamps of a file or directory.
+  ;; Note: This is similar to utimensat in POSIX.
+	(func (export "filestat_set_times")
+		;; Flags determining the method of how the path is resolved.
+		(param $flags $lookupflags_t)
+		;; The path of the file or directory to operate on.
+		(param $path string)
+		;; The desired values of the data access timestamp.
+		(param $st_atim $wasi.timestamp_t)
+		;; The desired values of the data modification timestamp.
+		(param $st_mtim $wasi.timestamp_t)
+		;; A bitmask indicating which timestamps to adjust.
+		(param $fst_flags $wasi.fstflags_t)
+	)
+
+	;; Create a hard link.
+	;; Note: This is similar to `linkat` in POSIX.
+	(func (export "link")
+		;; Flags determining the method of how the path is resolved.
+		(param $old_flags $lookupflags_t)
+		;; The source path from which to link.
+		(param $old_path string)
+		;; The working directory at which the resolution of the new path starts.
+		(param $new_fd $path)
+		;; The destination path at which to create the hard link.
+		(param $new_path string)
+	)
+
+	;; Open a file or directory.
+	;; The returned file descriptor is not guaranteed to be the lowest-numbered file descriptor not currently open; it is randomized to prevent applications from depending on making assumptions about indexes, since this is error-prone in multi-threaded contexts. The returned file descriptor is guaranteed to be less than 231.
+	;; Note: This is similar to openat in POSIX.
+	(func (export "open")
+		;; Flags determining the method of how the path is resolved.
+		(param $dirflags $lookupflags_t)
+		;; The relative path of the file or directory to open, relative to the `dirfd` directory.
+		(param $path string)
+		;; The method by which to open the file.
+		(param $o_flags $oflags_t)
+		;; The initial rights of the newly created file descriptor. The implementation is allowed to return a file descriptor with fewer rights than specified, if and only if those rights do not apply to the type of file being opened.
+		;; The base rights are rights that will apply to operations using the file descriptor itself, while the inheriting rights are rights that apply to file descriptors derived from it.
+		(param $fs_rights_base $wasi.rights_t)
+		(param $fs_rights_inherting $wasi.rights_t)
+		;; The file descriptor of the file that has been opened.
+		(result $opened_fd $fd)
+	)
+
+	;; Read the contents of a symbolic link.
+	;; Note: This is similar to readlinkat in POSIX.
+	(func (export "readlink")
+		;; The path of the symbolic link from which to read.
+		(param $path)
+		;; The buffer to which to write the contents of the symbolic link.
+		(param $buf string)
+		;; The number of bytes placed in the buffer.
+		(result $bufused $size_t)
+	)
+
+	;; Remove a directory.
+  ;; Return `__WASI_ENOTEMPTY` if the directory is not empty.
+  ;; Note: This is similar to `unlinkat(fd, path, AT_REMOVEDIR)` in POSIX.
+	(func (export "remove_directory")
+		;; The path to a directory to remove.
+		(param $path string)
+	)
+
+	;; Rename a file or directory.
+	;; Note: This is similar to `renameat` in POSIX.
+	(func (export "rename")
+		;; The source path of the file or directory to rename.
+		(param $old_path string)
+		;; The working directory at which the resolution of the new path starts.
+		(param $new_fd $fd)
+		;; The destination path to which to rename the file or directory.
+		(param $new_path string)
+	)
+
+	;; Create a symbolic link.
+  ;; Note: This is similar to symlinkat in POSIX.
+	(func (export "symlink")
+		;; The contents of the symbolic link.
+		(param $old_path string)
+		;; The destination path at which to create the symbolic link.
+		(param $new_path string)
+	)
+
+	
+	;; Unlink a file.
+	;; Return __WASI_EISDIR if the path refers to a directory.
+	;; Note: This is similar to unlinkat(fd, path, 0) in POSIX.
+	(func (export "unlink_file")
+		;; The path to a file to unlink.
+		(param $path string)
+	)
+) 
+
+(interface $poll
+	;; Concurrently poll for the occurrence of a set of events.
+	(static func (export "oneoff")
+		;; The events to which to subscribe.
+		(param $in $wasi.subscription_t)
+		;; The events that have occurred.
+		(param $out $wasi.event_t)
+		;; Both the number of subscriptions and events.
+		(param $nsubscriptions $size_t)
+		;; The number of events stored.
+		(result $nevents $size_t)
+	)
+)
+
+(interface $proc extends $wasi
+	;; Terminate the process normally. An exit code of 0 indicates successful termination of the program. The meanings of other values is dependent on the environment.
+	(static func (export "exit")
+		;; The exit code returned by the process.
+		(param $rval $wasi.exitcode_t)
+	)
+
+	;; Send a signal to the process of the calling thread.
+	;; Note: This is similar to `raise` in POSIX.
+	(static func (export "raise")
+		;; The signal condition to trigger.
+		(param $sig $wasi.signal_t)
+	)
+
+	;; Temporarily yield execution of the calling thread.
+  ;; Note: This is similar to `sched_yield` in POSIX.
+	(static func (export "sched_yield"))
+)
+
+(interface $random extends $wasi
+	;; Write high-quality random data into a buffer.
+	;; This function blocks when the implementation is unable to immediately provide sufficient high-quality random data.
+	;; This function may execute slowly, so when large mounts of random data are required, it's advisable to use this function to seed a pseudo-random number generator, rather than to provide the random data directly.
+	(static func (export "get")
+		;; The buffer to fill with random data.
+		(param $buf data)
+	)
+)
+
+(interface $sock extends $fd
+	;; Flags provided to __wasi_sock_recv().
+	(type $riflags_t
+		(struct
+			;; Returns the message without removing it from the socket's receive queue.
+			(field $SOCK_RECV_PEEK Bool)
+			;; On byte-stream sockets, block until the full amount of data can be returned.
+			(field $SOCK_RECV_WAITALL Bool)
+		)
+	)
+
+	;; Flags returned by __wasi_sock_recv().
+	(type $roflags_t
+		(struct
+			;; Returned by __wasi_sock_recv(): Message data has been truncated.
+			(field $SOCK_RECV_DATA_TRUNCATED Bool)
+		)
+	)
+
+	;; Flags provided to __wasi_sock_send(). As there are currently no flags defined, it must be set to zero.
+	(type $siflags_t u16)
+
+	;; Which channels on a socket to shut down.
+	(type $sdflags_t
+		(struct
+			;; Disables further receive operations.
+			(field $SHUT_RD Bool)
+			;; Disables further send operations.
+			(field $SHUT_WR Bool)
+		)
+	)
+
+
+	;; Receive a message from a socket.
+	;; Note: This is similar to recv in POSIX, though it also supports reading the data into multiple buffers in the manner of readv.
+	(func (export "recv")
+		;; List of scatter/gather vectors to which to store data.
+		(param $ri_data $wasi.iovec_t_array)
+		;; Message flags.
+		(param $ri_flags $riflags_t)
+		;; Number of bytes stored in ri_data.
+		(results $ro_datalen $size_t)
+		;; Message flags.
+		(results $ro_flags $roflags_t)
+	)
+
+	;; Send a message on a socket.
+  ;; Note: This is similar to `send` in POSIX, though it also supports writing the data from multiple buffers in the manner of `writev`.
+	(func (export "send")
+		;; List of scatter/gather vectors to which to retrieve data
+		(param $si_data $wasi.ciovec_t_array)
+		;; Message flags.
+		(param $si_flags $siflags_t)
+		;; Number of bytes transmitted.
+		(result $so_datalen $size_t)
+	)
+
+	;; Shut down socket send and receive channels.
+	;; Note: This is similar to shutdown in POSIX.
+	(func (export "shutdown")
+		;; Which channels on the socket to shut down.
+		(param $how $sdflags_t)
+	)
+)

--- a/watidl/wasi-core.watidl
+++ b/watidl/wasi-core.watidl
@@ -1,1076 +1,1120 @@
-(type $size_t u64)
-(type $string_array (array string))
 
-(interface $wasi (export "__wasi")
-	(type $iovec_t_array (array $iovec_t))
-	(type $ciovec_t_array (array $ciovec_t))
-	;; File or memory access pattern advisory information.
-	(type $advice_t
-		(enum
-			;; The application expects that it will not access the specified data in the near future.
-			$ADVICE_DONTNEED
-			;; The application expects to access the specified data once and then not reuse it thereafter.
-			$ADVICE_NOREUSE
-			;; The application has no advice to give on its behavior with respect to the specified data.
-			$ADVICE_NORMAL
-			;; The application expects to access the specified data in a random order.
-			$ADVICE_RANDOM
-			;; The application expects to access the specified data sequentially from lower offsets to higher offsets.
-			$ADVICE_SEQUENTIAL
-			;; The application expects to access the specified data in the near future.
-			$ADVICE_WILLNEED
-		)
-	)
+(interface $wasi
+  (type $size_t u64)
+  (type $string_array (array string))
+  (type $iovec_t_array (array $iovec_t))
+  (type $ciovec_t_array (array $ciovec_t))
 
-	;; A region of memory for scatter/gather reads.
-	(type $iovec_t
-		(struct
-			;; The address and length of the buffer to be filled.
-			(field $buf data)
-			(field $buf_len data)
-		)
-	)
+  ;; A region of memory for scatter/gather reads.
+  (type $iovec_t
+    (struct
+      ;; The address and length of the buffer to be filled.
+      (field $buf data)
+      (field $buf_len data)
+    )
+  )
 
-	;; A region of memory for scatter/gather writes.
-	(type $ciovec_t
-		(struct
-			;; The address and length of the buffer to be written.
-			(field $buf data)
-			(field $buf_len data)
-		)
-	)
+  ;; A region of memory for scatter/gather writes.
+  (type $ciovec_t
+    (struct
+      ;; The address and length of the buffer to be written.
+      (field $buf data)
+      (field $buf_len data)
+    )
+  )
 
-	;;Identifiers for clocks.
-	(type $clockid_t 
-		(enum
-			;; The store-wide monotonic clock, which is defined as a clock measuring real time, whose value cannot be adjusted and which cannot have negative clock jumps.
-			;; The epoch of this clock is undefined. The absolute time value of this clock therefore has no meaning.
-			$CLOCK_MONOTONIC
-			;; The CPU-time clock associated with the current process.
-			$CLOCK_PROCESS_CPUTIME_ID
-			;; The clock measuring real time. Time value zero corresponds with 1970-01-01T00:00:00Z.
-			$CLOCK_REALTIME
-			;; The CPU-time clock associated with the current thread.
-			$CLOCK_THREAD_CPUTIME_ID
-		)
-	)
+  ;;Identifiers for clocks.
+  (type $clockid_t 
+    (enum
+      ;; The store-wide monotonic clock, which is defined as a clock measuring real time, whose value cannot be adjusted and which cannot have negative clock jumps.
+      ;; The epoch of this clock is undefined. The absolute time value of this clock therefore has no meaning.
+      $CLOCK_MONOTONIC
+      ;; The CPU-time clock associated with the current process.
+      $CLOCK_PROCESS_CPUTIME_ID
+      ;; The clock measuring real time. Time value zero corresponds with 1970-01-01T00:00:00Z.
+      $CLOCK_REALTIME
+      ;; The CPU-time clock associated with the current thread.
+      $CLOCK_THREAD_CPUTIME_ID
+    )
+  )
 
-	;; Identifier for a device containing a file system. Can be used in combination with __wasi_inode_t to uniquely identify a file or directory in the filesystem.
-	(type $device_t u64)
+  ;; Error codes returned by functions.
+  ;; Not all of these error codes are returned by the functions provided by this API; some are used in higher-level library layers, and others are provided merely for alignment with POSIX.
+  (type $errno_t
+    (enum
+      ;; No error occurred. System call completed successfully.
+      $ESUCCESS
+      ;; Argument list too long.
+      $E2BIG
+      ;; Permission denied.
+      $EACCES
+      ;; Address in use.
+      $EADDRINUSE
+      ;; Address not available.
+      $EADDRNOTAVAIL
+      ;; Address family not supported.
+      $EAFNOSUPPORT
+      ;; Resource unavailable, or operation would block.
+      $EAGAIN
+      ;; Connection already in progress.
+      $EALREADY
+      ;; Bad file descriptor.
+      $EBADF
+      ;; Bad message.
+      $EBADMSG
+      ;; Device or resource busy.
+      $EBUSY
+      ;; Operation canceled.
+      $ECANCELED
+      ;; No child processes.
+      $ECHILD
+      ;; Connection aborted.
+      $ECONNABORTED
+      ;; Connection refused.
+      $ECONNREFUSED
+      ;; Connection reset.
+      $ECONNRESET
+      ;; Resource deadlock would occur.
+      $EDEADLK
+      ;; Destination address required.
+      $EDESTADDRREQ
+      ;; Mathematics argument out of domain of function.
+      $EDOM
+      ;; Reserved.
+      $EDQUOT
+      ;; File exists.
+      $EEXIST
+      ;; Bad address.
+      $EFAULT
+      ;; File too large.
+      $EFBIG
+      ;; Host is unreachable.
+      $EHOSTUNREACH
+      ;; Identifier removed.
+      $EIDRM
+      ;; Illegal byte sequence.
+      $EILSEQ
+      ;; Operation in progress.
+      $EINPROGRESS
+      ;; Interrupted function.
+      $EINTR
+      ;; Invalid argument.
+      $EINVAL
+      ;; I/O error.
+      $EIO
+      ;; Socket is connected.
+      $EISCONN
+      ;; Is a directory.
+      $EISDIR
+      ;; Too many levels of symbolic links.
+      $ELOOP
+      ;; File descriptor value too large.
+      $EMFILE
+      ;; Too many links.
+      $EMLINK
+      ;; Message too large.
+      $EMSGSIZE
+      ;; Reserved.
+      $EMULTIHOP
+      ;; Filename too long.
+      $ENAMETOOLONG
+      ;; Network is down.
+      $ENETDOWN
+      ;; Connection aborted by network.
+      $ENETRESET
+      ;; Network unreachable.
+      $ENETUNREACH
+      ;; Too many files open in system.
+      $ENFILE
+      ;; No buffer space available.
+      $ENOBUFS
+      ;; No such device.
+      $ENODEV
+      ;; No such file or directory.
+      $ENOENT
+      ;; Executable file format error.
+      $ENOEXEC
+      ;; No locks available.
+      $ENOLCK
+      ;; Reserved.
+      $ENOLINK
+      ;; Not enough space.
+      $ENOMEM
+      ;; No message of the desired type.
+      $ENOMSG
+      ;; Protocol not available.
+      $ENOPROTOOPT
+      ;; No space left on device.
+      $ENOSPC
+      ;; Function not supported.
+      $ENOSYS
+      ;; The socket is not connected.
+      $ENOTCONN
+      ;; Not a directory or a symbolic link to a directory.
+      $ENOTDIR
+      ;; Directory not empty.
+      $ENOTEMPTY
+      ;; State not recoverable.
+      $ENOTRECOVERABLE
+      ;; Not a socket.
+      $ENOTSOCK
+      ;; Not supported, or operation not supported on socket.
+      $ENOTSUP
+      ;; Inappropriate I/O control operation.
+      $ENOTTY
+      ;; No such device or address.
+      $ENXIO
+      ;; Value too large to be stored in data type.
+      $EOVERFLOW
+      ;; Previous owner died.
+      $EOWNERDEAD
+      ;; Operation not permitted.
+      $EPERM
+      ;; Broken pipe.
+      $EPIPE
+      ;; Protocol error.
+      $EPROTO
+      ;; Protocol not supported.
+      $EPROTONOSUPPORT
+      ;; Protocol wrong type for socket.
+      $EPROTOTYPE
+      ;; Result too large.
+      $ERANGE
+      ;; Read-only file system.
+      $EROFS
+      ;; Invalid seek.
+      $ESPIPE
+      ;; No such process.
+      $ESRCH
+      ;; Reserved.
+      $ESTALE
+      ;; Connection timed out.
+      $ETIMEDOUT
+      ;; Text file busy.
+      $ETXTBSY
+      ;; Cross-device link.
+      $EXDEV
+      ;; Extension: Capabilities insufficient.
+      $ENOTCAPABLE
+    )
+  )
 
-	;; A reference to the offset of a directory entry.
-	(type $dircookie_t u64)
 
-	;; A directory entry.
-	(type $dirent_t 
-		(struct
-			;; The offset of the next directory entry stored in this directory.
-			(field $d_next $dircookie_t)
-			;; The serial number of the file referred to by this directory entry.
-			(field $d_ino $inode_t)
-			;; The length of the name of the directory entry.
-			(field $d_namlen u32)
-			;; The type of the file referred to by this directory entry.
-			(field $d_type $filetype_t)
-		)
-	)
+  ;; File descriptor flags.
+  (type $fdflags_t
+    (struct
+      ;; Append mode: Data written to the file is always appended to the file's end.
+      (field $FDFLAG_APPEND Bool)
+      ;; Write according to synchronized I/O data integrity completion. Only the data stored in the file is synchronized.
+      (field $FDFLAG_DSYNC Bool)
+      ;; Non-blocking mode.
+      (field $FDFLAG_NONBLOCK Bool)
+      ;; Synchronized read I/O operations.
+      (field $FDFLAG_RSYNC Bool)
+      ;; Write according to synchronized I/O file integrity completion. In addition to synchronizing the data stored in the file, the implementation may also synchronously update the file's metadata.
+      (field $FDFLAG_SYNC Bool)
+    )
+  )
 
-	;; Error codes returned by functions.
-	;; Not all of these error codes are returned by the functions provided by this API; some are used in higher-level library layers, and others are provided merely for alignment with POSIX.
-	(type $errno_t
-		(enum
-			;; No error occurred. System call completed successfully.
-			$ESUCCESS
-			;; Argument list too long.
-			$E2BIG
-			;; Permission denied.
-			$EACCES
-			;; Address in use.
-			$EADDRINUSE
-			;; Address not available.
-			$EADDRNOTAVAIL
-			;; Address family not supported.
-			$EAFNOSUPPORT
-			;; Resource unavailable, or operation would block.
-			$EAGAIN
-			;; Connection already in progress.
-			$EALREADY
-			;; Bad file descriptor.
-			$EBADF
-			;; Bad message.
-			$EBADMSG
-			;; Device or resource busy.
-			$EBUSY
-			;; Operation canceled.
-			$ECANCELED
-			;; No child processes.
-			$ECHILD
-			;; Connection aborted.
-			$ECONNABORTED
-			;; Connection refused.
-			$ECONNREFUSED
-			;; Connection reset.
-			$ECONNRESET
-			;; Resource deadlock would occur.
-			$EDEADLK
-			;; Destination address required.
-			$EDESTADDRREQ
-			;; Mathematics argument out of domain of function.
-			$EDOM
-			;; Reserved.
-			$EDQUOT
-			;; File exists.
-			$EEXIST
-			;; Bad address.
-			$EFAULT
-			;; File too large.
-			$EFBIG
-			;; Host is unreachable.
-			$EHOSTUNREACH
-			;; Identifier removed.
-			$EIDRM
-			;; Illegal byte sequence.
-			$EILSEQ
-			;; Operation in progress.
-			$EINPROGRESS
-			;; Interrupted function.
-			$EINTR
-			;; Invalid argument.
-			$EINVAL
-			;; I/O error.
-			$EIO
-			;; Socket is connected.
-			$EISCONN
-			;; Is a directory.
-			$EISDIR
-			;; Too many levels of symbolic links.
-			$ELOOP
-			;; File descriptor value too large.
-			$EMFILE
-			;; Too many links.
-			$EMLINK
-			;; Message too large.
-			$EMSGSIZE
-			;; Reserved.
-			$EMULTIHOP
-			;; Filename too long.
-			$ENAMETOOLONG
-			;; Network is down.
-			$ENETDOWN
-			;; Connection aborted by network.
-			$ENETRESET
-			;; Network unreachable.
-			$ENETUNREACH
-			;; Too many files open in system.
-			$ENFILE
-			;; No buffer space available.
-			$ENOBUFS
-			;; No such device.
-			$ENODEV
-			;; No such file or directory.
-			$ENOENT
-			;; Executable file format error.
-			$ENOEXEC
-			;; No locks available.
-			$ENOLCK
-			;; Reserved.
-			$ENOLINK
-			;; Not enough space.
-			$ENOMEM
-			;; No message of the desired type.
-			$ENOMSG
-			;; Protocol not available.
-			$ENOPROTOOPT
-			;; No space left on device.
-			$ENOSPC
-			;; Function not supported.
-			$ENOSYS
-			;; The socket is not connected.
-			$ENOTCONN
-			;; Not a directory or a symbolic link to a directory.
-			$ENOTDIR
-			;; Directory not empty.
-			$ENOTEMPTY
-			;; State not recoverable.
-			$ENOTRECOVERABLE
-			;; Not a socket.
-			$ENOTSOCK
-			;; Not supported, or operation not supported on socket.
-			$ENOTSUP
-			;; Inappropriate I/O control operation.
-			$ENOTTY
-			;; No such device or address.
-			$ENXIO
-			;; Value too large to be stored in data type.
-			$EOVERFLOW
-			;; Previous owner died.
-			$EOWNERDEAD
-			;; Operation not permitted.
-			$EPERM
-			;; Broken pipe.
-			$EPIPE
-			;; Protocol error.
-			$EPROTO
-			;; Protocol not supported.
-			$EPROTONOSUPPORT
-			;; Protocol wrong type for socket.
-			$EPROTOTYPE
-			;; Result too large.
-			$ERANGE
-			;; Read-only file system.
-			$EROFS
-			;; Invalid seek.
-			$ESPIPE
-			;; No such process.
-			$ESRCH
-			;; Reserved.
-			$ESTALE
-			;; Connection timed out.
-			$ETIMEDOUT
-			;; Text file busy.
-			$ETXTBSY
-			;; Cross-device link.
-			$EXDEV
-			;; Extension: Capabilities insufficient.
-			$ENOTCAPABLE
-		)
-	)
+  ;; File descriptor attributes.
+  (type $fdstat_t 
+    ;; File type.
+    (field $fs_filetype $filetype_t)
+    ;; File descriptor flags.
+    (field $fs_flags $fdflags_t)
+    ;; Rights that apply to this file descriptor.
+    (field $fs_rights_base $rights_t)
+    ;; Maximum set of rights that may be installed on new file descriptors that are created through this file descriptor, e.g., through __wasi_path_open().
+    (field $fs_rights_inheriting $rights_t)
+  )
 
-	;; An event that occurred.
-	(type $event_t
-		(struct
-			;; User-provided value that got attached to __wasi_subscription_t::userdata.
-			(field $userdata $userdata_t)
-			;; If non-zero, an error that occurred while processing the subscription request.
-			(field $error $errno_t)
-			;; The type of the event that occurred.
-			(field $type $eventtype_t)
-			(field $u 
-				(type union
-					;; When type is __WASI_EVENTTYPE_FD_READ or __WASI_EVENTTYPE_FD_WRITE:
-					(field $fd_readwrite
-						(type stuct
-							;; The number of bytes available for reading or writing.
-							(field $nbytes $filesize_t)
-							;; The state of the file descriptor.
-							(field $flags $eventrwflags_t)
-						)
-					)
-					(field $else Null)
-				)
-			)
-		)
-	)
+  ;; Non-negative file size or length of a region within a file.
+  (type $filesize_t u64)
 
-	;; The state of the file descriptor subscribed to with __WASI_EVENTTYPE_FD_READ or __WASI_EVENTTYPE_FD_WRITE.
-	(type $eventrwflags_t
-		(struct
-			;; The peer of this socket has closed or disconnected.
-			(field $EVENT_FD_READWRITE_HANGUP Bool)
-		)
-	)
+  ;; Identifier for a device containing a file system. Can be used in combination with __wasi_inode_t to uniquely identify a file or directory in the filesystem.
+  (type $device_t u64)
 
-	;; Type of a subscription to an event or its occurrence.
-	(type $eventtype_t
-		(struct
-			;; The time value of clock __wasi_subscription_t::u.clock.clock_id has reached timestamp __wasi_subscription_t::u.clock.timeout.
-			(field $EVENTTYPE_CLOCK Bool)
-			;; File descriptor __wasi_subscription_t::u.fd_readwrite.fd has data available for reading. This event always triggers for regular files.
-			(field $EVENTTYPE_FD_READ Bool)
-			;; File descriptor __wasi_subscription_t::u.fd_readwrite.fd has capacity available for writing. This event always triggers for regular files.
-			(field $EVENTTYPE_FD_WRITE Bool)
-		)
-	)
+  ;; File attributes.
+  (type $filestat_t
+    (struct
+      ;; Device ID of device containing the file.
+      (field $st_dev $device_t)
+      ;; File serial number.
+      (field $st_ino $inode_t)
+      ;; File type.
+      (field $st_filetype $filetype_t)
+      ;; Number of hard links to the file.
+      (field $st_nlink $linkcount_t)
+      ;; For regular files, the file size in bytes. For symbolic links, the length in bytes of the pathname contained in the symbolic link.
+      (field $st_size $filesize_t)
+      ;; Last data access timestamp.
+      (field $st_atim $timestamp_t)
+      ;; Last data modification timestamp.
+      (field $st_mtim $timestamp_t)
+      ;; Last file status change timestamp.
+      (field $st_ctim $timestamp_t)
+    )
+  )
 
-	;; Exit code generated by a process when exiting.
-	(type $exitcode_t u32)
+  ;; The type of a file descriptor or file.
+  (type $filetype_t
+    (enum
+      ;; The type of the file descriptor or file is unknown or is different from any of the other types specified.
+      $FILETYPE_UNKNOWN
+      ;; The file descriptor or file refers to a block device inode.
+      $FILETYPE_BLOCK_DEVICE
+      ;; The file descriptor or file refers to a character device inode.
+      $FILETYPE_CHARACTER_DEVICE
+      ;; The file descriptor or file refers to a directory inode.
+      $FILETYPE_DIRECTORY
+      ;; The file descriptor or file refers to a regular file inode.
+      $FILETYPE_REGULAR_FILE
+      ;; The file descriptor or file refers to a datagram socket.
+      $FILETYPE_SOCKET_DGRAM
+      ;; The file descriptor or file refers to a byte-stream socket.
+      $FILETYPE_SOCKET_STREAM
+      ;; The file refers to a symbolic link inode.
+      $FILETYPE_SYMBOLIC_LINK
+    )
+  )
 
-	;; File descriptor flags.
-	(type $fdflags_t
-		(struct
-			;; Append mode: Data written to the file is always appended to the file's end.
-			(field $FDFLAG_APPEND Bool)
-			;; Write according to synchronized I/O data integrity completion. Only the data stored in the file is synchronized.
-			(field $FDFLAG_DSYNC Bool)
-			;; Non-blocking mode.
-			(field $FDFLAG_NONBLOCK Bool)
-			;; Synchronized read I/O operations.
-			(field $FDFLAG_RSYNC Bool)
-			;; Write according to synchronized I/O file integrity completion. In addition to synchronizing the data stored in the file, the implementation may also synchronously update the file's metadata.
-			(field $FDFLAG_SYNC Bool)
-		)
-	)
+  ;; Which file time attributes to adjust.
+  (type $fstflags_t
+    (struct 
+      ;; Adjust the last data access timestamp to the value stored in __wasi_filestat_t::st_atim.
+      (field $FILESTAT_SET_ATIM Bool)
+      ;; Adjust the last data access timestamp to the time of clock __WASI_CLOCK_REALTIME.
+      (field $FILESTAT_SET_ATIM_NOW Bool)
+      ;; Adjust the last data modification timestamp to the value stored in __wasi_filestat_t::st_mtim.
+      (field $FILESTAT_SET_MTIM Bool)
+      ;; Adjust the last data modification timestamp to the time of clock __WASI_CLOCK_REALTIME.
+      (field $FILESTAT_SET_MTIM_NOW Bool)
+    )
+  )
 
-	;; File descriptor attributes.
-	(type $fdstat_t 
-		;; File type.
-		(field $fs_filetype $filetype_t)
-		;; File descriptor flags.
-		(field $fs_flags $fdflags_t)
-		;; Rights that apply to this file descriptor.
-		(field $fs_rights_base $rights_t)
-		;; Maximum set of rights that may be installed on new file descriptors that are created through this file descriptor, e.g., through __wasi_path_open().
-		(field $fs_rights_inheriting $rights_t)
-	)
+  ;; File serial number that is unique within its file system.
+  (type $inode_t u64)
 
-	;; Non-negative file size or length of a region within a file.
-	(type $filesize_t u64)
+  ;; Number of hard links to an inode.
+  (type $linkcount_t u32)
 
-	;; File attributes.
-	(type $filestat_t
-		(struct
-			;; Device ID of device containing the file.
-			(field $st_dev $device_t)
-			;; File serial number.
-			(field $st_ino $inode_t)
-			;; File type.
-			(field $st_filetype $filetype_t)
-			;; Number of hard links to the file.
-			(field $st_nlink $linkcount_t)
-			;; For regular files, the file size in bytes. For symbolic links, the length in bytes of the pathname contained in the symbolic link.
-			(field $st_size $filesize_t)
-			;; Last data access timestamp.
-			(field $st_atim $timestamp_t)
-			;; Last data modification timestamp.
-			(field $st_mtim $timestamp_t)
-			;; Last file status change timestamp.
-			(field $st_ctim $timestamp_t)
-		)
-	)
+  ;; Signal condition.
+  (type $signal_t
+    (enum
+      ;; Process abort signal.
+      ;; Action: Terminates the process.
+      $SIGABRT
+      ;; Alarm clock.
+      ;; Action: Terminates the process.
+      $SIGALRM
+      ;; Access to an undefined portion of a memory object.
+      ;; Action: Terminates the process.
+      $SIGBUS
+      ;; Child process terminated, stopped, or continued.
+      ;; Action: Ignored.
+      $SIGCHLD
+      ;; Continue executing, if stopped.
+      ;; Action: Continues executing, if stopped.
+      $SIGCONT
+      ;; Erroneous arithmetic operation.
+      ;; Action: Terminates the process.
+      $SIGFPE
+      ;; Hangup.
+      ;; Action: Terminates the process.
+      $SIGHUP
+      ;; Illegal instruction.
+      ;; Action: Terminates the process.
+      $SIGILL
+      ;; Terminate interrupt signal.
+      ;; Action: Terminates the process.
+      $SIGINT
+      ;; Kill.
+      ;; Action: Terminates the process.
+      $SIGKILL
+      ;; Write on a pipe with no one to read it.
+      ;; Action: Ignored.
+      $SIGPIPE
+      ;; Terminal quit signal.
+      ;; Action: Terminates the process.
+      $SIGQUIT
+      ;; Invalid memory reference.
+      ;; Action: Terminates the process.
+      $SIGSEGV
+      ;; Stop executing.
+      ;; Action: Stops executing.
+      $SIGSTOP
+      ;; Bad system call.
+      ;; Action: Terminates the process.
+      $SIGSYS
+      ;; Termination signal.
+      ;; Action: Terminates the process.
+      $SIGTERM
+      ;; Trace/breakpoint trap.
+      ;; Action: Terminates the process.
+      $SIGTRAP
+      ;; Terminal stop signal.
+      ;; Action: Stops executing.
+      $SIGTSTP
+      ;; Background process attempting read.
+      ;; Action: Stops executing.
+      $SIGTTIN
+      ;; Background process attempting write.
+      ;; Action: Stops executing.
+      $SIGTTOU
+      ;; High bandwidth data is available at a socket.
+      ;; Action: Ignored.
+      $SIGURG
+      ;; User-defined signal 1.
+      ;; Action: Terminates the process.
+      $SIGUSR1
+      ;; User-defined signal 2.
+      ;; Action: Terminates the process.
+      $SIGUSR2
+      ;; Virtual timer expired.
+      ;; Action: Terminates the process.
+      $SIGVTALRM
+      ;; CPU time limit exceeded.
+      ;; Action: Terminates the process.
+      $SIGXCPU
+      ;; File size limit exceeded.
+      ;; Action: Terminates the process.
+      $SIGXFSZ
+    )
+  )
 
-	;; The type of a file descriptor or file.
-	(type $filetype_t
-		(enum
-			;; The type of the file descriptor or file is unknown or is different from any of the other types specified.
-			$FILETYPE_UNKNOWN
-			;; The file descriptor or file refers to a block device inode.
-			$FILETYPE_BLOCK_DEVICE
-			;; The file descriptor or file refers to a character device inode.
-			$FILETYPE_CHARACTER_DEVICE
-			;; The file descriptor or file refers to a directory inode.
-			$FILETYPE_DIRECTORY
-			;; The file descriptor or file refers to a regular file inode.
-			$FILETYPE_REGULAR_FILE
-			;; The file descriptor or file refers to a datagram socket.
-			$FILETYPE_SOCKET_DGRAM
-			;; The file descriptor or file refers to a byte-stream socket.
-			$FILETYPE_SOCKET_STREAM
-			;; The file refers to a symbolic link inode.
-			$FILETYPE_SYMBOLIC_LINK
-		)
-	)
+  ;; Flags determining how to interpret the timestamp provided in __wasi_subscription_t::u.clock.timeout.
+  (type $subclockflags_t
+    (struct
+      ;; If set, treat the timestamp provided in __wasi_subscription_t::u.clock.timeout as an absolute timestamp of clock __wasi_subscription_t::u.clock.clock_id.
+      ;; If clear, treat the timestamp provided in __wasi_subscription_t::u.clock.timeout relative to the current time value of clock __wasi_subscription_t::u.clock.clock_id.
+      (field $SUBSCRIPTION_CLOCK_ABSTIME Bool)
+    )
+  )
 
-	;; Which file time attributes to adjust.
-	(type $fstflags_t
-		(struct 
-			;; Adjust the last data access timestamp to the value stored in __wasi_filestat_t::st_atim.
-			(field $FILESTAT_SET_ATIM Bool)
-			;; Adjust the last data access timestamp to the time of clock __WASI_CLOCK_REALTIME.
-			(field $FILESTAT_SET_ATIM_NOW Bool)
-			;; Adjust the last data modification timestamp to the value stored in __wasi_filestat_t::st_mtim.
-			(field $FILESTAT_SET_MTIM Bool)
-			;; Adjust the last data modification timestamp to the time of clock __WASI_CLOCK_REALTIME.
-			(field $FILESTAT_SET_MTIM_NOW Bool)
-		)
-	)
+  ;; Subscription to an event.
+  (type $subscription_t
+    (struct
+      ;; User-provided value that is attached to the subscription in the implementation and returned through __wasi_event_t::userdata.
+      (field $userdata $userdata_t)
+      ;; The type of the event to which to subscribe.
+      (field $type $eventtype_t)
+      (field 
+        (type
+          (union
+            ;; When type is __WASI_EVENTTYPE_CLOCK
+            (field $clock
+              (type 
+                (struct
+                  ;; The user-defined unique identifier of the clock.
+                  (field $identifier $userdata_t)
+                  ;; The clock against which to compare the timestamp.
+                  (field $clock_id $clockid_t)
+                  ;; The absolute or relative timestamp.
+                  (field $timeout $timestamp_t)
+                  ;; The amount of time that the implementation may wait additionally to coalesce with other events.
+                  ;; Flags specifying whether the timeout is absolute or relative
+                  (field $precision $timestamp_t)
+                )
+              )
+            )
+            ;; When type is __WASI_EVENTTYPE_FD_READ or __WASI_EVENTTYPE_FD_WRITE:
+            (field $fd_readwrite
+              (type
+                (struct
+                  ;; The file descriptor on which to wait for it to become ready for reading or writing.
+                  (field $file_descriptor $fd_ref)
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
 
-	;; File serial number that is unique within its file system.
-	(type $inode_t u64)
+  ;; Timestamp in nanoseconds.
+  (type $timestamp_t u64) 
 
-	;; Number of hard links to an inode.
-	(type $linkcount_t u32)
+  ;; User-provided value that may be attached to objects that is retained when extracted from the implementation.
+  (type $userdata_t u64)
 
-	;; Signal condition.
-	(type $signal_t
-		(enum
-			;; Process abort signal.
-			;; Action: Terminates the process.
-			$SIGABRT
-			;; Alarm clock.
-			;; Action: Terminates the process.
-			$SIGALRM
-			;; Access to an undefined portion of a memory object.
-			;; Action: Terminates the process.
-			$SIGBUS
-			;; Child process terminated, stopped, or continued.
-			;; Action: Ignored.
-			$SIGCHLD
-			;; Continue executing, if stopped.
-			;; Action: Continues executing, if stopped.
-			$SIGCONT
-			;; Erroneous arithmetic operation.
-			;; Action: Terminates the process.
-			$SIGFPE
-			;; Hangup.
-			;; Action: Terminates the process.
-			$SIGHUP
-			;; Illegal instruction.
-			;; Action: Terminates the process.
-			$SIGILL
-			;; Terminate interrupt signal.
-			;; Action: Terminates the process.
-			$SIGINT
-			;; Kill.
-			;; Action: Terminates the process.
-			$SIGKILL
-			;; Write on a pipe with no one to read it.
-			;; Action: Ignored.
-			$SIGPIPE
-			;; Terminal quit signal.
-			;; Action: Terminates the process.
-			$SIGQUIT
-			;; Invalid memory reference.
-			;; Action: Terminates the process.
-			$SIGSEGV
-			;; Stop executing.
-			;; Action: Stops executing.
-			$SIGSTOP
-			;; Bad system call.
-			;; Action: Terminates the process.
-			$SIGSYS
-			;; Termination signal.
-			;; Action: Terminates the process.
-			$SIGTERM
-			;; Trace/breakpoint trap.
-			;; Action: Terminates the process.
-			$SIGTRAP
-			;; Terminal stop signal.
-			;; Action: Stops executing.
-			$SIGTSTP
-			;; Background process attempting read.
-			;; Action: Stops executing.
-			$SIGTTIN
-			;; Background process attempting write.
-			;; Action: Stops executing.
-			$SIGTTOU
-			;; High bandwidth data is available at a socket.
-			;; Action: Ignored.
-			$SIGURG
-			;; User-defined signal 1.
-			;; Action: Terminates the process.
-			$SIGUSR1
-			;; User-defined signal 2.
-			;; Action: Terminates the process.
-			$SIGUSR2
-			;; Virtual timer expired.
-			;; Action: Terminates the process.
-			$SIGVTALRM
-			;; CPU time limit exceeded.
-			;; Action: Terminates the process.
-			$SIGXCPU
-			;; File size limit exceeded.
-			;; Action: Terminates the process.
-			$SIGXFSZ
-		)
-	)
+  ;; File descriptor rights, determining which actions may be performed.
+  (type $rights_t
+    (struct
+      ;; The right to invoke __wasi_fd_datasync().
+      ;; If __WASI_RIGHT_PATH_OPEN is set, includes the right to invoke __wasi_path_open() with __WASI_FDFLAG_DSYNC.
+      (field $RIGHT_FD_DATASYNC Bool)
+      ;; The right to invoke __wasi_fd_read() and __wasi_sock_recv().
+      ;; If __WASI_RIGHT_FD_SEEK is set, includes the right to invoke __wasi_fd_pread().
+      (field $RIGHT_FD_READ Bool)
+      ;; The right to invoke __wasi_fd_seek(). This flag implies __WASI_RIGHT_FD_TELL.
+      (field $RIGHT_FD_SEEK Bool)
+      ;; The right to invoke __wasi_fd_fdstat_set_flags().
+      (field $RIGHT_FD_FDSTAT_SET_FLAGS Bool)
+      ;; The right to invoke __wasi_fd_sync().
+      ;; If __WASI_RIGHT_PATH_OPEN is set, includes the right to invoke __wasi_path_open() with __WASI_FDFLAG_RSYNC and __WASI_FDFLAG_DSYNC.
+      (field $RIGHT_FD_SYNC Bool)
+      ;; The right to invoke __wasi_fd_seek() in such a way that the file offset remains unaltered (i.e., __WASI_WHENCE_CUR with offset zero), or to invoke __wasi_fd_tell().
+      (field $RIGHT_FD_TELL Bool)
+      ;; The right to invoke __wasi_fd_write() and __wasi_sock_send().
+      ;; If __WASI_RIGHT_FD_SEEK is set, includes the right to invoke __wasi_fd_pwrite().
+      (field $RIGHT_FD_WRITE Bool)
+      ;; The right to invoke __wasi_fd_advise().
+      (field $RIGHT_FD_ADVISE Bool)
+      ;; The right to invoke __wasi_fd_allocate().
+      (field $RIGHT_FD_ALLOCATE Bool)
+      ;; The right to invoke __wasi_path_create_directory().
+      (field $RIGHT_PATH_CREATE_DIRECTORY Bool)
+      ;; If __WASI_RIGHT_PATH_OPEN is set, the right to invoke __wasi_path_open() with __WASI_O_CREAT.
+      (field $RIGHT_PATH_CREATE_FILE Bool)
+      ;; The right to invoke __wasi_path_link() with the file descriptor as the source directory.
+      (field $RIGHT_PATH_LINK_SOURCE Bool)
+      ;; The right to invoke __wasi_path_link() with the file descriptor as the target directory.
+      (field $RIGHT_PATH_LINK_TARGET Bool)
+      ;; The right to invoke __wasi_path_open().
+      (field $RIGHT_PATH_OPEN Bool)
+      ;; The right to invoke __wasi_fd_readdir().
+      (field $RIGHT_FD_READDIR Bool)
+      ;; The right to invoke __wasi_path_readlink().
+      (field $RIGHT_PATH_READLINK Bool)
+      ;; The right to invoke __wasi_path_rename() with the file descriptor as the source directory.
+      (field $RIGHT_PATH_RENAME_SOURCE Bool)
+      ;; The right to invoke __wasi_path_rename() with the file descriptor as the target directory.
+      (field $RIGHT_PATH_RENAME_TARGET Bool)
+      ;; The right to invoke __wasi_path_filestat_get().
+      (field $RIGHT_PATH_FILESTAT_GET Bool)
+      ;; The right to change a file's size (there is no __wasi_path_filestat_set_size()).
+      ;; If __WASI_RIGHT_PATH_OPEN is set, includes the right to invoke __wasi_path_open() with __WASI_O_TRUNC.
+      (field $RIGHT_PATH_FILESTAT_SET_SIZE Bool)
+      ;; The right to invoke __wasi_path_filestat_set_times().
+      (field $RIGHT_PATH_FILESTAT_SET_TIMES Bool)
+      ;; The right to invoke __wasi_fd_filestat_get().
+      (field $RIGHT_FD_FILESTAT_GET Bool)
+      ;; The right to invoke __wasi_fd_filestat_set_size().
+      (field $RIGHT_FD_FILESTAT_SET_SIZE Bool)
+      ;; The right to invoke __wasi_fd_filestat_set_times().
+      (field $RIGHT_FD_FILESTAT_SET_TIMES Bool)
+      ;; The right to invoke __wasi_path_symlink().
+      (field $RIGHT_PATH_SYMLINK Bool)
+      ;; The right to invoke __wasi_path_unlink_file().
+      (field $RIGHT_PATH_UNLINK_FILE Bool)
+      ;; The right to invoke __wasi_path_remove_directory().
+      (field $RIGHT_PATH_REMOVE_DIRECTORY Bool)
+      ;; If __WASI_RIGHT_FD_READ is set, includes the right to invoke __wasi_poll_oneoff() to subscribe to __WASI_EVENTTYPE_FD_READ.
+      ;; If __WASI_RIGHT_FD_WRITE is set, includes the right to invoke __wasi_poll_oneoff() to subscribe to __WASI_EVENTTYPE_FD_WRITE.
+      (field $RIGHT_POLL_FD_READWRITE Bool)
+      ;; The right to invoke __wasi_sock_shutdown().
+      (field $RIGHT_SOCK_SHUTDOWN Bool)
+    )
+  )
 
-	;; Flags determining how to interpret the timestamp provided in __wasi_subscription_t::u.clock.timeout.
-	(type $subclockflags_t
-		(struct
-			;; If set, treat the timestamp provided in __wasi_subscription_t::u.clock.timeout as an absolute timestamp of clock __wasi_subscription_t::u.clock.clock_id.
-			;; If clear, treat the timestamp provided in __wasi_subscription_t::u.clock.timeout relative to the current time value of clock __wasi_subscription_t::u.clock.clock_id.
-			(field $SUBSCRIPTION_CLOCK_ABSTIME Bool)
-		)
-	)
-
-	;; Subscription to an event.
-	(type $subscription_t
-		(struct
-			;; User-provided value that is attached to the subscription in the implementation and returned through __wasi_event_t::userdata.
-			(field $userdata $userdata_t)
-			;; The type of the event to which to subscribe.
-			(field $type $eventtype_t)
-			(field 
-				(type
-					(union
-						;; When type is __WASI_EVENTTYPE_CLOCK
-						(field $clock
-							(type 
-								(struct
-									;; The user-defined unique identifier of the clock.
-									(field $identifier $userdata_t)
-									;; The clock against which to compare the timestamp.
-									(field $clock_id $clockid_t)
-									;; The absolute or relative timestamp.
-									(field $timeout $timestamp_t)
-									;; The amount of time that the implementation may wait additionally to coalesce with other events.
-									;; Flags specifying whether the timeout is absolute or relative
-									(field $precision $timestamp_t)
-								)
-							)
-						)
-						;; When type is __WASI_EVENTTYPE_FD_READ or __WASI_EVENTTYPE_FD_WRITE:
-						(field $fd_readwrite
-							(type
-								(struct
-									;; The file descriptor on which to wait for it to become ready for reading or writing.
-									(field $file_descriptor $fd)
-								)
-							)
-						)
-					)
-				)
-			)
-		)
-	)
-
-	;; Timestamp in nanoseconds.
-	(type $timestamp_t u64) 
-
-	;; User-provided value that may be attached to objects that is retained when extracted from the implementation.
-	(type $userdata_t u64)
-
-	;; File descriptor rights, determining which actions may be performed.
-	(type $rights_t
-		(struct
-			;; The right to invoke __wasi_fd_datasync().
-			;; If __WASI_RIGHT_PATH_OPEN is set, includes the right to invoke __wasi_path_open() with __WASI_FDFLAG_DSYNC.
-			(field $RIGHT_FD_DATASYNC Bool)
-			;; The right to invoke __wasi_fd_read() and __wasi_sock_recv().
-			;; If __WASI_RIGHT_FD_SEEK is set, includes the right to invoke __wasi_fd_pread().
-			(field $RIGHT_FD_READ Bool)
-			;; The right to invoke __wasi_fd_seek(). This flag implies __WASI_RIGHT_FD_TELL.
-			(field $RIGHT_FD_SEEK Bool)
-			;; The right to invoke __wasi_fd_fdstat_set_flags().
-			(field $RIGHT_FD_FDSTAT_SET_FLAGS Bool)
-			;; The right to invoke __wasi_fd_sync().
-			;; If __WASI_RIGHT_PATH_OPEN is set, includes the right to invoke __wasi_path_open() with __WASI_FDFLAG_RSYNC and __WASI_FDFLAG_DSYNC.
-			(field $RIGHT_FD_SYNC Bool)
-			;; The right to invoke __wasi_fd_seek() in such a way that the file offset remains unaltered (i.e., __WASI_WHENCE_CUR with offset zero), or to invoke __wasi_fd_tell().
-			(field $RIGHT_FD_TELL Bool)
-			;; The right to invoke __wasi_fd_write() and __wasi_sock_send().
-			;; If __WASI_RIGHT_FD_SEEK is set, includes the right to invoke __wasi_fd_pwrite().
-			(field $RIGHT_FD_WRITE Bool)
-			;; The right to invoke __wasi_fd_advise().
-			(field $RIGHT_FD_ADVISE Bool)
-			;; The right to invoke __wasi_fd_allocate().
-			(field $RIGHT_FD_ALLOCATE Bool)
-			;; The right to invoke __wasi_path_create_directory().
-			(field $RIGHT_PATH_CREATE_DIRECTORY Bool)
-			;; If __WASI_RIGHT_PATH_OPEN is set, the right to invoke __wasi_path_open() with __WASI_O_CREAT.
-			(field $RIGHT_PATH_CREATE_FILE Bool)
-			;; The right to invoke __wasi_path_link() with the file descriptor as the source directory.
-			(field $RIGHT_PATH_LINK_SOURCE Bool)
-			;; The right to invoke __wasi_path_link() with the file descriptor as the target directory.
-			(field $RIGHT_PATH_LINK_TARGET Bool)
-			;; The right to invoke __wasi_path_open().
-			(field $RIGHT_PATH_OPEN Bool)
-			;; The right to invoke __wasi_fd_readdir().
-			(field $RIGHT_FD_READDIR Bool)
-			;; The right to invoke __wasi_path_readlink().
-			(field $RIGHT_PATH_READLINK Bool)
-			;; The right to invoke __wasi_path_rename() with the file descriptor as the source directory.
-			(field $RIGHT_PATH_RENAME_SOURCE Bool)
-			;; The right to invoke __wasi_path_rename() with the file descriptor as the target directory.
-			(field $RIGHT_PATH_RENAME_TARGET Bool)
-			;; The right to invoke __wasi_path_filestat_get().
-			(field $RIGHT_PATH_FILESTAT_GET Bool)
-			;; The right to change a file's size (there is no __wasi_path_filestat_set_size()).
-			;; If __WASI_RIGHT_PATH_OPEN is set, includes the right to invoke __wasi_path_open() with __WASI_O_TRUNC.
-			(field $RIGHT_PATH_FILESTAT_SET_SIZE Bool)
-			;; The right to invoke __wasi_path_filestat_set_times().
-			(field $RIGHT_PATH_FILESTAT_SET_TIMES Bool)
-			;; The right to invoke __wasi_fd_filestat_get().
-			(field $RIGHT_FD_FILESTAT_GET Bool)
-			;; The right to invoke __wasi_fd_filestat_set_size().
-			(field $RIGHT_FD_FILESTAT_SET_SIZE Bool)
-			;; The right to invoke __wasi_fd_filestat_set_times().
-			(field $RIGHT_FD_FILESTAT_SET_TIMES Bool)
-			;; The right to invoke __wasi_path_symlink().
-			(field $RIGHT_PATH_SYMLINK Bool)
-			;; The right to invoke __wasi_path_unlink_file().
-			(field $RIGHT_PATH_UNLINK_FILE Bool)
-			;; The right to invoke __wasi_path_remove_directory().
-			(field $RIGHT_PATH_REMOVE_DIRECTORY Bool)
-			;; If __WASI_RIGHT_FD_READ is set, includes the right to invoke __wasi_poll_oneoff() to subscribe to __WASI_EVENTTYPE_FD_READ.
-			;; If __WASI_RIGHT_FD_WRITE is set, includes the right to invoke __wasi_poll_oneoff() to subscribe to __WASI_EVENTTYPE_FD_WRITE.
-			(field $RIGHT_POLL_FD_READWRITE Bool)
-			;; The right to invoke __wasi_sock_shutdown().
-			(field $RIGHT_SOCK_SHUTDOWN Bool)
-		)
-	)
-
-	;; linear memory used by the program
-	(import "memory" (memory)) 
-	;; the program entry point
-	(import "_start" (func))
+  ;; linear memory used by the program
+  (import "memory" (memory)) 
+  ;; the program entry point
+  (import "_start" (func))
 )
 
 (interface $args extends $wasi
-	;; Read command-line argument data.
-	;; The size of the array should match that returned by `wasi_args_sizes_get()`
-	(static func (export "get")
-		(result $argv $string_array)
-	)
-	;; Return command-line argument data sizes.
-	(static func (export "size_get")
-		;; The number of arguments.
-		(result $argc $size_t) 
-		;; The size of the argument string data.
-		(result $argv_buf_size $size_t) 
-	)
+  ;; Read command-line argument data.
+  ;; The size of the array should match that returned by `wasi_args_sizes_get()`
+  (func (export "get")
+    (result $argv $string_array)
+  )
+  ;; Return command-line argument data sizes.
+  (func (export "size_get")
+    ;; The number of arguments.
+    (result $argc $size_t) 
+    ;; The size of the argument string data.
+    (result $argv_buf_size $size_t) 
+  )
 )
 
 (interface $environ extends $wasi
-	;; Read environment variable data.
-	;; The sizes of the buffers should match that returned by environ.sizes_get().
-	(static func (export "get")
-		(result $argv $string_array)
-	)
-	;; Return command-line argument data sizes.
-	(static func (export "size_get")
-		;; The number of arguments.
-		(result $argc $size_t) 
-		;; The size of the argument string data.
-		(result $argv_buf_size $size_t)
-	)
+  ;; Read environment variable data.
+  ;; The sizes of the buffers should match that returned by environ.sizes_get().
+  (func (export "get")
+    (result $argv $string_array)
+  )
+  ;; Return command-line argument data sizes.
+  (func (export "size_get")
+    ;; The number of arguments.
+    (result $argc $size_t) 
+    ;; The size of the argument string data.
+    (result $argv_buf_size $size_t)
+  )
 )
 
 (interface $clocks extends $wasi
-	;; Return the resolution of a clock.
-	;; Implementations are required to provide a non-zero value for supported clocks. For unsupported clocks, return `WASI_EINVAL`
-	;; Note: This is similar to clock_getres in POSIX.
-	(static func (export "res_get")
-		;; The clock for which to return the resolution.
-		(param $clock_id $wasi.clockid_t)
-		;; The resolution of the clock.
-		(result $resolution $wasi.timestamp_t)
-	) 
-	;; Return the time value of a clock.
-	;; Note: This is similar to clock_gettime in POSIX.
-	(static func (export "time_get")
-		;; The clock for which to return the time.
-		(param $clock_id $wasi.clockid_t)
-		;; The maximum lag (exclusive) that the returned time value may have, compared to its actual value.
-		(param $precision $wasi.timestamp_t)
-		;; The time value of the clock.
-		(result $time $wasi.timestamp_t)
-	) 
+  ;; Return the resolution of a clock.
+  ;; Implementations are required to provide a non-zero value for supported clocks. For unsupported clocks, return `WASI_EINVAL`
+  ;; Note: This is similar to clock_getres in POSIX.
+  (func (export "res_get")
+    ;; The clock for which to return the resolution.
+    (param $clock_id $wasi.clockid_t)
+    ;; The resolution of the clock.
+    (result $resolution $wasi.timestamp_t)
+  ) 
+  ;; Return the time value of a clock.
+  ;; Note: This is similar to clock_gettime in POSIX.
+  (func (export "time_get")
+    ;; The clock for which to return the time.
+    (param $clock_id $wasi.clockid_t)
+    ;; The maximum lag (exclusive) that the returned time value may have, compared to its actual value.
+    (param $precision $wasi.timestamp_t)
+    ;; The time value of the clock.
+    (result $time $wasi.timestamp_t)
+  ) 
 )
 
 (interface $fd extends $wasi
-	;; Relative offset within a file.
-	(type $filedelta_t s64)
+  ;; a reference to a file descriptor
+  (type $fd_ref anyref)
 
-	;; The position relative to which to set the offset of the file descriptor.
-	(type $whence_t
-		(enum
-			;; Seek relative to current position.
-			$WHENCE_CUR
-			;; Seek relative to end-of-file.
-			$WHENCE_END
-			;; Seek relative to start-of-file.
-			$WHENCE_SET
-		)
-	)
+  ;; Relative offset within a file.
+  (type $filedelta_t s64)
 
-	;; Provide file advisory information on a file descriptor.
-	;; Note: This is similar to posix_fadvise in POSIX.
-	(func (export "advise")
-		(param $offset $wasi.filesize_t) ;; The offset within the file to which the advisory applies.
-		(param $len $wasi.filesize_t) ;; The length of the region to which the advisory applies.
-		(param $advice $wasi.advice_t) ;; The advice.
-	)
+  ;; The position relative to which to set the offset of the file descriptor.
+  (type $whence_t
+    (enum
+      ;; Seek relative to current position.
+      $WHENCE_CUR
+      ;; Seek relative to end-of-file.
+      $WHENCE_END
+      ;; Seek relative to start-of-file.
+      $WHENCE_SET
+    )
+  )
+
+  ;; A reference to the offset of a directory entry.
+  (type $dircookie_t u64)
+
+  ;; A directory entry.
+  (type $dirent_t 
+    (struct
+      ;; The offset of the next directory entry stored in this directory.
+      (field $d_next $dircookie_t)
+      ;; The serial number of the file referred to by this directory entry.
+      (field $d_ino $inode_t)
+      ;; The length of the name of the directory entry.
+      (field $d_namlen u32)
+      ;; The type of the file referred to by this directory entry.
+      (field $d_type $filetype_t)
+    )
+  )
+
+  ;; File or memory access pattern advisory information.
+  (type $advice_t
+    (enum
+      ;; The application expects that it will not access the specified data in the near future.
+      $ADVICE_DONTNEED
+      ;; The application expects to access the specified data once and then not reuse it thereafter.
+      $ADVICE_NOREUSE
+      ;; The application has no advice to give on its behavior with respect to the specified data.
+      $ADVICE_NORMAL
+      ;; The application expects to access the specified data in a random order.
+      $ADVICE_RANDOM
+      ;; The application expects to access the specified data sequentially from lower offsets to higher offsets.
+      $ADVICE_SEQUENTIAL
+      ;; The application expects to access the specified data in the near future.
+      $ADVICE_WILLNEED
+    )
+  )
 
 
-	;; Force the allocation of space in a file.
-	;; Note: This is similar to posix_fallocate in POSIX.
-	(func (export "allocate")
-		;; The offset at which to start the allocation.
-		(param $offset $wasi.filesize_t) 
-		;; The length of the area that is allocated.
-		(param $len $wasi.filesize_t)
-	)
 
-	;; Close a file descriptor.
-	;; Note: This is similar to close in POSIX. 
-	(func (export "close"))
+  ;; Provide file advisory information on a file descriptor.
+  ;; Note: This is similar to posix_fadvise in POSIX.
+  (func (export "advise")
+    (param $this $fd_ref)
+    (param $offset $filesize_t) ;; The offset within the file to which the advisory applies.
+    (param $len $filesize_t) ;; The length of the region to which the advisory applies.
+    (param $advice $advice_t) ;; The advice.
+  )
 
-	;; Synchronize the data of a file to disk.
-	;; Note: This is similar to `fdatasync` in POSIX.
-	(func (export "datasync"))
 
-	;; Get the attributes of a file descriptor.
-	;; Note: This returns similar flags to `fsync(fd, F_GETFL)` in POSIX, as well as additional fields.
-	(func (export "fdstat_get")
-		;; The buffer where the file descriptor's attributes are stored.
-		(result $wasi.fdstat_t) 
-	)
+  ;; Force the allocation of space in a file.
+  ;; Note: This is similar to posix_fallocate in POSIX.
+  (func (export "allocate")
+    (method $fd_ref) 
+    ;; The offset at which to start the allocation.
+    (param $offset $wasi.filesize_t) 
+    ;; The length of the area that is allocated.
+    (param $len $wasi.filesize_t)
+  )
 
-	;; Adjust the flags associated with a file descriptor.
-	;; Note: This is similar to `fcntl(fd, F_SETFL, flags)` in POSIX.
-	(func (export "fdstat_set_flags")
-		;; The desired values of the file descriptor flags.
-		(param $flags $wasi.fdflags)
-	)
+  ;; Close a file descriptor.
+  ;; Note: This is similar to close in POSIX. 
+  (func (export "close")
+    (method $fd_ref) 
+  )
 
-	;;  Adjust the rights associated with a file descriptor.
-	;; This can only be used to remove rights, and returns `ENOTCAPABLE` if called in a way that would attempt to add rights
-	(func (export "fdstat_set_rights") 
-		;; The desired rights of the file descriptor.
-		(param $fs_rights_base $wasi.rights_t)
-		(param $fs_rights_inheriting $wasi.rights_t)
-	)
+  ;; Synchronize the data of a file to disk.
+  ;; Note: This is similar to `fdatasync` in POSIX.
+  (func (export "datasync")
+    (method $fd_ref) 
+  )
 
-	;; Return the attributes of an open file.
-	(func (export "filestat_get")
-		;; The buffer where the file's attributes are stored.
-		(result $fs_rights_base $wasi.rights_t)
-	)
+  ;; Get the attributes of a file descriptor.
+  ;; Note: This returns similar flags to `fsync(fd, F_GETFL)` in POSIX, as well as additional fields.
+  (func (export "fdstat_get")
+    (method $fd_ref) 
+    ;; The buffer where the file descriptor's attributes are stored.
+    (result $wasi.fdstat_t) 
+  )
 
-	;; Adjust the size of an open file. If this increases the file's size, the extra bytes are filled with zeros.
-	;; Note: This is similar to ftruncate in POSIX. 
-	(func (export "filestat_set_size")
-		;; The desired file size.
-		(param $st_size $wasi.filesize_t)
-	)
+  ;; Adjust the flags associated with a file descriptor.
+  ;; Note: This is similar to `fcntl(fd, F_SETFL, flags)` in POSIX.
+  (func (export "fdstat_set_flags")
+    (method $fd_ref) 
+    ;; The desired values of the file descriptor flags.
+    (param $flags $wasi.fdflags)
+  )
 
-	;; Adjust the timestamps of an open file or directory.
-	;; Note: This is similar to `futimens` in POSIX.
-	(func (export "filestat_set_times")
-		;; The desired values of the data access timestamp.
-		(param $st_atim $wasi.timestamp_t)
-		;; The desired values of the data modification timestamp.
-		(param $st_mtim $wasi.timestamp_t)
-		;; A bitmask indicating which timestamps to adjust.
-		(param $fst_flags $wasi.fstflags_t)
-	)
+  ;;  Adjust the rights associated with a file descriptor.
+  ;; This can only be used to remove rights, and returns `ENOTCAPABLE` if called in a way that would attempt to add rights
+  (func (export "fdstat_set_rights") 
+    (method $fd_ref) 
+    ;; The desired rights of the file descriptor.
+    (param $fs_rights_base $wasi.rights_t)
+    (param $fs_rights_inheriting $wasi.rights_t)
+  )
 
-	;; Read from a file descriptor, without using and updating the file descriptor's offset.
-	;; Note: This is similar to `preadv` in POSIX.
-	(func (export "pread")
-		;; List of scatter/gather vectors in which to store data.
-		(param $iovs $wasi.iovec_t_array)
-		;; The offset within the file at which to read.
-		(param $offset $wasi.filesize_t)
-		;; The number of bytes read.
-		(result $nread $wasi.size_t)
-	)
+  ;; Return the attributes of an open file.
+  (func (export "filestat_get")
+    (method $fd_ref) 
+    ;; The buffer where the file's attributes are stored.
+    (result $fs_rights_base $wasi.rights_t)
+  )
 
-	;; Return a description of the given preopened file descriptor.
-	(func (export "prestat_get")
-		;; The buffer where the description is stored.
-		(result $buf $wasi.prestat_t)
-	)
+  ;; Adjust the size of an open file. If this increases the file's size, the extra bytes are filled with zeros.
+  ;; Note: This is similar to ftruncate in POSIX. 
+  (func (export "filestat_set_size")
+    (method $fd_ref) 
+    ;; The desired file size.
+    (param $st_size $wasi.filesize_t)
+  )
 
-	;; Return a description of the given preopened file descriptor.
-	(func (export "prestat_dir_name")
-		;; A buffer into which to write the preopened directory name.
-		(param $path string)
-	)
+  ;; Adjust the timestamps of an open file or directory.
+  ;; Note: This is similar to `futimens` in POSIX.
+  (func (export "filestat_set_times")
+    (method $fd_ref) 
+    ;; The desired values of the data access timestamp.
+    (param $st_atim $wasi.timestamp_t)
+    ;; The desired values of the data modification timestamp.
+    (param $st_mtim $wasi.timestamp_t)
+    ;; A bitmask indicating which timestamps to adjust.
+    (param $fst_flags $wasi.fstflags_t)
+  )
 
-	;; Write to a file descriptor, without using and updating the file descriptor's offset.
-	;; Note: This is similar to `pwritev` in POSIX.
-	(func (export "pwrite")
-		;; List of scatter/gather vectors from which to retrieve data.
-		(param $iovs $wasi.iovec_t_array)
-		;; The offset within the file at which to write.
-		(param $offset $wasi.filesize_t)
-		;; The number of bytes written.
-		(result $nwritten $size_t)
-	)
+  ;; Read from a file descriptor, without using and updating the file descriptor's offset.
+  ;; Note: This is similar to `preadv` in POSIX.
+  (func (export "pread")
+    (method $fd_ref) 
+    ;; List of scatter/gather vectors in which to store data.
+    (param $iovs $iovec_t_array)
+    ;; The offset within the file at which to read.
+    (param $offset $wasi.filesize_t)
+    ;; The number of bytes read.
+    (result $nread $wasi.size_t)
+  )
 
-	;; Read from a file descriptor.
-	;; Note: This is similar to `readv` in POSIX.
-	(func (export "read")
-		;; List of scatter/gather vectors to which to store data.
-		(param $iovs $wasi.iovec_t_array)
-		;; The number of bytes read.
-		(result $nread $size_t)
-	)
+  ;; Return a description of the given preopened file descriptor.
+  (func (export "prestat_get")
+    (method $fd_ref) 
+    ;; The buffer where the description is stored.
+    (result $buf $wasi.prestat_t)
+  )
 
-	;; Read directory entries from a directory.
-	;; When successful, the contents of the output buffer consist of a sequence of directory entries. Each directory entry consists of a dirent_t object, followed by dirent_t::d_namlen bytes holding the name of the directory entry.
-	;; This function fills the output buffer as much as possible, potentially truncating the last directory entry. This allows the caller to grow its read buffer size in case it's too small to fit a single large directory entry, or skip the oversized directory entry.
-	(func (export "readdir")
-		;; The buffer where directory entries are stored
-		(param $buf data)
-		;; The location within the directory to start reading
-		(param $cookie $wasi.dircookie_t)
-		;; The number of bytes stored in the read buffer. If less than the size of the read buffer, the end of the directory has been reached.
-		(result $bufused $size_t)
-	)
+  ;; Return a description of the given preopened file descriptor.
+  (func (export "prestat_dir_name")
+    (method $fd_ref) 
+    ;; A buffer into which to write the preopened directory name.
+    (param $path string)
+  )
 
-	;; Atomically replace a file descriptor by renumbering another file descriptor.
-	;; Due to the strong focus on thread safety, this environment does not provide a mechanism to duplicate or renumber a file descriptor to an arbitrary number, like dup2(). This would be prone to race conditions, as an actual file descriptor with the same number could be allocated by a different thread at the same time.
- 	;; This function provides a way to atomically renumber file descriptors, which would disappear if dup2() were to be removed entirely.
-	(func (export "renumber")
-		;; The file descriptor to overwrite.
-		(param $to $fd)
-	)
+  ;; Write to a file descriptor, without using and updating the file descriptor's offset.
+  ;; Note: This is similar to `pwritev` in POSIX.
+  (func (export "pwrite")
+    (method $fd_ref) 
+    ;; List of scatter/gather vectors from which to retrieve data.
+    (param $iovs $iovec_t_array)
+    ;; The offset within the file at which to write.
+    (param $offset $wasi.filesize_t)
+    ;; The number of bytes written.
+    (result $nwritten $size_t)
+  )
 
-	;; Move the offset of a file descriptor.
-	;; Note: This is similar to lseek in POSIX.
-	(func (export "seek")
-		;; The number of bytes to move.
-		(param $offset $filedelta_t)
-		;; The base from which the offset is relative.
-		(param $whence $whence_t)
-		;; The new offset of the file descriptor, relative to the start of the file.
-		(result $newoffset $filesize_t)
-	)
+  ;; Read from a file descriptor.
+  ;; Note: This is similar to `readv` in POSIX.
+  (func (export "read")
+    (method $fd_ref) 
+    ;; List of scatter/gather vectors to which to store data.
+    (param $iovs $iovec_t_array)
+    ;; The number of bytes read.
+    (result $nread $size_t)
+  )
 
-	;; Synchronize the data and metadata of a file to disk.
-	;; Note: This is similar to `fsync` in POSIX.
-	(func (export "sync"))
+  ;; Read directory entries from a directory.
+  ;; When successful, the contents of the output buffer consist of a sequence of directory entries. Each directory entry consists of a dirent_t object, followed by dirent_t::d_namlen bytes holding the name of the directory entry.
+  ;; This function fills the output buffer as much as possible, potentially truncating the last directory entry. This allows the caller to grow its read buffer size in case it's too small to fit a single large directory entry, or skip the oversized directory entry.
+  (func (export "readdir")
+    (method $fd_ref) 
+    ;; The buffer where directory entries are stored
+    (param $buf data)
+    ;; The location within the directory to start reading
+    (param $cookie $dircookie_t)
+    ;; The number of bytes stored in the read buffer. If less than the size of the read buffer, the end of the directory has been reached.
+    (result $bufused $size_t)
+  )
 
-	;; Return the current offset of a file descriptor.
-	;; Note: This is similar to `lseek(fd, 0, SEEK_CUR)` in POSIX.
-	(func (export "tell")
-		;; The current offset of the file descriptor, relative to the start of the file.
-		(result $offset $filesize_t)
-	)
+  ;; Atomically replace a file descriptor by renumbering another file descriptor.
+  ;; Due to the strong focus on thread safety, this environment does not provide a mechanism to duplicate or renumber a file descriptor to an arbitrary number, like dup2(). This would be prone to race conditions, as an actual file descriptor with the same number could be allocated by a different thread at the same time.
+  ;; This function provides a way to atomically renumber file descriptors, which would disappear if dup2() were to be removed entirely.
+  (func (export "renumber")
+    (method $fd_ref)
+    ;; The file descriptor to overwrite.
+    (param $to $fd_ref)
+  )
 
-	;; Write to a file descriptor.
-	;; Note: This is similar to `writev` in POSIX.
-	(func (export "write")
-		;; List of scatter/gather vectors from which to retrieve data.
-		(param $iovs $wasi.iovec_t_array)
-		;; The number of bytes written.
-		(result $nwritten $size_t)
-	)
+  ;; Move the offset of a file descriptor.
+  ;; Note: This is similar to lseek in POSIX.
+  (func (export "seek")
+    (method $fd_ref)
+    ;; The number of bytes to move.
+    (param $offset $filedelta_t)
+    ;; The base from which the offset is relative.
+    (param $whence $whence_t)
+    ;; The new offset of the file descriptor, relative to the start of the file.
+    (result $newoffset $filesize_t)
+  )
+
+  ;; Synchronize the data and metadata of a file to disk.
+  ;; Note: This is similar to `fsync` in POSIX.
+  (func (export "sync")
+    (method $fd_ref)
+  )
+
+  ;; Return the current offset of a file descriptor.
+  ;; Note: This is similar to `lseek(fd, 0, SEEK_CUR)` in POSIX.
+  (func (export "tell")
+    (method $fd_ref)
+    ;; The current offset of the file descriptor, relative to the start of the file.
+    (result $offset $filesize_t)
+  )
+
+  ;; Write to a file descriptor.
+  ;; Note: This is similar to `writev` in POSIX.
+  (func (export "write")
+    (method $fd_ref)
+    ;; List of scatter/gather vectors from which to retrieve data.
+    (param $iovs $iovec_t_array)
+    ;; The number of bytes written.
+    (result $nwritten $size_t)
+  )
 )
 
 (interface $path extends $fd
-	;; Flags determining the method of how paths are resolved.
-	(type $lookupflags_t
-		(struct
-			;; As long as the resolved path corresponds to a symbolic link, it is expanded.
-			(field $LOOKUP_SYMLINK_FOLLOW Bool)
-		)
-	)
+  ;; Flags determining the method of how paths are resolved.
+  (type $lookupflags_t
+    (struct
+      ;; As long as the resolved path corresponds to a symbolic link, it is expanded.
+      (field $LOOKUP_SYMLINK_FOLLOW Bool)
+    )
+  )
 
-	;; Open flags used by __wasi_path_open().
-	(type $oflags_t
-		(struct
-			;; Create file if it does not exist.
-			(field $O_CREAT Bool)
-			;; Fail if not a directory.
-			(field $O_DIRECTORY Bool)
-			;; Fail if file already exists.
-			(field $O_EXCL Bool)
-			;; Truncate file to size 0.
-			(field $O_TRUNC Bool)
-		)
-	)
+  ;; Open flags used by __wasi_path_open().
+  (type $oflags_t
+    (struct
+      ;; Create file if it does not exist.
+      (field $O_CREAT Bool)
+      ;; Fail if not a directory.
+      (field $O_DIRECTORY Bool)
+      ;; Fail if file already exists.
+      (field $O_EXCL Bool)
+      ;; Truncate file to size 0.
+      (field $O_TRUNC Bool)
+    )
+  )
 
-	;; Create a directory.
-	;; Note: This is similar to `mkdirat` in POSIX.
-	(func (export "create_directory")
-		;; The path at which to create the directory.
-		(param $path string)
-	)
+  ;; Create a directory.
+  ;; Note: This is similar to `mkdirat` in POSIX.
+  (func (export "create_directory")
+    (method $fd_ref)
+    ;; The path at which to create the directory.
+    (param $path string)
+  )
 
-	;; Return the attributes of a file or directory.
-	;; Note: This is similar to stat in POSIX.
-	(func (export "filestat_get")
-		;; Flags determining the method of how the path is resolved.
-		(param $flags $lookupflags_t)
-		;; The path of the file or directory to inspect.
-		(param $path string)
-		;; The buffer where the file's attributes are stored.
-		(result $buf $wasi.filestat_t)
-	)
+  ;; Return the attributes of a file or directory.
+  ;; Note: This is similar to stat in POSIX.
+  (func (export "filestat_get")
+    (method $fd_ref)
+    ;; Flags determining the method of how the path is resolved.
+    (param $flags $lookupflags_t)
+    ;; The path of the file or directory to inspect.
+    (param $path string)
+    ;; The buffer where the file's attributes are stored.
+    (result $buf $filestat_t)
+  )
 
-	;; Adjust the timestamps of a file or directory.
-	;; Note: This is similar to utimensat in POSIX.
-	(func (export "filestat_set_times")
-		;; Flags determining the method of how the path is resolved.
-		(param $flags $lookupflags_t)
-		;; The path of the file or directory to operate on.
-		(param $path string)
-		;; The desired values of the data access timestamp.
-		(param $st_atim $wasi.timestamp_t)
-		;; The desired values of the data modification timestamp.
-		(param $st_mtim $wasi.timestamp_t)
-		;; A bitmask indicating which timestamps to adjust.
-		(param $fst_flags $wasi.fstflags_t)
-	)
+  ;; Adjust the timestamps of a file or directory.
+  ;; Note: This is similar to utimensat in POSIX.
+  (func (export "filestat_set_times")
+    (method $fd_ref)
+    ;; Flags determining the method of how the path is resolved.
+    (param $flags $lookupflags_t)
+    ;; The path of the file or directory to operate on.
+    (param $path string)
+    ;; The desired values of the data access timestamp.
+    (param $st_atim $wasi.timestamp_t)
+    ;; The desired values of the data modification timestamp.
+    (param $st_mtim $wasi.timestamp_t)
+    ;; A bitmask indicating which timestamps to adjust.
+    (param $fst_flags $fstflags_t)
+  )
 
-	;; Create a hard link.
-	;; Note: This is similar to `linkat` in POSIX.
-	(func (export "link")
-		;; Flags determining the method of how the path is resolved.
-		(param $old_flags $lookupflags_t)
-		;; The source path from which to link.
-		(param $old_path string)
-		;; The working directory at which the resolution of the new path starts.
-		(param $new_fd $path)
-		;; The destination path at which to create the hard link.
-		(param $new_path string)
-	)
+  ;; Create a hard link.
+  ;; Note: This is similar to `linkat` in POSIX.
+  (func (export "link")
+    (method $fd_ref)
+    ;; Flags determining the method of how the path is resolved.
+    (param $old_flags $lookupflags_t)
+    ;; The source path from which to link.
+    (param $old_path string)
+    ;; The working directory at which the resolution of the new path starts.
+    (param $new_fd $path)
+    ;; The destination path at which to create the hard link.
+    (param $new_path string)
+  )
 
-	;; Open a file or directory.
-	;; The returned file descriptor is not guaranteed to be the lowest-numbered file descriptor not currently open; it is randomized to prevent applications from depending on making assumptions about indexes, since this is error-prone in multi-threaded contexts. The returned file descriptor is guaranteed to be less than 231.
-	;; Note: This is similar to openat in POSIX.
-	(func (export "open")
-		;; Flags determining the method of how the path is resolved.
-		(param $dirflags $lookupflags_t)
-		;; The relative path of the file or directory to open, relative to the `dirfd` directory.
-		(param $path string)
-		;; The method by which to open the file.
-		(param $o_flags $oflags_t)
-		;; The initial rights of the newly created file descriptor. The implementation is allowed to return a file descriptor with fewer rights than specified, if and only if those rights do not apply to the type of file being opened.
-		;; The base rights are rights that will apply to operations using the file descriptor itself, while the inheriting rights are rights that apply to file descriptors derived from it.
-		(param $fs_rights_base $wasi.rights_t)
-		(param $fs_rights_inherting $wasi.rights_t)
-		;; The file descriptor of the file that has been opened.
-		(result $opened_fd $fd)
-	)
+  ;; Open a file or directory.
+  ;; The returned file descriptor is not guaranteed to be the lowest-numbered file descriptor not currently open; it is randomized to prevent applications from depending on making assumptions about indexes, since this is error-prone in multi-threaded contexts. The returned file descriptor is guaranteed to be less than 231.
+  ;; Note: This is similar to openat in POSIX.
+  (func (export "open")
+    (method $fd_ref)
+    ;; Flags determining the method of how the path is resolved.
+    (param $dirflags $lookupflags_t)
+    ;; The relative path of the file or directory to open, relative to the `dirfd` directory.
+    (param $path string)
+    ;; The method by which to open the file.
+    (param $o_flags $oflags_t)
+    ;; The initial rights of the newly created file descriptor. The implementation is allowed to return a file descriptor with fewer rights than specified, if and only if those rights do not apply to the type of file being opened.
+    ;; The base rights are rights that will apply to operations using the file descriptor itself, while the inheriting rights are rights that apply to file descriptors derived from it.
+    (param $fs_rights_base $wasi.rights_t)
+    (param $fs_rights_inherting $wasi.rights_t)
+    ;; The file descriptor of the file that has been opened.
+    (result $opened_fd $fd_ref)
+  )
 
-	;; Read the contents of a symbolic link.
-	;; Note: This is similar to readlinkat in POSIX.
-	(func (export "readlink")
-		;; The path of the symbolic link from which to read.
-		(param $path)
-		;; The buffer to which to write the contents of the symbolic link.
-		(param $buf string)
-		;; The number of bytes placed in the buffer.
-		(result $bufused $size_t)
-	)
+  ;; Read the contents of a symbolic link.
+  ;; Note: This is similar to readlinkat in POSIX.
+  (func (export "readlink")
+    (method $fd_ref)
+    ;; The path of the symbolic link from which to read.
+    (param $path)
+    ;; The buffer to which to write the contents of the symbolic link.
+    (param $buf string)
+    ;; The number of bytes placed in the buffer.
+    (result $bufused $size_t)
+  )
 
-	;; Remove a directory.
-	;; Return `__WASI_ENOTEMPTY` if the directory is not empty.
-	;; Note: This is similar to `unlinkat(fd, path, AT_REMOVEDIR)` in POSIX.
-	(func (export "remove_directory")
-		;; The path to a directory to remove.
-		(param $path string)
-	)
+  ;; Remove a directory.
+  ;; Return `__WASI_ENOTEMPTY` if the directory is not empty.
+  ;; Note: This is similar to `unlinkat(fd, path, AT_REMOVEDIR)` in POSIX.
+  (func (export "remove_directory")
+    (method $fd_ref)
+    ;; The path to a directory to remove.
+    (param $path string)
+  )
 
-	;; Rename a file or directory.
-	;; Note: This is similar to `renameat` in POSIX.
-	(func (export "rename")
-		;; The source path of the file or directory to rename.
-		(param $old_path string)
-		;; The working directory at which the resolution of the new path starts.
-		(param $new_fd $fd)
-		;; The destination path to which to rename the file or directory.
-		(param $new_path string)
-	)
+  ;; Rename a file or directory.
+  ;; Note: This is similar to `renameat` in POSIX.
+  (func (export "rename")
+    (method $fd_ref)
+    ;; The source path of the file or directory to rename.
+    (param $old_path string)
+    ;; The working directory at which the resolution of the new path starts.
+    (param $new_fd $fd)
+    ;; The destination path to which to rename the file or directory.
+    (param $new_path string)
+  )
 
-	;; Create a symbolic link.
-	;; Note: This is similar to symlinkat in POSIX.
-	(func (export "symlink")
-		;; The contents of the symbolic link.
-		(param $old_path string)
-		;; The destination path at which to create the symbolic link.
-		(param $new_path string)
-	)
+  ;; Create a symbolic link.
+  ;; Note: This is similar to symlinkat in POSIX.
+  (func (export "symlink")
+    (method $fd_ref)
+    ;; The contents of the symbolic link.
+    (param $old_path string)
+    ;; The destination path at which to create the symbolic link.
+    (param $new_path string)
+  )
 
-	
-	;; Unlink a file.
-	;; Return __WASI_EISDIR if the path refers to a directory.
-	;; Note: This is similar to unlinkat(fd, path, 0) in POSIX.
-	(func (export "unlink_file")
-		;; The path to a file to unlink.
-		(param $path string)
-	)
+
+  ;; Unlink a file.
+  ;; Return __WASI_EISDIR if the path refers to a directory.
+  ;; Note: This is similar to unlinkat(fd, path, 0) in POSIX.
+  (func (export "unlink_file")
+    (method $fd_ref)
+    ;; The path to a file to unlink.
+    (param $path string)
+  )
 ) 
 
 (interface $poll
-	;; Concurrently poll for the occurrence of a set of events.
-	(static func (export "oneoff")
-		;; The events to which to subscribe.
-		(param $in $wasi.subscription_t)
-		;; The events that have occurred.
-		(param $out $wasi.event_t)
-		;; Both the number of subscriptions and events.
-		(param $nsubscriptions $size_t)
-		;; The number of events stored.
-		(result $nevents $size_t)
-	)
+  ;; An event that occurred.
+  (type $event_t
+    (struct
+      ;; User-provided value that got attached to __wasi_subscription_t::userdata.
+      (field $userdata $userdata_t)
+      ;; If non-zero, an error that occurred while processing the subscription request.
+      (field $error $errno_t)
+      ;; The type of the event that occurred.
+      (field $type $eventtype_t)
+      (field $u 
+        (type union
+          ;; When type is __WASI_EVENTTYPE_FD_READ or __WASI_EVENTTYPE_FD_WRITE:
+          (field $fd_readwrite
+            (type stuct
+              ;; The number of bytes available for reading or writing.
+              (field $nbytes $filesize_t)
+              ;; The state of the file descriptor.
+              (field $flags $eventrwflags_t)
+            )
+          )
+          (field $else Null)
+        )
+      )
+    )
+  )
+
+  ;; The state of the file descriptor subscribed to with __WASI_EVENTTYPE_FD_READ or __WASI_EVENTTYPE_FD_WRITE.
+  (type $eventrwflags_t
+    (struct
+      ;; The peer of this socket has closed or disconnected.
+      (field $EVENT_FD_READWRITE_HANGUP Bool)
+    )
+  )
+
+  ;; Type of a subscription to an event or its occurrence.
+  (type $eventtype_t
+    (struct
+      ;; The time value of clock __wasi_subscription_t::u.clock.clock_id has reached timestamp __wasi_subscription_t::u.clock.timeout.
+      (field $EVENTTYPE_CLOCK Bool)
+      ;; File descriptor __wasi_subscription_t::u.fd_readwrite.fd has data available for reading. This event always triggers for regular files.
+      (field $EVENTTYPE_FD_READ Bool)
+      ;; File descriptor __wasi_subscription_t::u.fd_readwrite.fd has capacity available for writing. This event always triggers for regular files.
+      (field $EVENTTYPE_FD_WRITE Bool)
+    )
+  )
+
+  ;; Concurrently poll for the occurrence of a set of events.
+  (func (export "oneoff")
+    ;; The events to which to subscribe.
+    (param $in $wasi.subscription_t)
+    ;; The events that have occurred.
+    (param $out $wasi.event_t)
+    ;; Both the number of subscriptions and events.
+    (param $nsubscriptions $size_t)
+    ;; The number of events stored.
+    (result $nevents $size_t)
+  )
 )
 
 (interface $proc extends $wasi
-	;; Terminate the process normally. An exit code of 0 indicates successful termination of the program. The meanings of other values is dependent on the environment.
-	(static func (export "exit")
-		;; The exit code returned by the process.
-		(param $rval $wasi.exitcode_t)
-	)
+  ;; Exit code generated by a process when exiting.
+  (type $exitcode_t u32)
 
-	;; Send a signal to the process of the calling thread.
-	;; Note: This is similar to `raise` in POSIX.
-	(static func (export "raise")
-		;; The signal condition to trigger.
-		(param $sig $wasi.signal_t)
-	)
+  ;; Terminate the process normally. An exit code of 0 indicates successful termination of the program. The meanings of other values is dependent on the environment.
+  (func (export "exit")
+    ;; The exit code returned by the process.
+    (param $rval $exitcode_t)
+  )
 
-	;; Temporarily yield execution of the calling thread.
-	;; Note: This is similar to `sched_yield` in POSIX.
-	(static func (export "sched_yield"))
+  ;; Send a signal to the process of the calling thread.
+  ;; Note: This is similar to `raise` in POSIX.
+  (func (export "raise")
+    ;; The signal condition to trigger.
+    (param $sig $wasi.signal_t)
+  )
+
+  ;; Temporarily yield execution of the calling thread.
+  ;; Note: This is similar to `sched_yield` in POSIX.
+  (func (export "sched_yield"))
 )
 
 (interface $random extends $wasi
-	;; Write high-quality random data into a buffer.
-	;; This function blocks when the implementation is unable to immediately provide sufficient high-quality random data.
-	;; This function may execute slowly, so when large mounts of random data are required, it's advisable to use this function to seed a pseudo-random number generator, rather than to provide the random data directly.
-	(static func (export "get")
-		;; The buffer to fill with random data.
-		(param $buf data)
-	)
+;; Write high-quality random data into a buffer.
+;; This function blocks when the implementation is unable to immediately provide sufficient high-quality random data.
+;; This function may execute slowly, so when large mounts of random data are required, it's advisable to use this function to seed a pseudo-random number generator, rather than to provide the random data directly.
+  (func (export "get")
+    ;; The buffer to fill with random data.
+    (param $buf data)
+  )
 )
 
 (interface $sock extends $fd
-	;; Flags provided to __wasi_sock_recv().
-	(type $riflags_t
-		(struct
-			;; Returns the message without removing it from the socket's receive queue.
-			(field $SOCK_RECV_PEEK Bool)
-			;; On byte-stream sockets, block until the full amount of data can be returned.
-			(field $SOCK_RECV_WAITALL Bool)
-		)
-	)
+  ;; Flags provided to __wasi_sock_recv().
+  (type $riflags_t
+    (struct
+      ;; Returns the message without removing it from the socket's receive queue.
+      (field $SOCK_RECV_PEEK Bool)
+      ;; On byte-stream sockets, block until the full amount of data can be returned.
+      (field $SOCK_RECV_WAITALL Bool)
+    )
+  )
 
-	;; Flags returned by __wasi_sock_recv().
-	(type $roflags_t
-		(struct
-			;; Returned by __wasi_sock_recv(): Message data has been truncated.
-			(field $SOCK_RECV_DATA_TRUNCATED Bool)
-		)
-	)
+  ;; Flags returned by __wasi_sock_recv().
+  (type $roflags_t
+    (struct
+      ;; Returned by __wasi_sock_recv(): Message data has been truncated.
+      (field $SOCK_RECV_DATA_TRUNCATED Bool)
+    )
+  )
 
-	;; Flags provided to __wasi_sock_send(). As there are currently no flags defined, it must be set to zero.
-	(type $siflags_t u16)
+  ;; Flags provided to __wasi_sock_send(). As there are currently no flags defined, it must be set to zero.
+  (type $siflags_t u16)
 
-	;; Which channels on a socket to shut down.
-	(type $sdflags_t
-		(struct
-			;; Disables further receive operations.
-			(field $SHUT_RD Bool)
-			;; Disables further send operations.
-			(field $SHUT_WR Bool)
-		)
-	)
+  ;; Which channels on a socket to shut down.
+  (type $sdflags_t
+    (struct
+      ;; Disables further receive operations.
+      (field $SHUT_RD Bool)
+      ;; Disables further send operations.
+      (field $SHUT_WR Bool)
+    )
+  )
 
 
-	;; Receive a message from a socket.
-	;; Note: This is similar to recv in POSIX, though it also supports reading the data into multiple buffers in the manner of readv.
-	(func (export "recv")
-		;; List of scatter/gather vectors to which to store data.
-		(param $ri_data $wasi.iovec_t_array)
-		;; Message flags.
-		(param $ri_flags $riflags_t)
-		;; Number of bytes stored in ri_data.
-		(results $ro_datalen $size_t)
-		;; Message flags.
-		(results $ro_flags $roflags_t)
-	)
+  ;; Receive a message from a socket.
+  ;; Note: This is similar to recv in POSIX, though it also supports reading the data into multiple buffers in the manner of readv.
+  (func (export "recv")
+    (method $fd_ref)
+    ;; List of scatter/gather vectors to which to store data.
+    (param $ri_data $iovec_t_array)
+    ;; Message flags.
+    (param $ri_flags $riflags_t)
+    ;; Number of bytes stored in ri_data.
+    (results $ro_datalen $size_t)
+    ;; Message flags.
+    (results $ro_flags $roflags_t)
+  )
 
-	;; Send a message on a socket.
-	;; Note: This is similar to `send` in POSIX, though it also supports writing the data from multiple buffers in the manner of `writev`.
-	(func (export "send")
-		;; List of scatter/gather vectors to which to retrieve data
-		(param $si_data $wasi.ciovec_t_array)
-		;; Message flags.
-		(param $si_flags $siflags_t)
-		;; Number of bytes transmitted.
-		(result $so_datalen $size_t)
-	)
+  ;; Send a message on a socket.
+  ;; Note: This is similar to `send` in POSIX, though it also supports writing the data from multiple buffers in the manner of `writev`.
+  (func (export "send")
+    (method $fd_ref)
+    ;; List of scatter/gather vectors to which to retrieve data
+    (param $si_data $wasi.ciovec_t_array)
+    ;; Message flags.
+    (param $si_flags $siflags_t)
+    ;; Number of bytes transmitted.
+    (result $so_datalen $size_t)
+  )
 
-	;; Shut down socket send and receive channels.
-	;; Note: This is similar to shutdown in POSIX.
-	(func (export "shutdown")
-		;; Which channels on the socket to shut down.
-		(param $how $sdflags_t)
-	)
+  ;; Shut down socket send and receive channels.
+  ;; Note: This is similar to shutdown in POSIX.
+  (func (export "shutdown")
+    (method $fd_ref)
+    ;; Which channels on the socket to shut down.
+    (param $how $sdflags_t)
+  )
 )

--- a/watidl/wasi-core.watidl
+++ b/watidl/wasi-core.watidl
@@ -44,7 +44,7 @@
 	(type $clockid_t 
 		(enum
 			;; The store-wide monotonic clock, which is defined as a clock measuring real time, whose value cannot be adjusted and which cannot have negative clock jumps.
-      ;; The epoch of this clock is undefined. The absolute time value of this clock therefore has no meaning.
+			;; The epoch of this clock is undefined. The absolute time value of this clock therefore has no meaning.
 			$CLOCK_MONOTONIC
 			;; The CPU-time clock associated with the current process.
 			$CLOCK_PROCESS_CPUTIME_ID
@@ -76,7 +76,7 @@
 	)
 
 	;; Error codes returned by functions.
-  ;; Not all of these error codes are returned by the functions provided by this API; some are used in higher-level library layers, and others are provided merely for alignment with POSIX.
+	;; Not all of these error codes are returned by the functions provided by this API; some are used in higher-level library layers, and others are provided merely for alignment with POSIX.
 	(type $errno_t
 		(enum
 			;; No error occurred. System call completed successfully.
@@ -811,7 +811,7 @@
 	)
 
 	;; Synchronize the data and metadata of a file to disk.
-  ;; Note: This is similar to fsync in POSIX.
+	;; Note: This is similar to `fsync` in POSIX.
 	(func (export "sync"))
 
 	;; Return the current offset of a file descriptor.
@@ -862,7 +862,7 @@
 	)
 
 	;; Return the attributes of a file or directory.
-  ;; Note: This is similar to stat in POSIX.
+	;; Note: This is similar to stat in POSIX.
 	(func (export "filestat_get")
 		;; Flags determining the method of how the path is resolved.
 		(param $flags $lookupflags_t)
@@ -873,7 +873,7 @@
 	)
 
 	;; Adjust the timestamps of a file or directory.
-  ;; Note: This is similar to utimensat in POSIX.
+	;; Note: This is similar to utimensat in POSIX.
 	(func (export "filestat_set_times")
 		;; Flags determining the method of how the path is resolved.
 		(param $flags $lookupflags_t)
@@ -930,8 +930,8 @@
 	)
 
 	;; Remove a directory.
-  ;; Return `__WASI_ENOTEMPTY` if the directory is not empty.
-  ;; Note: This is similar to `unlinkat(fd, path, AT_REMOVEDIR)` in POSIX.
+	;; Return `__WASI_ENOTEMPTY` if the directory is not empty.
+	;; Note: This is similar to `unlinkat(fd, path, AT_REMOVEDIR)` in POSIX.
 	(func (export "remove_directory")
 		;; The path to a directory to remove.
 		(param $path string)
@@ -949,7 +949,7 @@
 	)
 
 	;; Create a symbolic link.
-  ;; Note: This is similar to symlinkat in POSIX.
+	;; Note: This is similar to symlinkat in POSIX.
 	(func (export "symlink")
 		;; The contents of the symbolic link.
 		(param $old_path string)
@@ -996,7 +996,7 @@
 	)
 
 	;; Temporarily yield execution of the calling thread.
-  ;; Note: This is similar to `sched_yield` in POSIX.
+	;; Note: This is similar to `sched_yield` in POSIX.
 	(static func (export "sched_yield"))
 )
 
@@ -1057,7 +1057,7 @@
 	)
 
 	;; Send a message on a socket.
-  ;; Note: This is similar to `send` in POSIX, though it also supports writing the data from multiple buffers in the manner of `writev`.
+	;; Note: This is similar to `send` in POSIX, though it also supports writing the data from multiple buffers in the manner of `writev`.
 	(func (export "send")
 		;; List of scatter/gather vectors to which to retrieve data
 		(param $si_data $wasi.ciovec_t_array)

--- a/watidl/wasi-core.watidl
+++ b/watidl/wasi-core.watidl
@@ -460,7 +460,7 @@
   ;; Provide file advisory information on a file descriptor.
   ;; Note: This is similar to posix_fadvise in POSIX.
   (func (export "advise")
-    (method $fd_ref)
+    (param $self $fd_ref)
     (param $offset $filesize_t) ;; The offset within the file to which the advisory applies.
     (param $len $filesize_t) ;; The length of the region to which the advisory applies.
     (param $advice $advice_t) ;; The advice.
@@ -470,7 +470,7 @@
   ;; Force the allocation of space in a file.
   ;; Note: This is similar to posix_fallocate in POSIX.
   (func (export "allocate")
-    (method $fd_ref) 
+    (param $self $fd_ref) 
     ;; The offset at which to start the allocation.
     (param $offset $filesize_t) 
     ;; The length of the area that is allocated.
@@ -480,19 +480,19 @@
   ;; Close a file descriptor.
   ;; Note: This is similar to close in POSIX. 
   (func (export "close")
-    (method $fd_ref) 
+    (param $self $fd_ref) 
   )
 
   ;; Synchronize the data of a file to disk.
   ;; Note: This is similar to `fdatasync` in POSIX.
   (func (export "datasync")
-    (method $fd_ref) 
+    (param $self $fd_ref) 
   )
 
   ;; Get the attributes of a file descriptor.
   ;; Note: This returns similar flags to `fsync(fd, F_GETFL)` in POSIX, as well as additional fields.
   (func (export "fdstat_get")
-    (method $fd_ref) 
+    (param $self $fd_ref) 
     ;; The buffer where the file descriptor's attributes are stored.
     (result $fdstat_t) 
   )
@@ -500,7 +500,7 @@
   ;; Adjust the flags associated with a file descriptor.
   ;; Note: This is similar to `fcntl(fd, F_SETFL, flags)` in POSIX.
   (func (export "fdstat_set_flags")
-    (method $fd_ref) 
+    (param $self $fd_ref) 
     ;; The desired values of the file descriptor flags.
     (param $flags $fdflags)
   )
@@ -508,7 +508,7 @@
   ;;  Adjust the rights associated with a file descriptor.
   ;; This can only be used to remove rights, and returns `ENOTCAPABLE` if called in a way that would attempt to add rights
   (func (export "fdstat_set_rights") 
-    (method $fd_ref) 
+    (param $self $fd_ref) 
     ;; The desired rights of the file descriptor.
     (param $fs_rights_base $rights_t)
     (param $fs_rights_inheriting $rights_t)
@@ -516,7 +516,7 @@
 
   ;; Return the attributes of an open file.
   (func (export "filestat_get")
-    (method $fd_ref) 
+    (param $self $fd_ref) 
     ;; The buffer where the file's attributes are stored.
     (result $fs_rights_base $rights_t)
   )
@@ -524,7 +524,7 @@
   ;; Adjust the size of an open file. If this increases the file's size, the extra bytes are filled with zeros.
   ;; Note: This is similar to ftruncate in POSIX. 
   (func (export "filestat_set_size")
-    (method $fd_ref) 
+    (param $self $fd_ref) 
     ;; The desired file size.
     (param $st_size $filesize_t)
   )
@@ -532,7 +532,7 @@
   ;; Adjust the timestamps of an open file or directory.
   ;; Note: This is similar to `futimens` in POSIX.
   (func (export "filestat_set_times")
-    (method $fd_ref) 
+    (param $self $fd_ref) 
     ;; The desired values of the data access timestamp.
     (param $st_atim $timestamp_t)
     ;; The desired values of the data modification timestamp.
@@ -544,25 +544,25 @@
   ;; Read from a file descriptor, without using and updating the file descriptor's offset.
   ;; Note: This is similar to `preadv` in POSIX.
   (func (export "pread")
-    (method $fd_ref) 
+    (param $self $fd_ref) 
     ;; List of scatter/gather vectors in which to store data.
     (param $iovs $iovec_t_array)
     ;; The offset within the file at which to read.
-    (param $offset $wasi.filesize_t)
+    (param $offset $filesize_t)
     ;; The number of bytes read.
-    (result $nread $wasi.size_t)
+    (result $nread $size_t)
   )
 
   ;; Return a description of the given preopened file descriptor.
   (func (export "prestat_get")
-    (method $fd_ref) 
+    (param $self $fd_ref) 
     ;; The buffer where the description is stored.
-    (result $buf $wasi.prestat_t)
+    (result $buf $prestat_t)
   )
 
   ;; Return a description of the given preopened file descriptor.
   (func (export "prestat_dir_name")
-    (method $fd_ref) 
+    (param $self $fd_ref) 
     ;; A buffer into which to write the preopened directory name.
     (param $path string)
   )
@@ -570,11 +570,11 @@
   ;; Write to a file descriptor, without using and updating the file descriptor's offset.
   ;; Note: This is similar to `pwritev` in POSIX.
   (func (export "pwrite")
-    (method $fd_ref) 
+    (param $self $fd_ref) 
     ;; List of scatter/gather vectors from which to retrieve data.
     (param $iovs $iovec_t_array)
     ;; The offset within the file at which to write.
-    (param $offset $wasi.filesize_t)
+    (param $offset $filesize_t)
     ;; The number of bytes written.
     (result $nwritten $size_t)
   )
@@ -582,7 +582,7 @@
   ;; Read from a file descriptor.
   ;; Note: This is similar to `readv` in POSIX.
   (func (export "read")
-    (method $fd_ref) 
+    (param $self $fd_ref) 
     ;; List of scatter/gather vectors to which to store data.
     (param $iovs $iovec_t_array)
     ;; The number of bytes read.
@@ -593,7 +593,7 @@
   ;; When successful, the contents of the output buffer consist of a sequence of directory entries. Each directory entry consists of a dirent_t object, followed by dirent_t::d_namlen bytes holding the name of the directory entry.
   ;; This function fills the output buffer as much as possible, potentially truncating the last directory entry. This allows the caller to grow its read buffer size in case it's too small to fit a single large directory entry, or skip the oversized directory entry.
   (func (export "readdir")
-    (method $fd_ref) 
+    (param $self $fd_ref) 
     ;; The buffer where directory entries are stored
     (param $buf data)
     ;; The location within the directory to start reading
@@ -606,7 +606,7 @@
   ;; Due to the strong focus on thread safety, this environment does not provide a mechanism to duplicate or renumber a file descriptor to an arbitrary number, like dup2(). This would be prone to race conditions, as an actual file descriptor with the same number could be allocated by a different thread at the same time.
   ;; This function provides a way to atomically renumber file descriptors, which would disappear if dup2() were to be removed entirely.
   (func (export "renumber")
-    (method $fd_ref)
+    (param $self $fd_ref)
     ;; The file descriptor to overwrite.
     (param $to $fd_ref)
   )
@@ -614,7 +614,7 @@
   ;; Move the offset of a file descriptor.
   ;; Note: This is similar to lseek in POSIX.
   (func (export "seek")
-    (method $fd_ref)
+    (param $self $fd_ref)
     ;; The number of bytes to move.
     (param $offset $filedelta_t)
     ;; The base from which the offset is relative.
@@ -626,13 +626,13 @@
   ;; Synchronize the data and metadata of a file to disk.
   ;; Note: This is similar to `fsync` in POSIX.
   (func (export "sync")
-    (method $fd_ref)
+    (param $self $fd_ref)
   )
 
   ;; Return the current offset of a file descriptor.
   ;; Note: This is similar to `lseek(fd, 0, SEEK_CUR)` in POSIX.
   (func (export "tell")
-    (method $fd_ref)
+    (param $self $fd_ref)
     ;; The current offset of the file descriptor, relative to the start of the file.
     (result $offset $filesize_t)
   )
@@ -640,7 +640,7 @@
   ;; Write to a file descriptor.
   ;; Note: This is similar to `writev` in POSIX.
   (func (export "write")
-    (method $fd_ref)
+    (param $self $fd_ref)
     ;; List of scatter/gather vectors from which to retrieve data.
     (param $iovs $iovec_t_array)
     ;; The number of bytes written.
@@ -699,7 +699,7 @@
   ;; Create a directory.
   ;; Note: This is similar to `mkdirat` in POSIX.
   (func (export "create_directory")
-    (method $fd_ref)
+    (param $self $fd_ref)
     ;; The path at which to create the directory.
     (param $path string)
   )
@@ -707,7 +707,7 @@
   ;; Return the attributes of a file or directory.
   ;; Note: This is similar to stat in POSIX.
   (func (export "filestat_get")
-    (method $fd_ref)
+    (param $self $fd_ref)
     ;; Flags determining the method of how the path is resolved.
     (param $flags $lookupflags_t)
     ;; The path of the file or directory to inspect.
@@ -719,15 +719,15 @@
   ;; Adjust the timestamps of a file or directory.
   ;; Note: This is similar to utimensat in POSIX.
   (func (export "filestat_set_times")
-    (method $fd_ref)
+    (param $self $fd_ref)
     ;; Flags determining the method of how the path is resolved.
     (param $flags $lookupflags_t)
     ;; The path of the file or directory to operate on.
     (param $path string)
     ;; The desired values of the data access timestamp.
-    (param $st_atim $wasi.timestamp_t)
+    (param $st_atim $timestamp_t)
     ;; The desired values of the data modification timestamp.
-    (param $st_mtim $wasi.timestamp_t)
+    (param $st_mtim $timestamp_t)
     ;; A bitmask indicating which timestamps to adjust.
     (param $fst_flags $fstflags_t)
   )
@@ -735,7 +735,7 @@
   ;; Create a hard link.
   ;; Note: This is similar to `linkat` in POSIX.
   (func (export "link")
-    (method $fd_ref)
+    (param $self $fd_ref)
     ;; Flags determining the method of how the path is resolved.
     (param $old_flags $lookupflags_t)
     ;; The source path from which to link.
@@ -750,7 +750,7 @@
   ;; The returned file descriptor is not guaranteed to be the lowest-numbered file descriptor not currently open; it is randomized to prevent applications from depending on making assumptions about indexes, since this is error-prone in multi-threaded contexts. The returned file descriptor is guaranteed to be less than 231.
   ;; Note: This is similar to openat in POSIX.
   (func (export "open")
-    (method $fd_ref)
+    (param $self $fd_ref)
     ;; Flags determining the method of how the path is resolved.
     (param $dirflags $lookupflags_t)
     ;; The relative path of the file or directory to open, relative to the `dirfd` directory.
@@ -759,8 +759,8 @@
     (param $o_flags $oflags_t)
     ;; The initial rights of the newly created file descriptor. The implementation is allowed to return a file descriptor with fewer rights than specified, if and only if those rights do not apply to the type of file being opened.
     ;; The base rights are rights that will apply to operations using the file descriptor itself, while the inheriting rights are rights that apply to file descriptors derived from it.
-    (param $fs_rights_base $wasi.rights_t)
-    (param $fs_rights_inherting $wasi.rights_t)
+    (param $fs_rights_base $rights_t)
+    (param $fs_rights_inherting $rights_t)
     ;; The file descriptor of the file that has been opened.
     (result $opened_fd $fd_ref)
   )
@@ -768,7 +768,7 @@
   ;; Read the contents of a symbolic link.
   ;; Note: This is similar to readlinkat in POSIX.
   (func (export "readlink")
-    (method $fd_ref)
+    (param $self $fd_ref)
     ;; The path of the symbolic link from which to read.
     (param $path)
     ;; The buffer to which to write the contents of the symbolic link.
@@ -781,7 +781,7 @@
   ;; Return `__WASI_ENOTEMPTY` if the directory is not empty.
   ;; Note: This is similar to `unlinkat(fd, path, AT_REMOVEDIR)` in POSIX.
   (func (export "remove_directory")
-    (method $fd_ref)
+    (param $self $fd_ref)
     ;; The path to a directory to remove.
     (param $path string)
   )
@@ -789,7 +789,7 @@
   ;; Rename a file or directory.
   ;; Note: This is similar to `renameat` in POSIX.
   (func (export "rename")
-    (method $fd_ref)
+    (param $self $fd_ref)
     ;; The source path of the file or directory to rename.
     (param $old_path string)
     ;; The working directory at which the resolution of the new path starts.
@@ -801,7 +801,7 @@
   ;; Create a symbolic link.
   ;; Note: This is similar to symlinkat in POSIX.
   (func (export "symlink")
-    (method $fd_ref)
+    (param $self $fd_ref)
     ;; The contents of the symbolic link.
     (param $old_path string)
     ;; The destination path at which to create the symbolic link.
@@ -813,7 +813,7 @@
   ;; Return __WASI_EISDIR if the path refers to a directory.
   ;; Note: This is similar to unlinkat(fd, path, 0) in POSIX.
   (func (export "unlink_file")
-    (method $fd_ref)
+    (param $self $fd_ref)
     ;; The path to a file to unlink.
     (param $path string)
   )
@@ -924,7 +924,7 @@
     ;; The events to which to subscribe.
     (param $in $subscription_t)
     ;; The events that have occurred.
-    (param $out $wasi.event_t)
+    (param $out $event_t)
     ;; Both the number of subscriptions and events.
     (param $nsubscriptions $size_t)
     ;; The number of events stored.
@@ -1031,7 +1031,7 @@
   ;; Note: This is similar to `raise` in POSIX.
   (func (export "raise")
     ;; The signal condition to trigger.
-    (param $sig $wasi.signal_t)
+    (param $sig $signal_t)
   )
 
   ;; Temporarily yield execution of the calling thread.
@@ -1084,7 +1084,7 @@
   ;; Receive a message from a socket.
   ;; Note: This is similar to recv in POSIX, though it also supports reading the data into multiple buffers in the manner of readv.
   (func (export "recv")
-    (method $fd_ref)
+    (param $self $fd_ref)
     ;; List of scatter/gather vectors to which to store data.
     (param $ri_data $iovec_t_array)
     ;; Message flags.
@@ -1098,7 +1098,7 @@
   ;; Send a message on a socket.
   ;; Note: This is similar to `send` in POSIX, though it also supports writing the data from multiple buffers in the manner of `writev`.
   (func (export "send")
-    (method $fd_ref)
+    (param $self $fd_ref)
     ;; List of scatter/gather vectors to which to retrieve data
     (param $si_data $ciovec_t_array)
     ;; Message flags.
@@ -1110,7 +1110,7 @@
   ;; Shut down socket send and receive channels.
   ;; Note: This is similar to shutdown in POSIX.
   (func (export "shutdown")
-    (method $fd_ref)
+    (param $self $fd_ref)
     ;; Which channels on the socket to shut down.
     (param $how $sdflags_t)
   )

--- a/watidl/watidl.md
+++ b/watidl/watidl.md
@@ -1,6 +1,5 @@
 # WatIDL :duck:
 
-
 WatIDL (`/ˈwädl/`) is an IDL for webassembly. Its goal is to be able to fully describe the import and export capabilities of Webassembly modules while being intuitive to read and reason about. It inherits the Webassembly text format's syntax and attempts to closely follow and fit into the Webassembly ecosystem. WatIDL should used as a simple syntax for describing the interfaces along with WebIDL bindings to describe how the different data structures are formed and received by Wasm modules.
 
 # Differences from WAT
@@ -10,9 +9,10 @@ While WatIDL follow close to WAT there are some differences
 WatIDL uses the following primitive types
 
 ```
+refTypes := "anyRef" | "funcRef"
 intType := "s8" | "s6" | "s32" | "s64" | "u8" | "u16" | "u32" | "u64";
 floatType ::= "f32" | "f64" 
-primType ::= "null" | "bool" | "string" | "data" | intType | floatType;
+primType ::= "null" | "bool" | "string" | "data" | intType | floatType | refTypes;
 ```
 
 In addition new types can also be created using
@@ -77,7 +77,7 @@ An interface is also a first class type
 ```
 
 ### inheritance
-An interface can extend a base interface inheriting its imports and exports
+An interface can extend a base interface inheriting its imports, functions and types
 
 ```
 (interface $b
@@ -94,25 +94,19 @@ An interface can extend a base interface inheriting its imports and exports
   )
 )
 ```
-### static
-A static function is one that has no associated context. All non static function must bind to a context 
+
+### Method
+The method parameter type signifies that the function expects a "this" value. A function definition can only have one `method` parameter. In the future this will enable us to have OO style bindings.
 
 for example the following interface
 ```
 (interface $a
-  (static func (export "static")
-    (result u64)
-  )
-
-  (func (export "non-static")
+  (func (export "foo")
+    (method anyRef)
+    (param i32)
     (result u64)
   )
 )
-```
-may have bindings that result in the following imports
-```
-(import "a" "static" (func (result s64)))
-(import "a" "non-static" (func (param $this s32) (result s64)))
 ```
 
 ## Bindings

--- a/watidl/watidl.md
+++ b/watidl/watidl.md
@@ -24,19 +24,19 @@ The syntax for these follows the [gc proposals](https://github.com/WebAssembly/g
 
 ```
 (type $drinks
-	(enum
-		$coffee
-		$juice
-		$water
-		$wine
-	)
+  (enum
+    $coffee
+    $juice
+    $water
+    $wine
+  )
 )
 
 (type $baz
-	(struct
-		(field $foo $drinks)
-		(field $bar bool)
-	)
+  (struct
+    (field $foo $drinks)
+    (field $bar bool)
+  )
 )
 ```
 
@@ -46,10 +46,10 @@ instead of having "module"s WatIDL has "interfaces" which has nearly the same sy
 
 ```
 (interface $a
-	;; the module using this interface must export "memory"
-	(import "memory" (memory)) 
-	(global $a (export "a_global") (mut i32) (i32.const -2))
-	(func (export "a_func"))
+  ;; the module using this interface must export "memory"
+  (import "memory" (memory)) 
+  (global $a (export "a_global") (mut i32) (i32.const -2))
+  (func (export "a_func"))
 )
 ```
 
@@ -57,8 +57,8 @@ instead of having "module"s WatIDL has "interfaces" which has nearly the same sy
 watidl can have multiple results and results can be labeled
 ```
 (func (export "multi-vale")
-	(result $result1 u64)
-	(result $result2 f32)
+  (result $result1 u64)
+  (result $result2 f32)
 )
 ```
 
@@ -69,9 +69,9 @@ An interface is also a first class type
 (interface $b)
 
 (interface $a
-	(func (export "factory")
-		(result $the_result $b)
-	)
+  (func (export "factory")
+    (result $the_result $b)
+  )
 )
 ```
 
@@ -80,17 +80,17 @@ An interface can extend a base interface inheriting its imports and exports
 
 ```
 (interface $b
-	(func (export "add")
-		(param u64 u64)
-		(result u64)
-	)
+  (func (export "add")
+    (param u64 u64)
+    (result u64)
+  )
 )
 
 (interface $a extends $b
-	(func (export "sub")
-		(param u64 u64)
-		(result u64)
-	)
+  (func (export "sub")
+    (param u64 u64)
+    (result u64)
+  )
 )
 ```
 ### static
@@ -99,13 +99,13 @@ A static function is one that does has no associated context. All non static fun
 for example the following interface
 ```
 (interface $a
-	(static func (export "static")
-		(result u64)
-	)
+  (static func (export "static")
+    (result u64)
+  )
 
-	(func (export "not-static")
-		(result u64)
-	)
+  (func (export "not-static")
+    (result u64)
+  )
 )
 ```
 may have bindings that result in the following imports
@@ -116,5 +116,3 @@ may have bindings that result in the following imports
 
 ## Bindings
 Watidl reuse the core of [webidl bindings](https://github.com/WebAssembly/webidl-bindings/blob/master/proposals/webidl-bindings/Explainer.md) to specify how to interact with the various complex types. 
-
-

--- a/watidl/watidl.md
+++ b/watidl/watidl.md
@@ -1,0 +1,120 @@
+# WatIDL
+
+WatIDL is an IDL for webassembly. Its goal is to be able to fully describe the import and export capabilities of webassembly modules while being intuitive to read and reason about. It inherits the webassembly text formats syntax and attempts to closely follow and fit into the webassembly ecosystem. WatIDL should used as a simple syntax for describing the interfaces along with WebIDL bindings to describe how the different data structures are formed and received by a Wasm module.
+
+# Differences from WAT
+While WatIDL follow close to WAT there are some differences
+
+## Types
+WatIDL uses the following primal types
+
+```
+intType := "i8" | "i6" | "i32" | "i64" | "u8" | "u16" | "u32" | "u64";
+floatType ::= "f32" | "f64" 
+primType ::= "null" | "bool" | "string" | "data" | intTypes | floatType;
+```
+
+In addition new types can also be created using
+- struct
+- array
+- union
+- enum
+
+The syntax for these follows the [gc proposals](https://github.com/WebAssembly/gc/blob/master/proposals/gc/Overview.md) syntax when possible.
+
+```
+(type $drinks
+	(enum
+		$coffee
+		$juice
+		$water
+		$wine
+	)
+)
+
+(type $baz
+	(struct
+		(field $foo $drinks)
+		(field $bar bool)
+	)
+)
+```
+
+## Interface and Functions
+### Imports and Exports
+instead of having "module"s WatIDL has "interfaces" which has nearly the same syntax as [modules](https://webassembly.github.io/spec/core/text/modules.html). An interfaces "exports" are to be imported by a module using the interface and the interfaces "imports" are to be exported by the module using the interface. Since imports are to be provided by the module using the interface the have no module namespace associated with them.  
+
+```
+(interface $a
+	;; the module using this interface must export "memory"
+	(import "memory" (memory)) 
+	(global $a (export "a_global") (mut i32) (i32.const -2))
+	(func (export "a_func"))
+)
+```
+
+### Results
+watidl can have multiple results and results can be labeled
+```
+(func (export "multi-vale")
+	(result $result1 u64)
+	(result $result2 f32)
+)
+```
+
+### Object Oriented
+An interface is also a first class type
+
+```
+(interface $b)
+
+(interface $a
+	(func (export "factory")
+		(result $the_result $b)
+	)
+)
+```
+
+### inheritance
+An interface can extend a base interface inheriting its imports and exports
+
+```
+(interface $b
+	(func (export "add")
+		(param u64 u64)
+		(result u64)
+	)
+)
+
+(interface $a extends $b
+	(func (export "sub")
+		(param u64 u64)
+		(result u64)
+	)
+)
+```
+### static
+A static function is one that does has no associated context. All non static function must bind to a context 
+
+for example the following interface
+```
+(interface $a
+	(static func (export "static")
+		(result u64)
+	)
+
+	(func (export "not-static")
+		(result u64)
+	)
+)
+```
+may have bindings that result in the following imports
+```
+(import "a" "static" (func (result i64)))
+(import "a" "non-static" (func (param $this i32) (result i64)))
+```
+
+## Bindings
+Watidl reuse the core of [webidl bindings](https://github.com/WebAssembly/webidl-bindings/blob/master/proposals/webidl-bindings/Explainer.md) to specify how to interact with the various complex types. 
+
+

--- a/watidl/watidl.md
+++ b/watidl/watidl.md
@@ -10,7 +10,7 @@ While WatIDL follow close to WAT there are some differences
 WatIDL uses the following primitive types
 
 ```
-intType := "i8" | "i6" | "i32" | "i64" | "u8" | "u16" | "u32" | "u64";
+intType := "s8" | "s6" | "s32" | "s64" | "u8" | "u16" | "u32" | "u64";
 floatType ::= "f32" | "f64" 
 primType ::= "null" | "bool" | "string" | "data" | intTypes | floatType;
 ```
@@ -49,7 +49,7 @@ Instead of having "module"s WatIDL has "interfaces" which has nearly the same sy
 (interface $a
   ;; the module using this interface must export "memory"
   (import "memory" (memory)) 
-  (global $a (export "a_global") (mut i32) (i32.const -2))
+  (global $a (export "a_global") (mut s32) (s32.const -2))
   (func (export "a_func"))
 )
 ```
@@ -111,8 +111,8 @@ for example the following interface
 ```
 may have bindings that result in the following imports
 ```
-(import "a" "static" (func (result i64)))
-(import "a" "non-static" (func (param $this i32) (result i64)))
+(import "a" "static" (func (result s64)))
+(import "a" "non-static" (func (param $this s32) (result s64)))
 ```
 
 ## Bindings

--- a/watidl/watidl.md
+++ b/watidl/watidl.md
@@ -1,12 +1,13 @@
-# WatIDL
+# WatIDL :duck:
 
-WatIDL is an IDL for webassembly. Its goal is to be able to fully describe the import and export capabilities of webassembly modules while being intuitive to read and reason about. It inherits the webassembly text formats syntax and attempts to closely follow and fit into the webassembly ecosystem. WatIDL should used as a simple syntax for describing the interfaces along with WebIDL bindings to describe how the different data structures are formed and received by a Wasm module.
+
+WatIDL (`/ˈwädl/`) is an IDL for webassembly. Its goal is to be able to fully describe the import and export capabilities of Webassembly modules while being intuitive to read and reason about. It inherits the Webassembly text format's syntax and attempts to closely follow and fit into the Webassembly ecosystem. WatIDL should used as a simple syntax for describing the interfaces along with WebIDL bindings to describe how the different data structures are formed and received by Wasm modules.
 
 # Differences from WAT
 While WatIDL follow close to WAT there are some differences
 
 ## Types
-WatIDL uses the following primal types
+WatIDL uses the following primitive types
 
 ```
 intType := "i8" | "i6" | "i32" | "i64" | "u8" | "u16" | "u32" | "u64";
@@ -42,7 +43,7 @@ The syntax for these follows the [gc proposals](https://github.com/WebAssembly/g
 
 ## Interface and Functions
 ### Imports and Exports
-instead of having "module"s WatIDL has "interfaces" which has nearly the same syntax as [modules](https://webassembly.github.io/spec/core/text/modules.html). An interfaces "exports" are to be imported by a module using the interface and the interfaces "imports" are to be exported by the module using the interface. Since imports are to be provided by the module using the interface the have no module namespace associated with them.  
+Instead of having "module"s WatIDL has "interfaces" which has nearly the same syntax as [modules](https://webassembly.github.io/spec/core/text/modules.html). An interfaces "exports" are to be imported by a module using the interface and the interfaces "imports" are to be exported by the module using the interface. Since imports are to be provided by the module using the interface the have no module namespace associated with them.  
 
 ```
 (interface $a

--- a/watidl/watidl.md
+++ b/watidl/watidl.md
@@ -63,19 +63,6 @@ watidl can have multiple results and results can be labeled
 )
 ```
 
-### Object Oriented
-An interface is also a first class type
-
-```
-(interface $b)
-
-(interface $a
-  (func (export "factory")
-    (result $the_result $b)
-  )
-)
-```
-
 ### Inheritance
 An interface can extend a base interface inheriting its imports, functions and types
 

--- a/watidl/watidl.md
+++ b/watidl/watidl.md
@@ -82,19 +82,5 @@ An interface can extend a base interface inheriting its imports, functions and t
 )
 ```
 
-### Method
-The method parameter type signifies that the function expects a "this" value. A function definition can only have one `method` parameter. In the future this will enable us to have OO style bindings.
-
-for example the following interface
-```
-(interface $a
-  (func (export "foo")
-    (method anyRef)
-    (param i32)
-    (result u64)
-  )
-)
-```
-
 ## Bindings
 Watidl reuse the core of [webidl bindings](https://github.com/WebAssembly/webidl-bindings/blob/master/proposals/webidl-bindings/Explainer.md) to specify how to interact with the various complex types. 

--- a/watidl/watidl.md
+++ b/watidl/watidl.md
@@ -76,7 +76,7 @@ An interface is also a first class type
 )
 ```
 
-### inheritance
+### Inheritance
 An interface can extend a base interface inheriting its imports, functions and types
 
 ```

--- a/watidl/watidl.md
+++ b/watidl/watidl.md
@@ -12,7 +12,7 @@ WatIDL uses the following primitive types
 ```
 intType := "s8" | "s6" | "s32" | "s64" | "u8" | "u16" | "u32" | "u64";
 floatType ::= "f32" | "f64" 
-primType ::= "null" | "bool" | "string" | "data" | intTypes | floatType;
+primType ::= "null" | "bool" | "string" | "data" | intType | floatType;
 ```
 
 In addition new types can also be created using
@@ -95,7 +95,7 @@ An interface can extend a base interface inheriting its imports and exports
 )
 ```
 ### static
-A static function is one that does has no associated context. All non static function must bind to a context 
+A static function is one that has no associated context. All non static function must bind to a context 
 
 for example the following interface
 ```
@@ -104,7 +104,7 @@ for example the following interface
     (result u64)
   )
 
-  (func (export "not-static")
+  (func (export "non-static")
     (result u64)
   )
 )


### PR DESCRIPTION
## WatIDL
 `/ˈwädl/` :duck: 

WatIDL is strawman text format for Wasm interfaces. This is an attempt to aggregate feedback from PR https://github.com/WebAssembly/WASI/pull/58

A quick overview
- WatIDL has the object model of capn-proto
- WatIDL has syntax of WAT
- WatIDL needs webIDL bindings

I didn't full flush out how the binding would look like but I think it will be fairly straight since the is a pretty straight forward mapping between watIDL type and webIDL types.  