### PR TITLE
Fix the name of `wasi_ephemeral_preview0` and update tests.

### DIFF
--- a/phases/ephemeral/witx/wasi_ephemeral_preview0.witx
+++ b/phases/ephemeral/witx/wasi_ephemeral_preview0.witx
@@ -8,7 +8,7 @@
 
 (use "typenames.witx")
 
-(module $wasi_ephemeral_preview
+(module $wasi_ephemeral_preview0
   ;; Linear memory to be accessed by WASI functions that need it.
   (import "memory" (memory))
 

--- a/tools/witx/tests/wasi_unstable.rs
+++ b/tools/witx/tests/wasi_unstable.rs
@@ -1,9 +1,23 @@
 use std::path::Path;
+use witx;
 
 #[test]
-fn validate_wasi_unstable() {
+fn validate_wasi_unstable_preview0() {
     witx::load(Path::new(
         "../../phases/unstable/witx/wasi_unstable_preview0.witx",
     ))
     .unwrap();
+}
+
+#[test]
+fn validate_wasi_ephemeral_preview0() {
+    witx::load(Path::new(
+        "../../phases/ephemeral/witx/wasi_ephemeral_preview0.witx",
+    ))
+    .unwrap();
+}
+
+#[test]
+fn validate_wasi_old_preview0() {
+    witx::load(Path::new("../../phases/old/witx/wasi_unstable.witx")).unwrap();
 }


### PR DESCRIPTION
`wasi_ephemeral_preview0` is meant to be versioned, so that it can be
superceded by new versions in the future.

Also, update the witx testsuite to test all the current witx files.