### PR TITLE
Add GitHub Actions CI for `witx` crate

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,36 @@
+name: CI
+on: [push, pull_request]
+
+jobs:
+  test:
+    name: Test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+    - uses: actions/checkout@master
+    - name: Install Rust (rustup)
+      run: rustup update stable --no-self-update && rustup default stable
+      if: matrix.os != 'macos-latest'
+    - name: Install Rust (macos)
+      run: |
+        curl https://sh.rustup.rs | sh -s -- -y
+        echo "##[add-path]$HOME/.cargo/bin"
+      if: matrix.os == 'macos-latest'
+    - run: cargo fetch
+      working-directory: tools/witx
+    - run: cargo build
+      working-directory: tools/witx
+    - run: cargo test
+      working-directory: tools/witx
+
+  rustfmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Install Rust
+      run: rustup update stable && rustup default stable && rustup component add rustfmt
+    - run: cargo fmt -- --check
+      working-directory: tools/witx

--- a/tools/witx/tests/wasi_unstable.rs
+++ b/tools/witx/tests/wasi_unstable.rs
@@ -1,7 +1,9 @@
 use std::path::Path;
-use witx_frontend;
 
 #[test]
 fn validate_wasi_unstable() {
-    witx_frontend::load(Path::new("../../design/wasi_unstable/wasi_unstable.witx")).unwrap();
+    witx::load(Path::new(
+        "../../phases/unstable/witx/wasi_unstable_preview0.witx",
+    ))
+    .unwrap();
 }


### PR DESCRIPTION
This adds some basic GitHub Actions configuration to build/test the `witx` crate, which also validates the `phases/unstable/witx/wasi_unstable_preview0.witx` file in this repo. I figured it'd be good to start out with some testing and if we need binary releases can layer that on afterwards.