### PR TITLE
witx crate: improve public API

### DIFF
--- a/tools/witx/src/ast.rs
+++ b/tools/witx/src/ast.rs
@@ -18,8 +18,41 @@ impl Id {
 
 #[derive(Debug, Clone)]
 pub struct Document {
-    pub definitions: Vec<Definition>,
-    pub entries: HashMap<Id, Entry>,
+    definitions: Vec<Definition>,
+    entries: HashMap<Id, Entry>,
+}
+
+impl Document {
+    pub(crate) fn new(definitions: Vec<Definition>, entries: HashMap<Id, Entry>) -> Self {
+        Document {
+            definitions,
+            entries,
+        }
+    }
+    pub fn datatype(&self, name: &Id) -> Option<Rc<Datatype>> {
+        self.entries.get(name).and_then(|e| match e {
+            Entry::Datatype(d) => Some(d.upgrade().expect("always possible to upgrade entry")),
+            _ => None,
+        })
+    }
+    pub fn datatypes<'a>(&'a self) -> impl Iterator<Item = Rc<Datatype>> + 'a {
+        self.definitions.iter().filter_map(|d| match d {
+            Definition::Datatype(d) => Some(d.clone()),
+            _ => None,
+        })
+    }
+    pub fn module(&self, name: &Id) -> Option<Rc<Module>> {
+        self.entries.get(&name).and_then(|e| match e {
+            Entry::Module(d) => Some(d.upgrade().expect("always possible to upgrade entry")),
+            _ => None,
+        })
+    }
+    pub fn modules<'a>(&'a self) -> impl Iterator<Item = Rc<Module>> + 'a {
+        self.definitions.iter().filter_map(|d| match d {
+            Definition::Module(d) => Some(d.clone()),
+            _ => None,
+        })
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -122,8 +155,46 @@ pub struct UnionVariant {
 #[derive(Debug, Clone)]
 pub struct Module {
     pub name: Id,
-    pub definitions: Vec<ModuleDefinition>,
-    pub entries: HashMap<Id, ModuleEntry>,
+    definitions: Vec<ModuleDefinition>,
+    entries: HashMap<Id, ModuleEntry>,
+}
+
+impl Module {
+    pub(crate) fn new(
+        name: Id,
+        definitions: Vec<ModuleDefinition>,
+        entries: HashMap<Id, ModuleEntry>,
+    ) -> Self {
+        Module {
+            name,
+            definitions,
+            entries,
+        }
+    }
+    pub fn import(&self, name: &str) -> Option<Rc<ModuleImport>> {
+        self.entries.get(&Id::new(name)).and_then(|e| match e {
+            ModuleEntry::Import(d) => Some(d.upgrade().expect("always possible to upgrade entry")),
+            _ => None,
+        })
+    }
+    pub fn imports<'a>(&'a self) -> impl Iterator<Item = Rc<ModuleImport>> + 'a {
+        self.definitions.iter().filter_map(|d| match d {
+            ModuleDefinition::Import(d) => Some(d.clone()),
+            _ => None,
+        })
+    }
+    pub fn func(&self, name: &Id) -> Option<Rc<InterfaceFunc>> {
+        self.entries.get(name).and_then(|e| match e {
+            ModuleEntry::Func(d) => Some(d.upgrade().expect("always possible to upgrade entry")),
+            _ => None,
+        })
+    }
+    pub fn funcs<'a>(&'a self) -> impl Iterator<Item = Rc<InterfaceFunc>> + 'a {
+        self.definitions.iter().filter_map(|d| match d {
+            ModuleDefinition::Func(d) => Some(d.clone()),
+            _ => None,
+        })
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/tools/witx/src/ast.rs
+++ b/tools/witx/src/ast.rs
@@ -55,6 +55,34 @@ impl Document {
     }
 }
 
+impl PartialEq for Document {
+    fn eq(&self, rhs: &Document) -> bool {
+        if self.definitions.len() != rhs.definitions.len() {
+            return false;
+        }
+        for d in self.datatypes() {
+            if let Some(d_rhs) = rhs.datatype(&d.name) {
+                if d != d_rhs {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+        }
+        for m in self.modules() {
+            if let Some(m_rhs) = rhs.module(&m.name) {
+                if m != m_rhs {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+        }
+        true
+    }
+}
+impl Eq for Document {}
+
 #[derive(Debug, Clone)]
 pub enum Definition {
     Datatype(Rc<Datatype>),
@@ -76,7 +104,7 @@ impl Entry {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DatatypeIdent {
     Builtin(BuiltinType),
     Array(Box<DatatypeIdent>),
@@ -85,13 +113,13 @@ pub enum DatatypeIdent {
     Ident(Rc<Datatype>),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Datatype {
     pub name: Id,
     pub variant: DatatypeVariant,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DatatypeVariant {
     Alias(AliasDatatype),
     Enum(EnumDatatype),
@@ -100,13 +128,13 @@ pub enum DatatypeVariant {
     Union(UnionDatatype),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AliasDatatype {
     pub name: Id,
     pub to: DatatypeIdent,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum IntRepr {
     I8,
     I16,
@@ -114,39 +142,39 @@ pub enum IntRepr {
     I64,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EnumDatatype {
     pub name: Id,
     pub repr: IntRepr,
     pub variants: Vec<Id>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FlagsDatatype {
     pub name: Id,
     pub repr: IntRepr,
     pub flags: Vec<Id>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StructDatatype {
     pub name: Id,
     pub members: Vec<StructMember>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StructMember {
     pub name: Id,
     pub type_: DatatypeIdent,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UnionDatatype {
     pub name: Id,
     pub variants: Vec<UnionVariant>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UnionVariant {
     pub name: Id,
     pub type_: DatatypeIdent,
@@ -171,8 +199,8 @@ impl Module {
             entries,
         }
     }
-    pub fn import(&self, name: &str) -> Option<Rc<ModuleImport>> {
-        self.entries.get(&Id::new(name)).and_then(|e| match e {
+    pub fn import(&self, name: &Id) -> Option<Rc<ModuleImport>> {
+        self.entries.get(name).and_then(|e| match e {
             ModuleEntry::Import(d) => Some(d.upgrade().expect("always possible to upgrade entry")),
             _ => None,
         })
@@ -197,6 +225,34 @@ impl Module {
     }
 }
 
+impl PartialEq for Module {
+    fn eq(&self, rhs: &Module) -> bool {
+        if self.definitions.len() != rhs.definitions.len() {
+            return false;
+        }
+        for i in self.imports() {
+            if let Some(i_rhs) = rhs.import(&i.name) {
+                if i != i_rhs {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+        }
+        for f in self.funcs() {
+            if let Some(f_rhs) = rhs.func(&f.name) {
+                if f != f_rhs {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+        }
+        true
+    }
+}
+impl Eq for Module {}
+
 #[derive(Debug, Clone)]
 pub enum ModuleDefinition {
     Import(Rc<ModuleImport>),
@@ -209,25 +265,25 @@ pub enum ModuleEntry {
     Func(Weak<InterfaceFunc>),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ModuleImport {
     pub name: Id,
     pub variant: ModuleImportVariant,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ModuleImportVariant {
     Memory,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InterfaceFunc {
     pub name: Id,
     pub params: Vec<InterfaceFuncParam>,
     pub results: Vec<InterfaceFuncParam>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InterfaceFuncParam {
     pub name: Id,
     pub type_: DatatypeIdent,

--- a/tools/witx/src/ast.rs
+++ b/tools/witx/src/ast.rs
@@ -136,10 +136,10 @@ pub struct AliasDatatype {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum IntRepr {
-    I8,
-    I16,
-    I32,
-    I64,
+    U8,
+    U16,
+    U32,
+    U64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/tools/witx/src/io.rs
+++ b/tools/witx/src/io.rs
@@ -5,8 +5,11 @@ use std::io::{BufRead, BufReader, Error, ErrorKind};
 use std::path::{Path, PathBuf};
 
 pub trait WitxIo {
+    /// Read the entire file into a String. Used to resolve `use` declarations.
     fn fgets(&self, path: &Path) -> Result<String, WitxError>;
+    /// Read a line of a file into a String. Used for error reporting.
     fn fget_line(&self, path: &Path, line_num: usize) -> Result<String, WitxError>;
+    /// Return the canonical (non-symlinked) path of a file. Used to resolve `use` declarations.
     fn canonicalize(&self, path: &Path) -> Result<PathBuf, WitxError>;
 }
 

--- a/tools/witx/src/io.rs
+++ b/tools/witx/src/io.rs
@@ -1,0 +1,88 @@
+use crate::WitxError;
+use std::collections::HashMap;
+use std::fs::{read_to_string, File};
+use std::io::{BufRead, BufReader, Error, ErrorKind};
+use std::path::{Path, PathBuf};
+
+pub trait WitxIo {
+    fn fgets(&self, path: &Path) -> Result<String, WitxError>;
+    fn fget_line(&self, path: &Path, line_num: usize) -> Result<String, WitxError>;
+    fn canonicalize(&self, path: &Path) -> Result<PathBuf, WitxError>;
+}
+
+pub struct Filesystem;
+
+impl WitxIo for Filesystem {
+    fn fgets(&self, path: &Path) -> Result<String, WitxError> {
+        read_to_string(path).map_err(|e| WitxError::Io(path.to_path_buf(), e))
+    }
+    fn fget_line(&self, path: &Path, line_num: usize) -> Result<String, WitxError> {
+        let f = File::open(path).map_err(|e| WitxError::Io(path.into(), e))?;
+        let buf = BufReader::new(f);
+        let l = buf
+            .lines()
+            .skip(line_num - 1)
+            .next()
+            .ok_or_else(|| {
+                WitxError::Io(path.into(), Error::new(ErrorKind::Other, "Line not found"))
+            })?
+            .map_err(|e| WitxError::Io(path.into(), e))?;
+
+        Ok(l)
+    }
+    fn canonicalize(&self, path: &Path) -> Result<PathBuf, WitxError> {
+        path.canonicalize()
+            .map_err(|e| WitxError::Io(path.to_path_buf(), e))
+    }
+}
+
+pub struct MockFs {
+    map: HashMap<String, String>,
+}
+
+impl MockFs {
+    pub fn new(strings: &[(&str, &str)]) -> Self {
+        MockFs {
+            map: strings
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
+        }
+    }
+}
+
+impl WitxIo for MockFs {
+    fn fgets(&self, path: &Path) -> Result<String, WitxError> {
+        if let Some(entry) = self.map.get(path.to_str().unwrap()) {
+            Ok(entry.to_string())
+        } else {
+            Err(WitxError::Io(
+                path.to_path_buf(),
+                Error::new(ErrorKind::Other, "mock fs: file not found"),
+            ))
+        }
+    }
+    fn fget_line(&self, path: &Path, line: usize) -> Result<String, WitxError> {
+        if let Some(entry) = self.map.get(path.to_str().unwrap()) {
+            entry
+                .lines()
+                .skip(line - 1)
+                .next()
+                .map(|s| s.to_string())
+                .ok_or_else(|| {
+                    WitxError::Io(
+                        path.to_path_buf(),
+                        Error::new(ErrorKind::Other, "mock fs: file not found"),
+                    )
+                })
+        } else {
+            Err(WitxError::Io(
+                path.to_path_buf(),
+                Error::new(ErrorKind::Other, "mock fs: file not found"),
+            ))
+        }
+    }
+    fn canonicalize(&self, path: &Path) -> Result<PathBuf, WitxError> {
+        Ok(PathBuf::from(path))
+    }
+}

--- a/tools/witx/src/lib.rs
+++ b/tools/witx/src/lib.rs
@@ -31,6 +31,7 @@ pub use validate::ValidationError;
 use failure::Fail;
 use std::path::{Path, PathBuf};
 
+/// Load a witx document from the filesystem
 pub fn load<P: AsRef<Path>>(path: P) -> Result<Document, WitxError> {
     use toplevel::parse_witx;
     use validate::validate_document;
@@ -38,6 +39,7 @@ pub fn load<P: AsRef<Path>>(path: P) -> Result<Document, WitxError> {
     validate_document(&parsed_decls).map_err(WitxError::Validation)
 }
 
+/// Parse a witx document from a str. `(use ...)` directives are not permitted.
 pub fn parse(source: &str) -> Result<Document, WitxError> {
     use toplevel::parse_witx_with;
     use validate::validate_document;

--- a/tools/witx/src/parser.rs
+++ b/tools/witx/src/parser.rs
@@ -1,3 +1,4 @@
+use crate::io::{Filesystem, WitxIo};
 use crate::sexpr::SExpr;
 use crate::Location;
 use failure::Fail;
@@ -23,8 +24,15 @@ pub struct ParseError {
 }
 
 impl ParseError {
+    pub fn report_with(&self, witxio: &dyn WitxIo) -> String {
+        format!(
+            "{}\n{}",
+            self.location.highlight_source_with(witxio),
+            self.message
+        )
+    }
     pub fn report(&self) -> String {
-        format!("{}\n{}", self.location.highlight_source(), self.message)
+        self.report_with(&Filesystem)
     }
 }
 

--- a/tools/witx/src/render.rs
+++ b/tools/witx/src/render.rs
@@ -1,0 +1,266 @@
+use crate::ast::*;
+use std::fmt;
+
+impl fmt::Display for Document {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        for d in self.datatypes() {
+            write!(f, "{}\n", d.to_sexpr())?;
+        }
+        for m in self.modules() {
+            write!(f, "{}\n", m.to_sexpr())?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum SExpr {
+    Vec(Vec<SExpr>),
+    Word(String),
+    Ident(String),
+    Quote(String),
+    /// Short for Annotation
+    Annot(String),
+}
+
+impl fmt::Display for SExpr {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            SExpr::Vec(vs) => {
+                write!(f, "(")?;
+                let mut vss = Vec::new();
+                for v in vs {
+                    vss.push(format!("{}", v));
+                }
+                f.write_str(&vss.join(" "))?;
+                write!(f, ")")
+            }
+            SExpr::Word(w) => write!(f, "{}", w),
+            SExpr::Ident(i) => write!(f, "${}", i),
+            SExpr::Quote(q) => write!(f, "\"{}\"", q),
+            SExpr::Annot(a) => write!(f, "@{}", a),
+        }
+    }
+}
+
+impl SExpr {
+    fn word(s: &str) -> SExpr {
+        SExpr::Word(s.to_string())
+    }
+    fn ident(s: &str) -> SExpr {
+        SExpr::Ident(s.to_string())
+    }
+    fn quote(s: &str) -> SExpr {
+        SExpr::Quote(s.to_string())
+    }
+    fn annot(s: &str) -> SExpr {
+        SExpr::Annot(s.to_string())
+    }
+}
+
+pub trait Render {
+    fn to_sexpr(&self) -> SExpr;
+}
+
+impl Render for Id {
+    fn to_sexpr(&self) -> SExpr {
+        SExpr::ident(self.as_str())
+    }
+}
+
+impl Render for BuiltinType {
+    fn to_sexpr(&self) -> SExpr {
+        match self {
+            BuiltinType::String => SExpr::word("string"),
+            BuiltinType::Data => SExpr::word("data"),
+            BuiltinType::U8 => SExpr::word("u8"),
+            BuiltinType::U16 => SExpr::word("u16"),
+            BuiltinType::U32 => SExpr::word("u32"),
+            BuiltinType::U64 => SExpr::word("u64"),
+            BuiltinType::S8 => SExpr::word("s8"),
+            BuiltinType::S16 => SExpr::word("s16"),
+            BuiltinType::S32 => SExpr::word("s32"),
+            BuiltinType::S64 => SExpr::word("s64"),
+            BuiltinType::F32 => SExpr::word("f32"),
+            BuiltinType::F64 => SExpr::word("f64"),
+        }
+    }
+}
+
+impl Render for DatatypeIdent {
+    fn to_sexpr(&self) -> SExpr {
+        match self {
+            DatatypeIdent::Builtin(b) => b.to_sexpr(),
+            DatatypeIdent::Array(a) => SExpr::Vec(vec![SExpr::word("array"), a.to_sexpr()]),
+            DatatypeIdent::Pointer(p) => SExpr::Vec(vec![
+                SExpr::annot("witx"),
+                SExpr::word("pointer"),
+                p.to_sexpr(),
+            ]),
+            DatatypeIdent::ConstPointer(p) => SExpr::Vec(vec![
+                SExpr::annot("witx"),
+                SExpr::word("const_pointer"),
+                p.to_sexpr(),
+            ]),
+            DatatypeIdent::Ident(i) => i.name.to_sexpr(),
+        }
+    }
+}
+
+impl Render for Datatype {
+    fn to_sexpr(&self) -> SExpr {
+        let name = self.name.to_sexpr();
+        let body = self.variant.to_sexpr();
+        SExpr::Vec(vec![SExpr::word("typename"), name, body])
+    }
+}
+
+impl Render for DatatypeVariant {
+    fn to_sexpr(&self) -> SExpr {
+        match self {
+            DatatypeVariant::Alias(a) => a.to_sexpr(),
+            DatatypeVariant::Enum(a) => a.to_sexpr(),
+            DatatypeVariant::Flags(a) => a.to_sexpr(),
+            DatatypeVariant::Struct(a) => a.to_sexpr(),
+            DatatypeVariant::Union(a) => a.to_sexpr(),
+        }
+    }
+}
+
+impl Render for AliasDatatype {
+    fn to_sexpr(&self) -> SExpr {
+        self.to.to_sexpr()
+    }
+}
+
+impl Render for EnumDatatype {
+    fn to_sexpr(&self) -> SExpr {
+        let header = vec![SExpr::word("enum"), self.repr.to_sexpr()];
+        let variants = self
+            .variants
+            .iter()
+            .map(|v| v.to_sexpr())
+            .collect::<Vec<SExpr>>();
+        SExpr::Vec([header, variants].concat())
+    }
+}
+
+impl Render for FlagsDatatype {
+    fn to_sexpr(&self) -> SExpr {
+        let header = vec![SExpr::word("flags"), self.repr.to_sexpr()];
+        let flags = self
+            .flags
+            .iter()
+            .map(|f| SExpr::Vec(vec![SExpr::word("flag"), f.to_sexpr()]))
+            .collect::<Vec<SExpr>>();
+        SExpr::Vec([header, flags].concat())
+    }
+}
+
+impl Render for StructDatatype {
+    fn to_sexpr(&self) -> SExpr {
+        let header = vec![SExpr::word("struct")];
+        let members = self
+            .members
+            .iter()
+            .map(|m| {
+                SExpr::Vec(vec![
+                    SExpr::word("field"),
+                    m.name.to_sexpr(),
+                    m.type_.to_sexpr(),
+                ])
+            })
+            .collect::<Vec<SExpr>>();
+        SExpr::Vec([header, members].concat())
+    }
+}
+
+impl Render for UnionDatatype {
+    fn to_sexpr(&self) -> SExpr {
+        let header = vec![SExpr::word("union")];
+        let variants = self
+            .variants
+            .iter()
+            .map(|v| {
+                SExpr::Vec(vec![
+                    SExpr::word("field"),
+                    v.name.to_sexpr(),
+                    v.type_.to_sexpr(),
+                ])
+            })
+            .collect::<Vec<SExpr>>();
+        SExpr::Vec([header, variants].concat())
+    }
+}
+
+impl Render for IntRepr {
+    fn to_sexpr(&self) -> SExpr {
+        match self {
+            IntRepr::I8 => SExpr::word("u8"),
+            IntRepr::I16 => SExpr::word("u16"),
+            IntRepr::I32 => SExpr::word("u32"),
+            IntRepr::I64 => SExpr::word("u64"),
+        }
+    }
+}
+
+impl Render for Module {
+    fn to_sexpr(&self) -> SExpr {
+        let header = vec![SExpr::word("module"), self.name.to_sexpr()];
+        let definitions = self
+            .imports()
+            .map(|i| i.to_sexpr())
+            .chain(self.funcs().map(|f| f.to_sexpr()))
+            .collect::<Vec<SExpr>>();
+        SExpr::Vec([header, definitions].concat())
+    }
+}
+
+impl Render for ModuleImport {
+    fn to_sexpr(&self) -> SExpr {
+        let variant = match self.variant {
+            ModuleImportVariant::Memory => SExpr::Vec(vec![SExpr::word("memory")]),
+        };
+        SExpr::Vec(vec![
+            SExpr::word("import"),
+            SExpr::quote(self.name.as_str()),
+            variant,
+        ])
+    }
+}
+
+impl Render for InterfaceFunc {
+    fn to_sexpr(&self) -> SExpr {
+        let header = vec![
+            SExpr::annot("interface"),
+            SExpr::word("func"),
+            SExpr::Vec(vec![
+                SExpr::word("export"),
+                SExpr::quote(self.name.as_str()),
+            ]),
+        ];
+        let params = self
+            .params
+            .iter()
+            .map(|f| {
+                SExpr::Vec(vec![
+                    SExpr::word("param"),
+                    f.name.to_sexpr(),
+                    f.type_.to_sexpr(),
+                ])
+            })
+            .collect();
+        let results = self
+            .results
+            .iter()
+            .map(|f| {
+                SExpr::Vec(vec![
+                    SExpr::word("result"),
+                    f.name.to_sexpr(),
+                    f.type_.to_sexpr(),
+                ])
+            })
+            .collect();
+        SExpr::Vec([header, params, results].concat())
+    }
+}

--- a/tools/witx/src/render.rs
+++ b/tools/witx/src/render.rs
@@ -196,10 +196,10 @@ impl Render for UnionDatatype {
 impl Render for IntRepr {
     fn to_sexpr(&self) -> SExpr {
         match self {
-            IntRepr::I8 => SExpr::word("u8"),
-            IntRepr::I16 => SExpr::word("u16"),
-            IntRepr::I32 => SExpr::word("u32"),
-            IntRepr::I64 => SExpr::word("u64"),
+            IntRepr::U8 => SExpr::word("u8"),
+            IntRepr::U16 => SExpr::word("u16"),
+            IntRepr::U32 => SExpr::word("u32"),
+            IntRepr::U64 => SExpr::word("u64"),
         }
     }
 }

--- a/tools/witx/src/sexpr.rs
+++ b/tools/witx/src/sexpr.rs
@@ -1,3 +1,4 @@
+use crate::io::{Filesystem, WitxIo};
 pub use crate::lexer::LexError;
 use crate::lexer::{Lexer, LocatedError, LocatedToken, Token};
 use crate::Location;
@@ -41,13 +42,16 @@ pub enum SExprParseError {
 }
 
 impl SExprParseError {
-    pub fn report(&self) -> String {
+    pub fn report_with(&self, witxio: &dyn WitxIo) -> String {
         use SExprParseError::*;
         match self {
-            Lex(lex_err, loc) => format!("{}\n{}", loc.highlight_source(), lex_err),
-            UnexpectedCloseParen(loc) => format!("{}\n{}", loc.highlight_source(), self),
+            Lex(lex_err, loc) => format!("{}\n{}", loc.highlight_source_with(witxio), lex_err),
+            UnexpectedCloseParen(loc) => format!("{}\n{}", loc.highlight_source_with(witxio), self),
             UnexpectedEof(_path) => format!("{}", self),
         }
+    }
+    pub fn report(&self) -> String {
+        self.report_with(&Filesystem)
     }
 }
 

--- a/tools/witx/src/validate.rs
+++ b/tools/witx/src/validate.rs
@@ -1,4 +1,5 @@
 use crate::{
+    io::{Filesystem, WitxIo},
     parser::{
         DatatypeIdentSyntax, DeclSyntax, EnumSyntax, FlagsSyntax, IdentSyntax, ImportTypeSyntax,
         ModuleDeclSyntax, StructSyntax, TypedefSyntax, UnionSyntax,
@@ -42,24 +43,29 @@ pub enum ValidationError {
 }
 
 impl ValidationError {
-    pub fn report(&self) -> String {
+    pub fn report_with(&self, witxio: &dyn WitxIo) -> String {
         use ValidationError::*;
         match self {
             UnknownName { location, .. }
             | WrongKindName { location, .. }
             | Recursive { location, .. }
-            | InvalidRepr { location, .. } => format!("{}\n{}", location.highlight_source(), &self),
+            | InvalidRepr { location, .. } => {
+                format!("{}\n{}", location.highlight_source_with(witxio), &self)
+            }
             NameAlreadyExists {
                 at_location,
                 previous_location,
                 ..
             } => format!(
                 "{}\n{}\nOriginally defined at:\n{}",
-                at_location.highlight_source(),
+                at_location.highlight_source_with(witxio),
                 &self,
-                previous_location.highlight_source(),
+                previous_location.highlight_source_with(witxio),
             ),
         }
+    }
+    pub fn report(&self) -> String {
+        self.report_with(&Filesystem)
     }
 }
 

--- a/tools/witx/src/validate.rs
+++ b/tools/witx/src/validate.rs
@@ -311,10 +311,10 @@ impl DocValidation {
 
 fn validate_int_repr(type_: &BuiltinType, location: &Location) -> Result<IntRepr, ValidationError> {
     match type_ {
-        BuiltinType::U8 => Ok(IntRepr::I8),
-        BuiltinType::U16 => Ok(IntRepr::I16),
-        BuiltinType::U32 => Ok(IntRepr::I32),
-        BuiltinType::U64 => Ok(IntRepr::I64),
+        BuiltinType::U8 => Ok(IntRepr::U8),
+        BuiltinType::U16 => Ok(IntRepr::U16),
+        BuiltinType::U32 => Ok(IntRepr::U32),
+        BuiltinType::U64 => Ok(IntRepr::U64),
         _ => Err(ValidationError::InvalidRepr {
             repr: type_.clone(),
             location: location.clone(),

--- a/tools/witx/src/validate.rs
+++ b/tools/witx/src/validate.rs
@@ -70,10 +70,7 @@ pub fn validate_document(decls: &[DeclSyntax]) -> Result<Document, ValidationErr
         definitions.push(validator.validate_decl(&d)?);
     }
 
-    Ok(Document {
-        entries: validator.entries,
-        definitions,
-    })
+    Ok(Document::new(definitions, validator.entries))
 }
 
 struct IdentValidation {
@@ -167,11 +164,11 @@ impl DocValidation {
                     .map(|d| module_validator.validate_decl(&d))
                     .collect::<Result<Vec<_>, _>>()?;
 
-                let rc_module = Rc::new(Module {
-                    name: name.clone(),
+                let rc_module = Rc::new(Module::new(
+                    name.clone(),
                     definitions,
-                    entries: module_validator.entries,
-                });
+                    module_validator.entries,
+                ));
                 self.entries
                     .insert(name, Entry::Module(Rc::downgrade(&rc_module)));
                 Ok(Definition::Module(rc_module))

--- a/tools/witx/tests/wasi_unstable.rs
+++ b/tools/witx/tests/wasi_unstable.rs
@@ -21,3 +21,19 @@ fn validate_wasi_ephemeral_preview0() {
 fn validate_wasi_old_preview0() {
     witx::load(Path::new("../../phases/old/witx/wasi_unstable.witx")).unwrap();
 }
+
+#[test]
+fn render_roundtrip() {
+    let doc = witx::load(Path::new(
+        "../../phases/unstable/witx/wasi_unstable_preview0.witx",
+    ))
+    .unwrap();
+
+    let back_to_sexprs = format!("{}", doc);
+    println!("{}", back_to_sexprs);
+    let doc2 = witx::parse(&back_to_sexprs)
+        .map_err(|e| e.report_with(&witx::MockFs::new(&[("-", &back_to_sexprs)])))
+        .unwrap();
+
+    assert_eq!(doc, doc2);
+}


### PR DESCRIPTION
* Friendly public API to `Document` and `Module` - expose a getter and an iterator for each kind of definition in each, rather than expose the internal Vec<Definition>/HashMap<Id, Entry> datastructures.
* Implement `PartialEq` and `Eq` for all AST nodes. The Document and Module implementations are implemented manually, and are not sensitive to the order of definitions.
* Make a standalone `parse(&str) -> Result<Document,...>` function available. This uses `MockFs` under the hood.
* Factor out IO to a separate module in the crate. Add variants of error reporting that looks up the location of the error using `WitxIo`
* Add a `Render` trait that converts AST nodes back into s-expressions. A separate SExpr enum is used because it needs to own `String`s, rather than have refs (`&'a str`) and `Location` throughout. Implement `Display` to render SExprs to text. This allows the validated AST to be serialized to a single string or file.