### PR TITLE
wasi_unstable_preview0.witx: fixes to match current implementations

### DIFF
--- a/phases/ephemeral/witx/wasi_ephemeral_preview0.witx
+++ b/phases/ephemeral/witx/wasi_ephemeral_preview0.witx
@@ -37,6 +37,7 @@
   )
   ;; Return command-line argument data sizes.
   (@interface func (export "environ_sizes_get")
+    (result $error $errno_t)
     ;; The number of arguments.
     (result $argc $size_t)
     ;; The size of the argument string data.
@@ -373,6 +374,7 @@
     ;; file descriptors derived from it.
     (param $fs_rights_base $rights_t)
     (param $fs_rights_inherting $rights_t)
+    (param $flags $fdflags_t)
     (result $error $errno_t)
     ;; The file descriptor of the file that has been opened.
     (result $opened_fd $fd_t)
@@ -468,7 +470,7 @@
 
   ;; Temporarily yield execution of the calling thread.
   ;; Note: This is similar to `sched_yield` in POSIX.
-  (@interface func (export "proc_sched_yield")
+  (@interface func (export "sched_yield")
     (result $error $errno_t)
   )
 

--- a/phases/old/witx/wasi_unstable.witx
+++ b/phases/old/witx/wasi_unstable.witx
@@ -40,6 +40,7 @@
   )
   ;; Return command-line argument data sizes.
   (@interface func (export "environ_sizes_get")
+    (result $error $errno_t)
     ;; The number of arguments.
     (result $argc $size_t)
     ;; The size of the argument string data.
@@ -376,6 +377,7 @@
     ;; file descriptors derived from it.
     (param $fs_rights_base $rights_t)
     (param $fs_rights_inherting $rights_t)
+    (param $flags $fdflags_t)
     (result $error $errno_t)
     ;; The file descriptor of the file that has been opened.
     (result $opened_fd $fd_t)
@@ -471,7 +473,7 @@
 
   ;; Temporarily yield execution of the calling thread.
   ;; Note: This is similar to `sched_yield` in POSIX.
-  (@interface func (export "proc_sched_yield")
+  (@interface func (export "sched_yield")
     (result $error $errno_t)
   )
 

--- a/phases/unstable/witx/wasi_unstable_preview0.witx
+++ b/phases/unstable/witx/wasi_unstable_preview0.witx
@@ -37,6 +37,7 @@
   )
   ;; Return command-line argument data sizes.
   (@interface func (export "environ_sizes_get")
+    (result $error $errno_t)
     ;; The number of arguments.
     (result $argc $size_t)
     ;; The size of the argument string data.
@@ -373,6 +374,7 @@
     ;; file descriptors derived from it.
     (param $fs_rights_base $rights_t)
     (param $fs_rights_inherting $rights_t)
+    (param $flags $fdflags_t)
     (result $error $errno_t)
     ;; The file descriptor of the file that has been opened.
     (result $opened_fd $fd_t)
@@ -468,7 +470,7 @@
 
   ;; Temporarily yield execution of the calling thread.
   ;; Note: This is similar to `sched_yield` in POSIX.
-  (@interface func (export "proc_sched_yield")
+  (@interface func (export "sched_yield")
     (result $error $errno_t)
   )
 


### PR DESCRIPTION
This PR makes changes to `wasi_unstable_preview0.witx` to align with the current implementations (wasi-libc, wasi-common, and the wasi rust crate)

* `environ_sizes_get` returns an `errno_t` as its first result
* `path_open` takes a `fdflags_t` argument.
* `proc_sched_yield` is actually called `sched_yield`

Open question: These changes are seeking to make the witx document descriptive, rather than prescriptive. `wasi_unstable_preview0.witx` is also out of sync with current implementations by using the `wasi_unstable_preview0` module name, where current implementations use `wasi_unstable`.

Should we instead make `phases/old/witx/wasi_unstable.witx` that describes current (pre-`preview0`) implementations? Or should `preview0`?