### PR TITLE
witx crate: calculate module type signature of an interface function

### DIFF
--- a/tools/witx/src/ast.rs
+++ b/tools/witx/src/ast.rs
@@ -137,7 +137,7 @@ pub struct AliasDatatype {
     pub to: DatatypeIdent,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum IntRepr {
     U8,
     U16,
@@ -293,4 +293,11 @@ pub struct InterfaceFunc {
 pub struct InterfaceFuncParam {
     pub name: Id,
     pub type_: DatatypeIdent,
+    pub position: InterfaceFuncParamPosition,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InterfaceFuncParamPosition {
+    Param(usize),
+    Result(usize),
 }

--- a/tools/witx/src/ast.rs
+++ b/tools/witx/src/ast.rs
@@ -57,28 +57,9 @@ impl Document {
 
 impl PartialEq for Document {
     fn eq(&self, rhs: &Document) -> bool {
-        if self.definitions.len() != rhs.definitions.len() {
-            return false;
-        }
-        for d in self.datatypes() {
-            if let Some(d_rhs) = rhs.datatype(&d.name) {
-                if d != d_rhs {
-                    return false;
-                }
-            } else {
-                return false;
-            }
-        }
-        for m in self.modules() {
-            if let Some(m_rhs) = rhs.module(&m.name) {
-                if m != m_rhs {
-                    return false;
-                }
-            } else {
-                return false;
-            }
-        }
-        true
+        // For equality, we don't care about the ordering of definitions,
+        // so we only need to check that the entries map is equal
+        self.entries == rhs.entries
     }
 }
 impl Eq for Document {}
@@ -100,6 +81,28 @@ impl Entry {
         match self {
             Entry::Datatype { .. } => "datatype",
             Entry::Module { .. } => "module",
+        }
+    }
+}
+
+impl PartialEq for Entry {
+    fn eq(&self, rhs: &Entry) -> bool {
+        match (self, rhs) {
+            (Entry::Datatype(d), Entry::Datatype(d_rhs)) => {
+                d.upgrade()
+                    .expect("possible to upgrade entry when part of document")
+                    == d_rhs
+                        .upgrade()
+                        .expect("possible to upgrade entry when part of document")
+            }
+            (Entry::Module(m), Entry::Module(m_rhs)) => {
+                m.upgrade()
+                    .expect("possible to upgrade entry when part of document")
+                    == m_rhs
+                        .upgrade()
+                        .expect("possible to upgrade entry when part of document")
+            }
+            _ => false,
         }
     }
 }
@@ -227,28 +230,9 @@ impl Module {
 
 impl PartialEq for Module {
     fn eq(&self, rhs: &Module) -> bool {
-        if self.definitions.len() != rhs.definitions.len() {
-            return false;
-        }
-        for i in self.imports() {
-            if let Some(i_rhs) = rhs.import(&i.name) {
-                if i != i_rhs {
-                    return false;
-                }
-            } else {
-                return false;
-            }
-        }
-        for f in self.funcs() {
-            if let Some(f_rhs) = rhs.func(&f.name) {
-                if f != f_rhs {
-                    return false;
-                }
-            } else {
-                return false;
-            }
-        }
-        true
+        // For equality, we don't care about the ordering of definitions,
+        // so we only need to check that the entries map is equal
+        self.entries == rhs.entries
     }
 }
 impl Eq for Module {}
@@ -263,6 +247,28 @@ pub enum ModuleDefinition {
 pub enum ModuleEntry {
     Import(Weak<ModuleImport>),
     Func(Weak<InterfaceFunc>),
+}
+
+impl PartialEq for ModuleEntry {
+    fn eq(&self, rhs: &ModuleEntry) -> bool {
+        match (self, rhs) {
+            (ModuleEntry::Import(i), ModuleEntry::Import(i_rhs)) => {
+                i.upgrade()
+                    .expect("always possible to upgrade moduleentry when part of module")
+                    == i_rhs
+                        .upgrade()
+                        .expect("always possible to upgrade moduleentry when part of module")
+            }
+            (ModuleEntry::Func(i), ModuleEntry::Func(i_rhs)) => {
+                i.upgrade()
+                    .expect("always possible to upgrade moduleentry when part of module")
+                    == i_rhs
+                        .upgrade()
+                        .expect("always possible to upgrade moduleentry when part of module")
+            }
+            _ => false,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/tools/witx/src/lib.rs
+++ b/tools/witx/src/lib.rs
@@ -4,6 +4,8 @@ mod ast;
 mod io;
 /// Lexer text into tokens
 mod lexer;
+/// Determine module type of function
+mod moduletype;
 /// Witx syntax parsing from SExprs
 mod parser;
 /// Render ast to text
@@ -17,12 +19,15 @@ mod validate;
 
 pub use ast::{
     AliasDatatype, BuiltinType, Datatype, DatatypeIdent, DatatypeVariant, Definition, Document,
-    Entry, EnumDatatype, FlagsDatatype, Id, IntRepr, InterfaceFunc, InterfaceFuncParam, Module,
-    ModuleDefinition, ModuleEntry, ModuleImport, ModuleImportVariant, StructDatatype, StructMember,
-    UnionDatatype, UnionVariant,
+    Entry, EnumDatatype, FlagsDatatype, Id, IntRepr, InterfaceFunc, InterfaceFuncParam,
+    InterfaceFuncParamPosition, Module, ModuleDefinition, ModuleEntry, ModuleImport,
+    ModuleImportVariant, StructDatatype, StructMember, UnionDatatype, UnionVariant,
 };
 pub use io::{Filesystem, MockFs, WitxIo};
 pub use lexer::LexError;
+pub use moduletype::{
+    AtomType, DatatypePassedBy, ModuleFuncType, ModuleParamSignifies, ModuleParamType,
+};
 pub use parser::{DeclSyntax, ParseError};
 pub use render::{Render, SExpr as RenderSExpr};
 pub use sexpr::SExprParseError;

--- a/tools/witx/src/lib.rs
+++ b/tools/witx/src/lib.rs
@@ -1,11 +1,11 @@
 /// Types describing a validated witx document
 mod ast;
+/// Map witx types to core (wasm standard) types
+mod coretypes;
 /// Interface for filesystem or mock IO
 mod io;
 /// Lexer text into tokens
 mod lexer;
-/// Determine module type of function
-mod moduletype;
 /// Witx syntax parsing from SExprs
 mod parser;
 /// Render ast to text
@@ -23,11 +23,9 @@ pub use ast::{
     InterfaceFuncParamPosition, Module, ModuleDefinition, ModuleEntry, ModuleImport,
     ModuleImportVariant, StructDatatype, StructMember, UnionDatatype, UnionVariant,
 };
+pub use coretypes::{AtomType, CoreFuncType, CoreParamSignifies, CoreParamType, DatatypePassedBy};
 pub use io::{Filesystem, MockFs, WitxIo};
 pub use lexer::LexError;
-pub use moduletype::{
-    AtomType, DatatypePassedBy, ModuleFuncType, ModuleParamSignifies, ModuleParamType,
-};
 pub use parser::{DeclSyntax, ParseError};
 pub use render::{Render, SExpr as RenderSExpr};
 pub use sexpr::SExprParseError;

--- a/tools/witx/src/moduletype.rs
+++ b/tools/witx/src/moduletype.rs
@@ -1,0 +1,176 @@
+use crate::{
+    BuiltinType, DatatypeIdent, DatatypeVariant, IntRepr, InterfaceFunc, InterfaceFuncParam,
+};
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+/// Enumerates the types permitted for function arguments in a WebAssembly module
+pub enum AtomType {
+    I32,
+    I64,
+    F32,
+    F64,
+}
+
+impl From<IntRepr> for AtomType {
+    fn from(i: IntRepr) -> AtomType {
+        match i {
+            IntRepr::U8 | IntRepr::U16 | IntRepr::U32 => AtomType::I32,
+            IntRepr::U64 => AtomType::I64,
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+/// Enumerates the strategies which may be used to pass a datatype as an argument
+pub enum DatatypePassedBy {
+    /// Pass by value specifies the AtomType used to represent that value
+    Value(AtomType),
+    /// Pass by a pointer into linear memory
+    Pointer,
+    /// Pass by a pointer and length pair, into linear memory
+    PointerLengthPair,
+}
+
+impl DatatypeIdent {
+    /// Determine the simplest strategy by which a type may be passed. Value always preferred over
+    /// Pointer.
+    pub fn passed_by(&self) -> DatatypePassedBy {
+        match &self {
+            DatatypeIdent::Builtin(b) => match b {
+                BuiltinType::String | BuiltinType::Data => DatatypePassedBy::PointerLengthPair,
+                BuiltinType::U8
+                | BuiltinType::U16
+                | BuiltinType::U32
+                | BuiltinType::S8
+                | BuiltinType::S16
+                | BuiltinType::S32 => DatatypePassedBy::Value(AtomType::I32),
+                BuiltinType::U64 | BuiltinType::S64 => DatatypePassedBy::Value(AtomType::I64),
+                BuiltinType::F32 => DatatypePassedBy::Value(AtomType::F32),
+                BuiltinType::F64 => DatatypePassedBy::Value(AtomType::F64),
+            },
+            DatatypeIdent::Array { .. } => DatatypePassedBy::PointerLengthPair,
+            DatatypeIdent::Pointer { .. } | DatatypeIdent::ConstPointer { .. } => {
+                DatatypePassedBy::Value(AtomType::I32)
+            }
+            DatatypeIdent::Ident(i) => match &i.variant {
+                DatatypeVariant::Alias(a) => a.to.passed_by(),
+                DatatypeVariant::Enum(e) => DatatypePassedBy::Value(e.repr.into()),
+                DatatypeVariant::Flags(f) => DatatypePassedBy::Value(f.repr.into()),
+                DatatypeVariant::Struct { .. } | DatatypeVariant::Union { .. } => {
+                    DatatypePassedBy::Pointer
+                }
+            },
+        }
+    }
+}
+
+/// A parameter in the module type of a function.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ModuleParamType {
+    /// The interface function parameter to which this
+    pub param: InterfaceFuncParam,
+    /// The relationship of the module type parameter to the function interface parameter
+    pub signifies: ModuleParamSignifies,
+}
+
+impl ModuleParamType {
+    /// Representation of the module type parameter. This is the type that will appear
+    /// in the function's module type signature.
+    pub fn repr(&self) -> AtomType {
+        self.signifies.repr()
+    }
+}
+
+/// Enumerates the sort of relationship an module type parameter to an interface function
+/// parameter.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ModuleParamSignifies {
+    /// Module type represents the value using an AtomType
+    Value(AtomType),
+    /// Module type represents a pointer into linear memory
+    PointerTo,
+    /// Module type represents a length of a region of linear memory
+    LengthOf,
+}
+
+impl ModuleParamSignifies {
+    /// Representation of the module type parameter.
+    pub fn repr(&self) -> AtomType {
+        match self {
+            ModuleParamSignifies::Value(a) => *a,
+            ModuleParamSignifies::PointerTo | ModuleParamSignifies::LengthOf => AtomType::I32,
+        }
+    }
+}
+
+impl InterfaceFuncParam {
+    /// Gives the module type that corresponds to passing this interface func parameter by value.
+    /// Not all types can be passed by value: those which cannot return None
+    pub fn pass_by_value(&self) -> Option<ModuleParamType> {
+        match self.type_.passed_by() {
+            DatatypePassedBy::Value(atom) => Some(ModuleParamType {
+                signifies: ModuleParamSignifies::Value(atom),
+                param: self.clone(),
+            }),
+            DatatypePassedBy::Pointer | DatatypePassedBy::PointerLengthPair => None,
+        }
+    }
+
+    /// Gives the module types that correspond to passing this interface func parameter
+    /// by reference. Some types are passed by reference using a single pointer, others
+    /// require both a pointer and length.
+    pub fn pass_by_reference(&self) -> Vec<ModuleParamType> {
+        match self.type_.passed_by() {
+            DatatypePassedBy::Value(_) | DatatypePassedBy::Pointer => vec![ModuleParamType {
+                signifies: ModuleParamSignifies::PointerTo,
+                param: self.clone(),
+            }],
+            DatatypePassedBy::PointerLengthPair => vec![
+                ModuleParamType {
+                    signifies: ModuleParamSignifies::PointerTo,
+                    param: self.clone(),
+                },
+                ModuleParamType {
+                    signifies: ModuleParamSignifies::LengthOf,
+                    param: self.clone(),
+                },
+            ],
+        }
+    }
+}
+
+/// Describes the module type signature of a function
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ModuleFuncType {
+    pub args: Vec<ModuleParamType>,
+    pub ret: Option<ModuleParamType>,
+}
+
+impl InterfaceFunc {
+    /// Get the module type signature for this interface function
+    pub fn module_type(&self) -> ModuleFuncType {
+        let mut results = self.results.iter();
+        // The ret value is the first result (if there is one), passed
+        // by value.
+        let ret = results.next().map(|param| {
+            param
+                .pass_by_value()
+                .expect("validation ensures first result can be passed by value")
+        });
+        let args = self
+            .params
+            .iter()
+            .flat_map(|param| {
+                // interface function parameters are passed by value if possible,
+                // and fall back on passing by reference.
+                param
+                    .pass_by_value()
+                    .map(|ptype| vec![ptype])
+                    .unwrap_or_else(|| param.pass_by_reference())
+            })
+            // Then, the remaining results are passed by reference.
+            .chain(results.flat_map(|param| param.pass_by_reference()))
+            .collect();
+        ModuleFuncType { args, ret }
+    }
+}


### PR DESCRIPTION
Also ports in a fix that should have been in #96 .

This PR defines a mapping of interface function types to module types. This mapping reflects the way witx maps to the existing implementations of WASI:
* Array, Data, and String types are passed as a pointer and a length
* Structs and Union types are passed as a pointer
* Pointer and ConstPointer are passed as I32. This is considered passing by value.
* All other types can be passed by value - integer and floats get mapped to the smallest atom that can represent them.
* the first result type is returned by value. validation requires that a pass-by-value datatype is used here.
* subsequent result types are passed as arguments, by reference.