### PR TITLE
Remove the "data" builtin type.

### DIFF
--- a/tools/witx/src/parser.rs
+++ b/tools/witx/src/parser.rs
@@ -63,7 +63,6 @@ macro_rules! id {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BuiltinType {
     String,
-    Data,
     U8,
     U16,
     U32,
@@ -97,7 +96,6 @@ impl BuiltinType {
     pub fn parse(sexpr: &SExpr) -> Result<Self, ParseError> {
         match sexpr {
             SExpr::Word("string", _loc) => Ok(BuiltinType::String),
-            SExpr::Word("data", _loc) => Ok(BuiltinType::Data),
             SExpr::Word("u8", _loc) => Ok(BuiltinType::U8),
             SExpr::Word("u16", _loc) => Ok(BuiltinType::U16),
             SExpr::Word("u32", _loc) => Ok(BuiltinType::U32),

--- a/tools/witx/src/parser.rs
+++ b/tools/witx/src/parser.rs
@@ -79,7 +79,6 @@ impl BuiltinType {
     pub fn starts_parsing(sexpr: &SExpr) -> bool {
         match sexpr {
             SExpr::Word("string", _)
-            | SExpr::Word("data", _)
             | SExpr::Word("u8", _)
             | SExpr::Word("u16", _)
             | SExpr::Word("u32", _)

--- a/tools/witx/src/render.rs
+++ b/tools/witx/src/render.rs
@@ -72,7 +72,6 @@ impl Render for BuiltinType {
     fn to_sexpr(&self) -> SExpr {
         match self {
             BuiltinType::String => SExpr::word("string"),
-            BuiltinType::Data => SExpr::word("data"),
             BuiltinType::U8 => SExpr::word("u8"),
             BuiltinType::U16 => SExpr::word("u16"),
             BuiltinType::U32 => SExpr::word("u32"),


### PR DESCRIPTION
"data" isn't currently used by any witx files; we're using `pointer`
and `const_pointer` with explicit lengths instead, as these handle
mutable buffers in a much simpler way.