### PR TITLE
fix & release witx 0.3.0

### DIFF
--- a/tools/witx/Cargo.toml
+++ b/tools/witx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "witx"
-version = "0.2.0"
+version = "0.3.0"
 description = "Parse and validate witx file format"
 homepage = "https://github.com/WebAssembly/WASI"
 repository = "https://github.com/WebAssembly/WASI"

--- a/tools/witx/src/coretypes.rs
+++ b/tools/witx/src/coretypes.rs
@@ -37,7 +37,7 @@ impl DatatypeIdent {
     pub fn passed_by(&self) -> DatatypePassedBy {
         match &self {
             DatatypeIdent::Builtin(b) => match b {
-                BuiltinType::String | BuiltinType::Data => DatatypePassedBy::PointerLengthPair,
+                BuiltinType::String => DatatypePassedBy::PointerLengthPair,
                 BuiltinType::U8
                 | BuiltinType::U16
                 | BuiltinType::U32


### PR DESCRIPTION
The merge of #102 followed by #101 left in a use of BuiltinType::Data that breaks witx.

Fix that, and bump the version to 0.3.0 for publishing on crates.io