### PR TITLE
Update the logistics for the 10-15 in-person meeting.

### DIFF
--- a/meetings/2019/WASI-10-15.md
+++ b/meetings/2019/WASI-10-15.md
@@ -10,8 +10,13 @@
 
 ### Registration
 
-None required if you've attended before. Email Dan Gohman to sign up if it's
-your first time. The meeting is open to CG members only.
+This meeting is open to WebAssembly CG members only. To register, please
+visit the CG participants page:
+
+https://www.w3.org/community/webassembly/participants
+
+Also, the host for this in-person meeting has requested we provide a list
+of attendees, so please email Dan Gohman if you plan on attending.
 
 ## Agenda items
 


### PR DESCRIPTION
Attendees of this meeting should be members of the WebAssembly CG;
see the included link for details.

And, the host for this in-person meeting has requested we provide a
list of attendees, so please email Dan Gohman if you plan on
attending.