### PR TITLE
Remove the "0" from the ephemeral module name.

### DIFF
--- a/phases/ephemeral/witx/wasi_ephemeral_preview.witx
+++ b/phases/ephemeral/witx/wasi_ephemeral_preview.witx
@@ -8,7 +8,7 @@
 
 (use "typenames.witx")
 
-(module $wasi_ephemeral_preview0
+(module $wasi_ephemeral_preview
   ;; Linear memory to be accessed by WASI functions that need it.
   (import "memory" (memory))
 

--- a/tools/witx/tests/wasi_unstable.rs
+++ b/tools/witx/tests/wasi_unstable.rs
@@ -10,9 +10,9 @@ fn validate_wasi_unstable_preview0() {
 }
 
 #[test]
-fn validate_wasi_ephemeral_preview0() {
+fn validate_wasi_ephemeral_preview() {
     witx::load(Path::new(
-        "../../phases/ephemeral/witx/wasi_ephemeral_preview0.witx",
+        "../../phases/ephemeral/witx/wasi_ephemeral_preview.witx",
     ))
     .unwrap();
 }


### PR DESCRIPTION
The ephemeral module isn't meant to be versioned, so remove the "0"
version number.