### PR TITLE
Reorder the `clockid_t` values to match existing practice.

### DIFF
--- a/phases/ephemeral/docs/wasi_ephemeral_preview.md
+++ b/phases/ephemeral/docs/wasi_ephemeral_preview.md
@@ -1113,6 +1113,11 @@ Used by [`__wasi_subscription_t`](#subscription), [`__wasi_clock_res_get()`](#cl
 
 Possible values:
 
+- <a href="#clockid.realtime" name="clockid.realtime"></a>**`__WASI_CLOCK_REALTIME`**
+
+    The clock measuring real time. Time value
+    zero corresponds with 1970-01-01T00:00:00Z.
+
 - <a href="#clockid.monotonic" name="clockid.monotonic"></a>**`__WASI_CLOCK_MONOTONIC`**
 
     The store-wide monotonic clock, which is defined as a
@@ -1126,11 +1131,6 @@ Possible values:
 
     The CPU-time clock associated with the current
     process.
-
-- <a href="#clockid.realtime" name="clockid.realtime"></a>**`__WASI_CLOCK_REALTIME`**
-
-    The clock measuring real time. Time value
-    zero corresponds with 1970-01-01T00:00:00Z.
 
 - <a href="#clockid.thread_cputime_id" name="clockid.thread_cputime_id"></a>**`__WASI_CLOCK_THREAD_CPUTIME_ID`**
 

--- a/phases/ephemeral/witx/typenames.witx
+++ b/phases/ephemeral/witx/typenames.witx
@@ -16,6 +16,9 @@
 ;; Identifiers for clocks.
 (typename $clockid_t
   (enum u32
+    ;; The clock measuring real time. Time value zero corresponds with
+    ;; 1970-01-01T00:00:00Z.
+    $CLOCK_REALTIME
     ;; The store-wide monotonic clock, which is defined as a clock measuring
     ;; real time, whose value cannot be adjusted and which cannot have negative
     ;; clock jumps. The epoch of this clock is undefined. The absolute time
@@ -23,9 +26,6 @@
     $CLOCK_MONOTONIC
     ;; The CPU-time clock associated with the current process.
     $CLOCK_PROCESS_CPUTIME_ID
-    ;; The clock measuring real time. Time value zero corresponds with
-    ;; 1970-01-01T00:00:00Z.
-    $CLOCK_REALTIME
     ;; The CPU-time clock associated with the current thread.
     $CLOCK_THREAD_CPUTIME_ID
   )

--- a/phases/old/docs/wasi_unstable_preview0.md
+++ b/phases/old/docs/wasi_unstable_preview0.md
@@ -1113,6 +1113,11 @@ Used by [`__wasi_subscription_t`](#subscription), [`__wasi_clock_res_get()`](#cl
 
 Possible values:
 
+- <a href="#clockid.realtime" name="clockid.realtime"></a>**`__WASI_CLOCK_REALTIME`**
+
+    The clock measuring real time. Time value
+    zero corresponds with 1970-01-01T00:00:00Z.
+
 - <a href="#clockid.monotonic" name="clockid.monotonic"></a>**`__WASI_CLOCK_MONOTONIC`**
 
     The store-wide monotonic clock, which is defined as a
@@ -1126,11 +1131,6 @@ Possible values:
 
     The CPU-time clock associated with the current
     process.
-
-- <a href="#clockid.realtime" name="clockid.realtime"></a>**`__WASI_CLOCK_REALTIME`**
-
-    The clock measuring real time. Time value
-    zero corresponds with 1970-01-01T00:00:00Z.
 
 - <a href="#clockid.thread_cputime_id" name="clockid.thread_cputime_id"></a>**`__WASI_CLOCK_THREAD_CPUTIME_ID`**
 

--- a/phases/old/witx/typenames.witx
+++ b/phases/old/witx/typenames.witx
@@ -16,6 +16,9 @@
 ;; Identifiers for clocks.
 (typename $clockid_t
   (enum u32
+    ;; The clock measuring real time. Time value zero corresponds with
+    ;; 1970-01-01T00:00:00Z.
+    $CLOCK_REALTIME
     ;; The store-wide monotonic clock, which is defined as a clock measuring
     ;; real time, whose value cannot be adjusted and which cannot have negative
     ;; clock jumps. The epoch of this clock is undefined. The absolute time
@@ -23,9 +26,6 @@
     $CLOCK_MONOTONIC
     ;; The CPU-time clock associated with the current process.
     $CLOCK_PROCESS_CPUTIME_ID
-    ;; The clock measuring real time. Time value zero corresponds with
-    ;; 1970-01-01T00:00:00Z.
-    $CLOCK_REALTIME
     ;; The CPU-time clock associated with the current thread.
     $CLOCK_THREAD_CPUTIME_ID
   )

--- a/phases/unstable/docs/wasi_unstable_preview0.md
+++ b/phases/unstable/docs/wasi_unstable_preview0.md
@@ -1113,6 +1113,11 @@ Used by [`__wasi_subscription_t`](#subscription), [`__wasi_clock_res_get()`](#cl
 
 Possible values:
 
+- <a href="#clockid.realtime" name="clockid.realtime"></a>**`__WASI_CLOCK_REALTIME`**
+
+    The clock measuring real time. Time value
+    zero corresponds with 1970-01-01T00:00:00Z.
+
 - <a href="#clockid.monotonic" name="clockid.monotonic"></a>**`__WASI_CLOCK_MONOTONIC`**
 
     The store-wide monotonic clock, which is defined as a
@@ -1126,11 +1131,6 @@ Possible values:
 
     The CPU-time clock associated with the current
     process.
-
-- <a href="#clockid.realtime" name="clockid.realtime"></a>**`__WASI_CLOCK_REALTIME`**
-
-    The clock measuring real time. Time value
-    zero corresponds with 1970-01-01T00:00:00Z.
 
 - <a href="#clockid.thread_cputime_id" name="clockid.thread_cputime_id"></a>**`__WASI_CLOCK_THREAD_CPUTIME_ID`**
 

--- a/phases/unstable/witx/typenames.witx
+++ b/phases/unstable/witx/typenames.witx
@@ -16,6 +16,9 @@
 ;; Identifiers for clocks.
 (typename $clockid_t
   (enum u32
+    ;; The clock measuring real time. Time value zero corresponds with
+    ;; 1970-01-01T00:00:00Z.
+    $CLOCK_REALTIME
     ;; The store-wide monotonic clock, which is defined as a clock measuring
     ;; real time, whose value cannot be adjusted and which cannot have negative
     ;; clock jumps. The epoch of this clock is undefined. The absolute time
@@ -23,9 +26,6 @@
     $CLOCK_MONOTONIC
     ;; The CPU-time clock associated with the current process.
     $CLOCK_PROCESS_CPUTIME_ID
-    ;; The clock measuring real time. Time value zero corresponds with
-    ;; 1970-01-01T00:00:00Z.
-    $CLOCK_REALTIME
     ;; The CPU-time clock associated with the current thread.
     $CLOCK_THREAD_CPUTIME_ID
   )


### PR DESCRIPTION
Move `CLOCK_REALTIME` to be the first `clockid_t` value. This change
reflects the definitions used in [existing practice], so this patch
updates the `wasi_unstable_preview0` and `wasi_unstable` definitions
as well.

This is the same change as #41, but updated for the WASI repository's
new phases directory structure.

[existing practice]: https://github.com/CraneStation/wasi-libc/blob/master/libc-bottom-half/headers/public/wasi/core.h#L42