### PR TITLE
witx: add handles kind

### DIFF
--- a/phases/ephemeral/witx/typenames.witx
+++ b/phases/ephemeral/witx/typenames.witx
@@ -273,8 +273,8 @@
   )
 )
 
-;;; A file descriptor index.
-(typename $fd u32)
+;;; A file descriptor handle.
+(typename $fd (handle))
 
 ;;; A region of memory for scatter/gather reads.
 (typename $iovec

--- a/tools/witx/src/ast.rs
+++ b/tools/witx/src/ast.rs
@@ -130,6 +130,21 @@ pub enum DatatypeVariant {
     Flags(FlagsDatatype),
     Struct(StructDatatype),
     Union(UnionDatatype),
+    Handle(HandleDatatype),
+}
+
+impl DatatypeVariant {
+    pub fn kind(&self) -> &'static str {
+        use DatatypeVariant::*;
+        match self {
+            Alias(_) => "alias",
+            Enum(_) => "enum",
+            Flags(_) => "flags",
+            Struct(_) => "struct",
+            Union(_) => "union",
+            Handle(_) => "handle",
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -196,6 +211,12 @@ pub struct UnionVariant {
     pub name: Id,
     pub type_: DatatypeIdent,
     pub docs: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HandleDatatype {
+    pub name: Id,
+    pub supertypes: Vec<DatatypeIdent>,
 }
 
 #[derive(Debug, Clone)]

--- a/tools/witx/src/coretypes.rs
+++ b/tools/witx/src/coretypes.rs
@@ -59,6 +59,7 @@ impl DatatypeIdent {
                 DatatypeVariant::Struct { .. } | DatatypeVariant::Union { .. } => {
                     DatatypePassedBy::Pointer
                 }
+                DatatypeVariant::Handle { .. } => DatatypePassedBy::Value(AtomType::I32),
             },
         }
     }

--- a/tools/witx/src/docs.rs
+++ b/tools/witx/src/docs.rs
@@ -68,6 +68,7 @@ impl Documentation for DatatypeVariant {
             DatatypeVariant::Flags(a) => a.to_md(),
             DatatypeVariant::Struct(a) => a.to_md(),
             DatatypeVariant::Union(a) => a.to_md(),
+            DatatypeVariant::Handle(a) => a.to_md(),
         }
     }
 }
@@ -148,6 +149,17 @@ impl Documentation for UnionDatatype {
     }
 }
 
+impl Documentation for HandleDatatype {
+    fn to_md(&self) -> String {
+        let supertypes = self
+            .supertypes
+            .iter()
+            .map(|s| format!("* {}", s.name()))
+            .collect::<Vec<String>>()
+            .join("\n");
+        format!("### Handle supertypes:\n{}\n", supertypes)
+    }
+}
 impl IntRepr {
     fn name(&self) -> &'static str {
         match self {

--- a/tools/witx/src/lib.rs
+++ b/tools/witx/src/lib.rs
@@ -17,9 +17,10 @@ mod validate;
 
 pub use ast::{
     AliasDatatype, BuiltinType, Datatype, DatatypeIdent, DatatypeVariant, Definition, Document,
-    Entry, EnumDatatype, EnumVariant, FlagsDatatype, FlagsMember, Id, IntRepr, InterfaceFunc,
-    InterfaceFuncParam, InterfaceFuncParamPosition, Module, ModuleDefinition, ModuleEntry,
-    ModuleImport, ModuleImportVariant, StructDatatype, StructMember, UnionDatatype, UnionVariant,
+    Entry, EnumDatatype, EnumVariant, FlagsDatatype, FlagsMember, HandleDatatype, Id, IntRepr,
+    InterfaceFunc, InterfaceFuncParam, InterfaceFuncParamPosition, Module, ModuleDefinition,
+    ModuleEntry, ModuleImport, ModuleImportVariant, StructDatatype, StructMember, UnionDatatype,
+    UnionVariant,
 };
 pub use coretypes::{AtomType, CoreFuncType, CoreParamSignifies, CoreParamType, DatatypePassedBy};
 pub use docs::Documentation;

--- a/tools/witx/src/parser.rs
+++ b/tools/witx/src/parser.rs
@@ -23,6 +23,7 @@ mod kw {
     wast::custom_keyword!(f64);
     wast::custom_keyword!(field);
     wast::custom_keyword!(flags);
+    wast::custom_keyword!(handle);
     wast::custom_keyword!(pointer);
     wast::custom_keyword!(r#enum = "enum");
     wast::custom_keyword!(r#struct = "struct");
@@ -333,6 +334,7 @@ pub enum TypedefSyntax<'a> {
     Flags(FlagsSyntax<'a>),
     Struct(StructSyntax<'a>),
     Union(UnionSyntax<'a>),
+    Handle(HandleSyntax<'a>),
 }
 
 impl<'a> Parse<'a> for TypedefSyntax<'a> {
@@ -351,6 +353,8 @@ impl<'a> Parse<'a> for TypedefSyntax<'a> {
                 Ok(TypedefSyntax::Struct(parser.parse()?))
             } else if l.peek::<kw::r#union>() {
                 Ok(TypedefSyntax::Union(parser.parse()?))
+            } else if l.peek::<kw::handle>() {
+                Ok(TypedefSyntax::Handle(parser.parse()?))
             } else {
                 Err(l.error())
             }
@@ -443,6 +447,22 @@ impl<'a> Parse<'a> for UnionSyntax<'a> {
             fields.push(parser.parse()?);
         }
         Ok(UnionSyntax { fields })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HandleSyntax<'a> {
+    pub supertypes: Vec<wast::Id<'a>>,
+}
+
+impl<'a> Parse<'a> for HandleSyntax<'a> {
+    fn parse(parser: Parser<'a>) -> Result<Self> {
+        parser.parse::<kw::handle>()?;
+        let mut supertypes = Vec::new();
+        while !parser.is_empty() {
+            supertypes.push(parser.parse()?);
+        }
+        Ok(HandleSyntax { supertypes })
     }
 }
 

--- a/tools/witx/src/render.rs
+++ b/tools/witx/src/render.rs
@@ -135,6 +135,7 @@ impl Render for DatatypeVariant {
             DatatypeVariant::Flags(a) => a.to_sexpr(),
             DatatypeVariant::Struct(a) => a.to_sexpr(),
             DatatypeVariant::Union(a) => a.to_sexpr(),
+            DatatypeVariant::Handle(a) => a.to_sexpr(),
         }
     }
 }
@@ -211,6 +212,17 @@ impl Render for UnionDatatype {
     }
 }
 
+impl Render for HandleDatatype {
+    fn to_sexpr(&self) -> SExpr {
+        let header = vec![SExpr::word("handle")];
+        let supertypes = self
+            .supertypes
+            .iter()
+            .map(|s| s.to_sexpr())
+            .collect::<Vec<SExpr>>();
+        SExpr::Vec([header, supertypes].concat())
+    }
+}
 impl Render for IntRepr {
     fn to_sexpr(&self) -> SExpr {
         match self {


### PR DESCRIPTION
`handle` is a kind of datatype for foreign references, or capabilities: it is opaque (has no in-memory representation), and is passed as a u32 index.

In ephemeral, `fd_t` is changed to be a handle, rather than a u32.