### PR TITLE
Remove `subscription_t`'s `clock.identifier` field.

### DIFF
--- a/phases/ephemeral/witx/typenames.witx
+++ b/phases/ephemeral/witx/typenames.witx
@@ -552,8 +552,6 @@
 ;; The contents of a $subscription_t when type is `EVENTTYPE_CLOCK`.
 (typename $subscription_clock_t
   (struct
-    ;; The user-defined unique identifier of the clock.
-    (field $identifier $userdata_t)
     ;; The clock against which to compare the timestamp.
     (field $clock_id $clockid_t)
     ;; The absolute or relative timestamp.


### PR DESCRIPTION
As noticed in
https://github.com/rust-lang/rust/pull/65617#issue-330088745,
the `clock.identifier` field in `subscription_t` isn't used for
anything. It came from CloudABI, where it appears to be a holdover from
an earlier API feature which is no longer present.