### PR TITLE
Change hard link count to 64-bits.

### DIFF
--- a/phases/ephemeral/docs/wasi_ephemeral_preview.md
+++ b/phases/ephemeral/docs/wasi_ephemeral_preview.md
@@ -1799,7 +1799,7 @@ Members:
 
     The address and length of the buffer to be filled.
 
-### <a href="#linkcount" name="linkcount"></a>`__wasi_linkcount_t` (`uint32_t`)
+### <a href="#linkcount" name="linkcount"></a>`__wasi_linkcount_t` (`uint64_t`)
 
 Number of hard links to an inode.
 

--- a/phases/ephemeral/witx/typenames.witx
+++ b/phases/ephemeral/witx/typenames.witx
@@ -451,7 +451,7 @@
 )
 
 ;; Number of hard links to an inode.
-(typename $linkcount_t u32)
+(typename $linkcount_t u64)
 
 ;; File attributes.
 (typename $filestat_t


### PR DESCRIPTION
This commit changes the type for `__wasi_linkcount_t` to 64-bits to support
large link counts.

Fixes #70.