### PR TITLE
Fix the missing `flags` field in `subscription_clock_t`.

### DIFF
--- a/phases/ephemeral/witx/typenames.witx
+++ b/phases/ephemeral/witx/typenames.witx
@@ -560,9 +560,9 @@
     (field $timeout $timestamp_t)
     ;; The amount of time that the implementation may wait additionally
     ;; to coalesce with other events.
-    ;;
-    ;; Flags specifying whether the timeout is absolute or relative
     (field $precision $timestamp_t)
+    ;; Flags specifying whether the timeout is absolute or relative
+    (field $flags $subclockflags_t)
   )
 )
 

--- a/phases/old/witx/typenames.witx
+++ b/phases/old/witx/typenames.witx
@@ -560,9 +560,9 @@
     (field $timeout $timestamp_t)
     ;; The amount of time that the implementation may wait additionally
     ;; to coalesce with other events.
-    ;;
-    ;; Flags specifying whether the timeout is absolute or relative
     (field $precision $timestamp_t)
+    ;; Flags specifying whether the timeout is absolute or relative
+    (field $flags $subclockflags_t)
   )
 )
 

--- a/phases/unstable/witx/typenames.witx
+++ b/phases/unstable/witx/typenames.witx
@@ -560,9 +560,9 @@
     (field $timeout $timestamp_t)
     ;; The amount of time that the implementation may wait additionally
     ;; to coalesce with other events.
-    ;;
-    ;; Flags specifying whether the timeout is absolute or relative
     (field $precision $timestamp_t)
+    ;; Flags specifying whether the timeout is absolute or relative
+    (field $flags $subclockflags_t)
   )
 )
 


### PR DESCRIPTION
Add the `flags` field to `subscription_clock_t`, which was accidentally
omitted. This change reflects the definitions used in [existing practice],
so this patch updates the `wasi_unstable_preview0` and `wasi_unstable`
definitions as well.

[existing practice]: https://github.com/CraneStation/wasi-libc/blob/master/libc-bottom-half/headers/public/wasi/core.h#L421