### PR TITLE
Fix CI on Windows.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Install Rust (rustup)
+      shell: bash
       run: rustup update stable --no-self-update && rustup default stable
       if: matrix.os != 'macos-latest'
     - name: Install Rust (macos)


### PR DESCRIPTION
Use `bash` as the default shell for installing Rust as `&&` is not a valid
command separator in PowerShell.