### PR TITLE
Make `eventtype_t` an enum rather than a flags.

### DIFF
--- a/phases/ephemeral/witx/typenames.witx
+++ b/phases/ephemeral/witx/typenames.witx
@@ -483,16 +483,16 @@
 
 ;; Type of a subscription to an event or its occurrence.
 (typename $eventtype_t
-  (flags u8
+  (enum u8
     ;; The time value of clock `subscription_t::u.clock.clock_id` has
     ;; reached timestamp `subscription_t::u.clock.timeout`.
-    (flag $EVENTTYPE_CLOCK)
+    $EVENTTYPE_CLOCK
     ;; File descriptor `subscription_t::u.fd_readwrite.fd` has data
     ;; available for reading. This event always triggers for regular files.
-    (flag $EVENTTYPE_FD_READ)
+    $EVENTTYPE_FD_READ
     ;; File descriptor `subscription_t::u.fd_readwrite.fd` has capacity
     ;; available for writing. This event always triggers for regular files.
-    (flag $EVENTTYPE_FD_WRITE)
+    $EVENTTYPE_FD_WRITE
   )
 )
 

--- a/phases/old/witx/typenames.witx
+++ b/phases/old/witx/typenames.witx
@@ -481,16 +481,16 @@
 
 ;; Type of a subscription to an event or its occurrence.
 (typename $eventtype_t
-  (flags u8
+  (enum u8
     ;; The time value of clock `subscription_t::u.clock.clock_id` has
     ;; reached timestamp `subscription_t::u.clock.timeout`.
-    (flag $EVENTTYPE_CLOCK)
+    $EVENTTYPE_CLOCK
     ;; File descriptor `subscription_t::u.fd_readwrite.fd` has data
     ;; available for reading. This event always triggers for regular files.
-    (flag $EVENTTYPE_FD_READ)
+    $EVENTTYPE_FD_READ
     ;; File descriptor `subscription_t::u.fd_readwrite.fd` has capacity
     ;; available for writing. This event always triggers for regular files.
-    (flag $EVENTTYPE_FD_WRITE)
+    $EVENTTYPE_FD_WRITE
   )
 )
 

--- a/phases/unstable/witx/typenames.witx
+++ b/phases/unstable/witx/typenames.witx
@@ -481,16 +481,16 @@
 
 ;; Type of a subscription to an event or its occurrence.
 (typename $eventtype_t
-  (flags u8
+  (enum u8
     ;; The time value of clock `subscription_t::u.clock.clock_id` has
     ;; reached timestamp `subscription_t::u.clock.timeout`.
-    (flag $EVENTTYPE_CLOCK)
+    $EVENTTYPE_CLOCK
     ;; File descriptor `subscription_t::u.fd_readwrite.fd` has data
     ;; available for reading. This event always triggers for regular files.
-    (flag $EVENTTYPE_FD_READ)
+    $EVENTTYPE_FD_READ
     ;; File descriptor `subscription_t::u.fd_readwrite.fd` has capacity
     ;; available for writing. This event always triggers for regular files.
-    (flag $EVENTTYPE_FD_WRITE)
+    $EVENTTYPE_FD_WRITE
   )
 )
 


### PR DESCRIPTION
This matches existing practice, so update the `unstable` and `old`
definitions too.