### PR TITLE
Mechanical witx naming convention changes

### DIFF
--- a/phases/ephemeral/witx/typenames.witx
+++ b/phases/ephemeral/witx/typenames.witx
@@ -18,16 +18,16 @@
   (enum u32
     ;;; The clock measuring real time. Time value zero corresponds with
     ;;; 1970-01-01T00:00:00Z.
-    $clock_realtime
+    $realtime
     ;;; The store-wide monotonic clock, which is defined as a clock measuring
     ;;; real time, whose value cannot be adjusted and which cannot have negative
     ;;; clock jumps. The epoch of this clock is undefined. The absolute time
     ;;; value of this clock therefore has no meaning.
-    $clock_monotonic
+    $monotonic
     ;;; The CPU-time clock associated with the current process.
-    $clock_process_cputime_id
+    $process_cputime_id
     ;;; The CPU-time clock associated with the current thread.
-    $clock_thread_cputime_id
+    $thread_cputime_id
   )
 )
 
@@ -201,75 +201,75 @@
     ;;
     ;;; If `RIGHT_PATH_OPEN` is set, includes the right to invoke
     ;;; `path_open` with `FDFLAG_DSYNC`.
-    $right_fd_datasync
+    $fd_datasync
     ;;; The right to invoke `fd_read` and `sock_recv`.
     ;;
     ;;; If `RIGHT_FD_SEEK` is set, includes the right to invoke `fd_pread`.
-    $right_fd_read
+    $fd_read
     ;;; The right to invoke `fd_seek`. This flag implies `RIGHT_FD_TELL`.
-    $right_fd_seek
+    $fd_seek
     ;;; The right to invoke `fd_fdstat_set_flags`.
-    $right_fd_fdstat_set_flags
+    $fd_fdstat_set_flags
     ;;; The right to invoke `fd_sync`.
     ;;
     ;;; If `RIGHT_PATH_OPEN` is set, includes the right to invoke
     ;;; `path_open` with `FDFLAG_RSYNC` and `FDFLAG_DSYNC`.
-    $right_fd_sync
+    $fd_sync
     ;;; The right to invoke `fd_seek` in such a way that the file offset
     ;;; remains unaltered (i.e., `WHENCE_CUR` with offset zero), or to
     ;;; invoke `fd_tell`.
-    $right_fd_tell
+    $fd_tell
     ;;; The right to invoke `fd_write` and `sock_send`.
     ;;; If `RIGHT_FD_SEEK` is set, includes the right to invoke `fd_pwrite`.
-    $right_fd_write
+    $fd_write
     ;;; The right to invoke `fd_advise`.
-    $right_fd_advise
+    $fd_advise
     ;;; The right to invoke `fd_allocate`.
-    $right_fd_allocate
+    $fd_allocate
     ;;; The right to invoke `path_create_directory`.
-    $right_path_create_directory
+    $path_create_directory
     ;;; If `RIGHT_PATH_OPEN` is set, the right to invoke `path_open` with `O_CREAT`.
-    $right_path_create_file
+    $path_create_file
     ;;; The right to invoke `path_link` with the file descriptor as the
     ;;; source directory.
-    $right_path_link_source
+    $path_link_source
     ;;; The right to invoke `path_link` with the file descriptor as the
     ;;; target directory.
-    $right_path_link_target
+    $path_link_target
     ;;; The right to invoke `path_open`.
-    $right_path_open
+    $path_open
     ;;; The right to invoke `fd_readdir`.
-    $right_fd_readdir
+    $fd_readdir
     ;;; The right to invoke `path_readlink`.
-    $right_path_readlink
+    $path_readlink
     ;;; The right to invoke `path_rename` with the file descriptor as the source directory.
-    $right_path_rename_source
+    $path_rename_source
     ;;; The right to invoke `path_rename` with the file descriptor as the target directory.
-    $right_path_rename_target
+    $path_rename_target
     ;;; The right to invoke `path_filestat_get`.
-    $right_path_filestat_get
+    $path_filestat_get
     ;;; The right to change a file's size (there is no `path_filestat_set_size`).
     ;;; If `RIGHT_PATH_OPEN` is set, includes the right to invoke `path_open` with `O_TRUNC`.
-    $right_path_filestat_set_size
+    $path_filestat_set_size
     ;;; The right to invoke `path_filestat_set_times`.
-    $right_path_filestat_set_times
+    $path_filestat_set_times
     ;;; The right to invoke `fd_filestat_get`.
-    $right_fd_filestat_get
+    $fd_filestat_get
     ;;; The right to invoke `fd_filestat_set_size`.
-    $right_fd_filestat_set_size
+    $fd_filestat_set_size
     ;;; The right to invoke `fd_filestat_set_times`.
-    $right_fd_filestat_set_times
+    $fd_filestat_set_times
     ;;; The right to invoke `path_symlink`.
-    $right_path_symlink
+    $path_symlink
     ;;; The right to invoke `path_remove_directory`.
-    $right_path_remove_directory
+    $path_remove_directory
     ;;; The right to invoke `path_unlink_file`.
-    $right_path_unlink_file
+    $path_unlink_file
     ;;; If `RIGHT_FD_READ` is set, includes the right to invoke `poll_oneoff` to subscribe to `EVENTTYPE_FD_READ`.
     ;;; If `RIGHT_FD_WRITE` is set, includes the right to invoke `poll_oneoff` to subscribe to `EVENTTYPE_FD_WRITE`.
-    $right_poll_fd_readwrite
+    $poll_fd_readwrite
     ;;; The right to invoke `sock_shutdown`.
-    $right_sock_shutdown
+    $sock_shutdown
   )
 )
 
@@ -306,11 +306,11 @@
 (typename $whence
   (enum u8
     ;;; Seek relative to start-of-file.
-    $whence_set
+    $set
     ;;; Seek relative to current position.
-    $whence_cur
+    $cur
     ;;; Seek relative to end-of-file.
-    $whence_end
+    $end
   )
 )
 
@@ -329,21 +329,21 @@
 (typename $filetype
   (enum u8
     ;;; The type of the file descriptor or file is unknown or is different from any of the other types specified.
-    $filetype_unknown
+    $unknown
     ;;; The file descriptor or file refers to a block device inode.
-    $filetype_block_device
+    $block_device
     ;;; The file descriptor or file refers to a character device inode.
-    $filetype_character_device
+    $character_device
     ;;; The file descriptor or file refers to a directory inode.
-    $filetype_directory
+    $directory
     ;;; The file descriptor or file refers to a regular file inode.
-    $filetype_regular_file
+    $regular_file
     ;;; The file descriptor or file refers to a datagram socket.
-    $filetype_socket_dgram
+    $socket_dgram
     ;;; The file descriptor or file refers to a byte-stream socket.
-    $filetype_socket_stream
+    $socket_stream
     ;;; The file refers to a symbolic link inode.
-    $filetype_symbolic_link
+    $symbolic_link
   )
 )
 
@@ -365,17 +365,17 @@
 (typename $advice
   (enum u8
     ;;; The application has no advice to give on its behavior with respect to the specified data.
-    $advice_normal
+    $normal
     ;;; The application expects to access the specified data sequentially from lower offsets to higher offsets.
-    $advice_sequential
+    $sequential
     ;;; The application expects to access the specified data in a random order.
-    $advice_random
+    $random
     ;;; The application expects to access the specified data in the near future.
-    $advice_willneed
+    $willneed
     ;;; The application expects that it will not access the specified data in the near future.
-    $advice_dontneed
+    $dontneed
     ;;; The application expects to access the specified data once and then not reuse it thereafter.
-    $advice_noreuse
+    $noreuse
   )
 )
 
@@ -383,17 +383,17 @@
 (typename $fdflags
   (flags u16
     ;;; Append mode: Data written to the file is always appended to the file's end.
-    $fdflag_append
+    $append
     ;;; Write according to synchronized I/O data integrity completion. Only the data stored in the file is synchronized.
-    $fdflag_dsync
+    $dsync
     ;;; Non-blocking mode.
-    $fdflag_nonblock
+    $nonblock
     ;;; Synchronized read I/O operations.
-    $fdflag_rsync
+    $rsync
     ;;; Write according to synchronized I/O file integrity completion. In
     ;;; addition to synchronizing the data stored in the file, the implementation
     ;;; may also synchronously update the file's metadata.
-    $fdflag_sync
+    $sync
   )
 )
 
@@ -420,13 +420,13 @@
 (typename $fstflags
   (flags u16
     ;;; Adjust the last data access timestamp to the value stored in `filestat_t::st_atim`.
-    $filestat_set_atim
+    $atim
     ;;; Adjust the last data access timestamp to the time of clock `CLOCK_REALTIME`.
-    $filestat_set_atim_now
+    $atim_now
     ;;; Adjust the last data modification timestamp to the value stored in `filestat_t::st_mtim`.
-    $filestat_set_mtim
+    $mtim
     ;;; Adjust the last data modification timestamp to the time of clock `CLOCK_REALTIME`.
-    $filestat_set_mtim_now
+    $mtim_now
   )
 )
 
@@ -434,7 +434,7 @@
 (typename $lookupflags
   (flags u32
     ;;; As long as the resolved path corresponds to a symbolic link, it is expanded.
-    $lookup_symlink_follow
+    $symlink_follow
   )
 )
 
@@ -442,13 +442,13 @@
 (typename $oflags
   (flags u16
     ;;; Create file if it does not exist.
-    $o_creat
+    $creat
     ;;; Fail if not a directory.
-    $o_directory
+    $directory
     ;;; Fail if file already exists.
-    $o_excl
+    $excl
     ;;; Truncate file to size 0.
-    $o_trunc
+    $trunc
   )
 )
 
@@ -459,21 +459,21 @@
 (typename $filestat
   (struct
     ;;; Device ID of device containing the file.
-    (field $st_dev $device)
+    (field $dev $device)
     ;;; File serial number.
-    (field $st_ino $inode)
+    (field $ino $inode)
     ;;; File type.
-    (field $st_filetype $filetype)
+    (field $filetype $filetype)
     ;;; Number of hard links to the file.
-    (field $st_nlink $linkcount)
+    (field $nlink $linkcount)
     ;;; For regular files, the file size in bytes. For symbolic links, the length in bytes of the pathname contained in the symbolic link.
-    (field $st_size $filesize)
+    (field $size $filesize)
     ;;; Last data access timestamp.
-    (field $st_atim $timestamp)
+    (field $atim $timestamp)
     ;;; Last data modification timestamp.
-    (field $st_mtim $timestamp)
+    (field $mtim $timestamp)
     ;;; Last file status change timestamp.
-    (field $st_ctim $timestamp)
+    (field $ctim $timestamp)
   )
 )
 
@@ -555,7 +555,7 @@
 (typename $subscription_clock
   (struct
     ;;; The clock against which to compare the timestamp.
-    (field $clock_id $clockid)
+    (field $id $clockid)
     ;;; The absolute or relative timestamp.
     (field $timeout $timestamp)
     ;;; The amount of time that the implementation may wait additionally
@@ -704,9 +704,9 @@
 (typename $riflags
   (flags u16
     ;;; Returns the message without removing it from the socket's receive queue.
-    $sock_recv_peek
+    $recv_peek
     ;;; On byte-stream sockets, block until the full amount of data can be returned.
-    $sock_recv_waitall
+    $recv_waitall
   )
 )
 
@@ -714,7 +714,7 @@
 (typename $roflags
   (flags u16
     ;;; Returned by `sock_recv`: Message data has been truncated.
-    $sock_recv_data_truncated
+    $recv_data_truncated
   )
 )
 
@@ -726,9 +726,9 @@
 (typename $sdflags
   (flags u8
     ;;; Disables further receive operations.
-    $shut_rd
+    $rd
     ;;; Disables further send operations.
-    $shut_wr
+    $wr
   )
 )
 
@@ -736,7 +736,7 @@
 (typename $preopentype
   (enum u8
     ;;; A pre-opened directory.
-    $preopentype_dir
+    $dir
   )
 )
 

--- a/phases/ephemeral/witx/typenames.witx
+++ b/phases/ephemeral/witx/typenames.witx
@@ -18,16 +18,16 @@
   (enum u32
     ;;; The clock measuring real time. Time value zero corresponds with
     ;;; 1970-01-01T00:00:00Z.
-    $CLOCK_REALTIME
+    $clock_realtime
     ;;; The store-wide monotonic clock, which is defined as a clock measuring
     ;;; real time, whose value cannot be adjusted and which cannot have negative
     ;;; clock jumps. The epoch of this clock is undefined. The absolute time
     ;;; value of this clock therefore has no meaning.
-    $CLOCK_MONOTONIC
+    $clock_monotonic
     ;;; The CPU-time clock associated with the current process.
-    $CLOCK_PROCESS_CPUTIME_ID
+    $clock_process_cputime_id
     ;;; The CPU-time clock associated with the current thread.
-    $CLOCK_THREAD_CPUTIME_ID
+    $clock_thread_cputime_id
   )
 )
 
@@ -38,159 +38,159 @@
 (typename $errno
   (enum u16
     ;;; No error occurred. System call completed successfully.
-    $ESUCCESS
+    $esuccess
     ;;; Argument list too long.
-    $E2BIG
+    $e2big
     ;;; Permission denied.
-    $EACCES
+    $eacces
     ;;; Address in use.
-    $EADDRINUSE
+    $eaddrinuse
     ;;; Address not available.
-    $EADDRNOTAVAIL
+    $eaddrnotavail
     ;;; Address family not supported.
-    $EAFNOSUPPORT
+    $eafnosupport
     ;;; Resource unavailable, or operation would block.
-    $EAGAIN
+    $eagain
     ;;; Connection already in progress.
-    $EALREADY
+    $ealready
     ;;; Bad file descriptor.
-    $EBADF
+    $ebadf
     ;;; Bad message.
-    $EBADMSG
+    $ebadmsg
     ;;; Device or resource busy.
-    $EBUSY
+    $ebusy
     ;;; Operation canceled.
-    $ECANCELED
+    $ecanceled
     ;;; No child processes.
-    $ECHILD
+    $echild
     ;;; Connection aborted.
-    $ECONNABORTED
+    $econnaborted
     ;;; Connection refused.
-    $ECONNREFUSED
+    $econnrefused
     ;;; Connection reset.
-    $ECONNRESET
+    $econnreset
     ;;; Resource deadlock would occur.
-    $EDEADLK
+    $edeadlk
     ;;; Destination address required.
-    $EDESTADDRREQ
+    $edestaddrreq
     ;;; Mathematics argument out of domain of function.
-    $EDOM
+    $edom
     ;;; Reserved.
-    $EDQUOT
+    $edquot
     ;;; File exists.
-    $EEXIST
+    $eexist
     ;;; Bad address.
-    $EFAULT
+    $efault
     ;;; File too large.
-    $EFBIG
+    $efbig
     ;;; Host is unreachable.
-    $EHOSTUNREACH
+    $ehostunreach
     ;;; Identifier removed.
-    $EIDRM
+    $eidrm
     ;;; Illegal byte sequence.
-    $EILSEQ
+    $eilseq
     ;;; Operation in progress.
-    $EINPROGRESS
+    $einprogress
     ;;; Interrupted function.
-    $EINTR
+    $eintr
     ;;; Invalid argument.
-    $EINVAL
+    $einval
     ;;; I/O error.
-    $EIO
+    $eio
     ;;; Socket is connected.
-    $EISCONN
+    $eisconn
     ;;; Is a directory.
-    $EISDIR
+    $eisdir
     ;;; Too many levels of symbolic links.
-    $ELOOP
+    $eloop
     ;;; File descriptor value too large.
-    $EMFILE
+    $emfile
     ;;; Too many links.
-    $EMLINK
+    $emlink
     ;;; Message too large.
-    $EMSGSIZE
+    $emsgsize
     ;;; Reserved.
-    $EMULTIHOP
+    $emultihop
     ;;; Filename too long.
-    $ENAMETOOLONG
+    $enametoolong
     ;;; Network is down.
-    $ENETDOWN
+    $enetdown
     ;;; Connection aborted by network.
-    $ENETRESET
+    $enetreset
     ;;; Network unreachable.
-    $ENETUNREACH
+    $enetunreach
     ;;; Too many files open in system.
-    $ENFILE
+    $enfile
     ;;; No buffer space available.
-    $ENOBUFS
+    $enobufs
     ;;; No such device.
-    $ENODEV
+    $enodev
     ;;; No such file or directory.
-    $ENOENT
+    $enoent
     ;;; Executable file format error.
-    $ENOEXEC
+    $enoexec
     ;;; No locks available.
-    $ENOLCK
+    $enolck
     ;;; Reserved.
-    $ENOLINK
+    $enolink
     ;;; Not enough space.
-    $ENOMEM
+    $enomem
     ;;; No message of the desired type.
-    $ENOMSG
+    $enomsg
     ;;; Protocol not available.
-    $ENOPROTOOPT
+    $enoprotoopt
     ;;; No space left on device.
-    $ENOSPC
+    $enospc
     ;;; Function not supported.
-    $ENOSYS
+    $enosys
     ;;; The socket is not connected.
-    $ENOTCONN
+    $enotconn
     ;;; Not a directory or a symbolic link to a directory.
-    $ENOTDIR
+    $enotdir
     ;;; Directory not empty.
-    $ENOTEMPTY
+    $enotempty
     ;;; State not recoverable.
-    $ENOTRECOVERABLE
+    $enotrecoverable
     ;;; Not a socket.
-    $ENOTSOCK
+    $enotsock
     ;;; Not supported, or operation not supported on socket.
-    $ENOTSUP
+    $enotsup
     ;;; Inappropriate I/O control operation.
-    $ENOTTY
+    $enotty
     ;;; No such device or address.
-    $ENXIO
+    $enxio
     ;;; Value too large to be stored in data type.
-    $EOVERFLOW
+    $eoverflow
     ;;; Previous owner died.
-    $EOWNERDEAD
+    $eownerdead
     ;;; Operation not permitted.
-    $EPERM
+    $eperm
     ;;; Broken pipe.
-    $EPIPE
+    $epipe
     ;;; Protocol error.
-    $EPROTO
+    $eproto
     ;;; Protocol not supported.
-    $EPROTONOSUPPORT
+    $eprotonosupport
     ;;; Protocol wrong type for socket.
-    $EPROTOTYPE
+    $eprototype
     ;;; Result too large.
-    $ERANGE
+    $erange
     ;;; Read-only file system.
-    $EROFS
+    $erofs
     ;;; Invalid seek.
-    $ESPIPE
+    $espipe
     ;;; No such process.
-    $ESRCH
+    $esrch
     ;;; Reserved.
-    $ESTALE
+    $estale
     ;;; Connection timed out.
-    $ETIMEDOUT
+    $etimedout
     ;;; Text file busy.
-    $ETXTBSY
+    $etxtbsy
     ;;; Cross-device link.
-    $EXDEV
+    $exdev
     ;;; Extension: Capabilities insufficient.
-    $ENOTCAPABLE
+    $enotcapable
   )
 )
 
@@ -201,75 +201,75 @@
     ;;
     ;;; If `RIGHT_PATH_OPEN` is set, includes the right to invoke
     ;;; `path_open` with `FDFLAG_DSYNC`.
-    $RIGHT_FD_DATASYNC
+    $right_fd_datasync
     ;;; The right to invoke `fd_read` and `sock_recv`.
     ;;
     ;;; If `RIGHT_FD_SEEK` is set, includes the right to invoke `fd_pread`.
-    $RIGHT_FD_READ
+    $right_fd_read
     ;;; The right to invoke `fd_seek`. This flag implies `RIGHT_FD_TELL`.
-    $RIGHT_FD_SEEK
+    $right_fd_seek
     ;;; The right to invoke `fd_fdstat_set_flags`.
-    $RIGHT_FD_FDSTAT_SET_FLAGS
+    $right_fd_fdstat_set_flags
     ;;; The right to invoke `fd_sync`.
     ;;
     ;;; If `RIGHT_PATH_OPEN` is set, includes the right to invoke
     ;;; `path_open` with `FDFLAG_RSYNC` and `FDFLAG_DSYNC`.
-    $RIGHT_FD_SYNC
+    $right_fd_sync
     ;;; The right to invoke `fd_seek` in such a way that the file offset
     ;;; remains unaltered (i.e., `WHENCE_CUR` with offset zero), or to
     ;;; invoke `fd_tell`.
-    $RIGHT_FD_TELL
+    $right_fd_tell
     ;;; The right to invoke `fd_write` and `sock_send`.
     ;;; If `RIGHT_FD_SEEK` is set, includes the right to invoke `fd_pwrite`.
-    $RIGHT_FD_WRITE
+    $right_fd_write
     ;;; The right to invoke `fd_advise`.
-    $RIGHT_FD_ADVISE
+    $right_fd_advise
     ;;; The right to invoke `fd_allocate`.
-    $RIGHT_FD_ALLOCATE
+    $right_fd_allocate
     ;;; The right to invoke `path_create_directory`.
-    $RIGHT_PATH_CREATE_DIRECTORY
+    $right_path_create_directory
     ;;; If `RIGHT_PATH_OPEN` is set, the right to invoke `path_open` with `O_CREAT`.
-    $RIGHT_PATH_CREATE_FILE
+    $right_path_create_file
     ;;; The right to invoke `path_link` with the file descriptor as the
     ;;; source directory.
-    $RIGHT_PATH_LINK_SOURCE
+    $right_path_link_source
     ;;; The right to invoke `path_link` with the file descriptor as the
     ;;; target directory.
-    $RIGHT_PATH_LINK_TARGET
+    $right_path_link_target
     ;;; The right to invoke `path_open`.
-    $RIGHT_PATH_OPEN
+    $right_path_open
     ;;; The right to invoke `fd_readdir`.
-    $RIGHT_FD_READDIR
+    $right_fd_readdir
     ;;; The right to invoke `path_readlink`.
-    $RIGHT_PATH_READLINK
+    $right_path_readlink
     ;;; The right to invoke `path_rename` with the file descriptor as the source directory.
-    $RIGHT_PATH_RENAME_SOURCE
+    $right_path_rename_source
     ;;; The right to invoke `path_rename` with the file descriptor as the target directory.
-    $RIGHT_PATH_RENAME_TARGET
+    $right_path_rename_target
     ;;; The right to invoke `path_filestat_get`.
-    $RIGHT_PATH_FILESTAT_GET
+    $right_path_filestat_get
     ;;; The right to change a file's size (there is no `path_filestat_set_size`).
     ;;; If `RIGHT_PATH_OPEN` is set, includes the right to invoke `path_open` with `O_TRUNC`.
-    $RIGHT_PATH_FILESTAT_SET_SIZE
+    $right_path_filestat_set_size
     ;;; The right to invoke `path_filestat_set_times`.
-    $RIGHT_PATH_FILESTAT_SET_TIMES
+    $right_path_filestat_set_times
     ;;; The right to invoke `fd_filestat_get`.
-    $RIGHT_FD_FILESTAT_GET
+    $right_fd_filestat_get
     ;;; The right to invoke `fd_filestat_set_size`.
-    $RIGHT_FD_FILESTAT_SET_SIZE
+    $right_fd_filestat_set_size
     ;;; The right to invoke `fd_filestat_set_times`.
-    $RIGHT_FD_FILESTAT_SET_TIMES
+    $right_fd_filestat_set_times
     ;;; The right to invoke `path_symlink`.
-    $RIGHT_PATH_SYMLINK
+    $right_path_symlink
     ;;; The right to invoke `path_remove_directory`.
-    $RIGHT_PATH_REMOVE_DIRECTORY
+    $right_path_remove_directory
     ;;; The right to invoke `path_unlink_file`.
-    $RIGHT_PATH_UNLINK_FILE
+    $right_path_unlink_file
     ;;; If `RIGHT_FD_READ` is set, includes the right to invoke `poll_oneoff` to subscribe to `EVENTTYPE_FD_READ`.
     ;;; If `RIGHT_FD_WRITE` is set, includes the right to invoke `poll_oneoff` to subscribe to `EVENTTYPE_FD_WRITE`.
-    $RIGHT_POLL_FD_READWRITE
+    $right_poll_fd_readwrite
     ;;; The right to invoke `sock_shutdown`.
-    $RIGHT_SOCK_SHUTDOWN
+    $right_sock_shutdown
   )
 )
 
@@ -306,11 +306,11 @@
 (typename $whence
   (enum u8
     ;;; Seek relative to start-of-file.
-    $WHENCE_SET
+    $whence_set
     ;;; Seek relative to current position.
-    $WHENCE_CUR
+    $whence_cur
     ;;; Seek relative to end-of-file.
-    $WHENCE_END
+    $whence_end
   )
 )
 
@@ -329,21 +329,21 @@
 (typename $filetype
   (enum u8
     ;;; The type of the file descriptor or file is unknown or is different from any of the other types specified.
-    $FILETYPE_UNKNOWN
+    $filetype_unknown
     ;;; The file descriptor or file refers to a block device inode.
-    $FILETYPE_BLOCK_DEVICE
+    $filetype_block_device
     ;;; The file descriptor or file refers to a character device inode.
-    $FILETYPE_CHARACTER_DEVICE
+    $filetype_character_device
     ;;; The file descriptor or file refers to a directory inode.
-    $FILETYPE_DIRECTORY
+    $filetype_directory
     ;;; The file descriptor or file refers to a regular file inode.
-    $FILETYPE_REGULAR_FILE
+    $filetype_regular_file
     ;;; The file descriptor or file refers to a datagram socket.
-    $FILETYPE_SOCKET_DGRAM
+    $filetype_socket_dgram
     ;;; The file descriptor or file refers to a byte-stream socket.
-    $FILETYPE_SOCKET_STREAM
+    $filetype_socket_stream
     ;;; The file refers to a symbolic link inode.
-    $FILETYPE_SYMBOLIC_LINK
+    $filetype_symbolic_link
   )
 )
 
@@ -365,17 +365,17 @@
 (typename $advice
   (enum u8
     ;;; The application has no advice to give on its behavior with respect to the specified data.
-    $ADVICE_NORMAL
+    $advice_normal
     ;;; The application expects to access the specified data sequentially from lower offsets to higher offsets.
-    $ADVICE_SEQUENTIAL
+    $advice_sequential
     ;;; The application expects to access the specified data in a random order.
-    $ADVICE_RANDOM
+    $advice_random
     ;;; The application expects to access the specified data in the near future.
-    $ADVICE_WILLNEED
+    $advice_willneed
     ;;; The application expects that it will not access the specified data in the near future.
-    $ADVICE_DONTNEED
+    $advice_dontneed
     ;;; The application expects to access the specified data once and then not reuse it thereafter.
-    $ADVICE_NOREUSE
+    $advice_noreuse
   )
 )
 
@@ -383,17 +383,17 @@
 (typename $fdflags
   (flags u16
     ;;; Append mode: Data written to the file is always appended to the file's end.
-    $FDFLAG_APPEND
+    $fdflag_append
     ;;; Write according to synchronized I/O data integrity completion. Only the data stored in the file is synchronized.
-    $FDFLAG_DSYNC
+    $fdflag_dsync
     ;;; Non-blocking mode.
-    $FDFLAG_NONBLOCK
+    $fdflag_nonblock
     ;;; Synchronized read I/O operations.
-    $FDFLAG_RSYNC
+    $fdflag_rsync
     ;;; Write according to synchronized I/O file integrity completion. In
     ;;; addition to synchronizing the data stored in the file, the implementation
     ;;; may also synchronously update the file's metadata.
-    $FDFLAG_SYNC
+    $fdflag_sync
   )
 )
 
@@ -420,13 +420,13 @@
 (typename $fstflags
   (flags u16
     ;;; Adjust the last data access timestamp to the value stored in `filestat_t::st_atim`.
-    $FILESTAT_SET_ATIM
+    $filestat_set_atim
     ;;; Adjust the last data access timestamp to the time of clock `CLOCK_REALTIME`.
-    $FILESTAT_SET_ATIM_NOW
+    $filestat_set_atim_now
     ;;; Adjust the last data modification timestamp to the value stored in `filestat_t::st_mtim`.
-    $FILESTAT_SET_MTIM
+    $filestat_set_mtim
     ;;; Adjust the last data modification timestamp to the time of clock `CLOCK_REALTIME`.
-    $FILESTAT_SET_MTIM_NOW
+    $filestat_set_mtim_now
   )
 )
 
@@ -434,7 +434,7 @@
 (typename $lookupflags
   (flags u32
     ;;; As long as the resolved path corresponds to a symbolic link, it is expanded.
-    $LOOKUP_SYMLINK_FOLLOW
+    $lookup_symlink_follow
   )
 )
 
@@ -442,13 +442,13 @@
 (typename $oflags
   (flags u16
     ;;; Create file if it does not exist.
-    $O_CREAT
+    $o_creat
     ;;; Fail if not a directory.
-    $O_DIRECTORY
+    $o_directory
     ;;; Fail if file already exists.
-    $O_EXCL
+    $o_excl
     ;;; Truncate file to size 0.
-    $O_TRUNC
+    $o_trunc
   )
 )
 
@@ -486,13 +486,13 @@
   (enum u8
     ;;; The time value of clock `subscription_t::u.clock.clock_id` has
     ;;; reached timestamp `subscription_t::u.clock.timeout`.
-    $EVENTTYPE_CLOCK
+    $eventtype_clock
     ;;; File descriptor `subscription_t::u.fd_readwrite.fd` has data
     ;;; available for reading. This event always triggers for regular files.
-    $EVENTTYPE_FD_READ
+    $eventtype_fd_read
     ;;; File descriptor `subscription_t::u.fd_readwrite.fd` has capacity
     ;;; available for writing. This event always triggers for regular files.
-    $EVENTTYPE_FD_WRITE
+    $eventtype_fd_write
   )
 )
 
@@ -501,7 +501,7 @@
 (typename $eventrwflags
   (flags u16
     ;;; The peer of this socket has closed or disconnected.
-    $EVENT_FD_READWRITE_HANGUP
+    $event_fd_readwrite_hangup
   )
 )
 
@@ -547,7 +547,7 @@
     ;;; `subscription_t::u.clock.clock_id.` If clear, treat the timestamp
     ;;; provided in `subscription_t::u.clock.timeout` relative to the
     ;;; current time value of clock `subscription_t::u.clock.clock_id.`
-    $SUBSCRIPTION_CLOCK_ABSTIME
+    $subscription_clock_abstime
   )
 )
 
@@ -606,97 +606,97 @@
   (enum u8
     ;;; No signal. Note that POSIX has special semantics for `kill(pid, 0)`,
     ;;; so this value is reserved.
-    $SIGNONE
+    $signone
     ;;; Hangup.
     ;;; Action: Terminates the process.
-    $SIGHUP
+    $sighup
     ;;; Terminate interrupt signal.
     ;;; Action: Terminates the process.
-    $SIGINT
+    $sigint
     ;;; Terminal quit signal.
     ;;; Action: Terminates the process.
-    $SIGQUIT
+    $sigquit
     ;;; Illegal instruction.
     ;;; Action: Terminates the process.
-    $SIGILL
+    $sigill
     ;;; Trace/breakpoint trap.
     ;;; Action: Terminates the process.
-    $SIGTRAP
+    $sigtrap
     ;;; Process abort signal.
     ;;; Action: Terminates the process.
-    $SIGABRT
+    $sigabrt
     ;;; Access to an undefined portion of a memory object.
     ;;; Action: Terminates the process.
-    $SIGBUS
+    $sigbus
     ;;; Erroneous arithmetic operation.
     ;;; Action: Terminates the process.
-    $SIGFPE
+    $sigfpe
     ;;; Kill.
     ;;; Action: Terminates the process.
-    $SIGKILL
+    $sigkill
     ;;; User-defined signal 1.
     ;;; Action: Terminates the process.
-    $SIGUSR1
+    $sigusr1
     ;;; Invalid memory reference.
     ;;; Action: Terminates the process.
-    $SIGSEGV
+    $sigsegv
     ;;; User-defined signal 2.
     ;;; Action: Terminates the process.
-    $SIGUSR2
+    $sigusr2
     ;;; Write on a pipe with no one to read it.
     ;;; Action: Ignored.
-    $SIGPIPE
+    $sigpipe
     ;;; Alarm clock.
     ;;; Action: Terminates the process.
-    $SIGALRM
+    $sigalrm
     ;;; Termination signal.
     ;;; Action: Terminates the process.
-    $SIGTERM
+    $sigterm
     ;;; Child process terminated, stopped, or continued.
     ;;; Action: Ignored.
-    $SIGCHLD
+    $sigchld
     ;;; Continue executing, if stopped.
     ;;; Action: Continues executing, if stopped.
-    $SIGCONT
+    $sigcont
     ;;; Stop executing.
     ;;; Action: Stops executing.
-    $SIGSTOP
+    $sigstop
     ;;; Terminal stop signal.
     ;;; Action: Stops executing.
-    $SIGTSTP
+    $sigtstp
     ;;; Background process attempting read.
     ;;; Action: Stops executing.
-    $SIGTTIN
+    $sigttin
     ;;; Background process attempting write.
     ;;; Action: Stops executing.
-    $SIGTTOU
+    $sigttou
     ;;; High bandwidth data is available at a socket.
     ;;; Action: Ignored.
-    $SIGURG
+    $sigurg
     ;;; CPU time limit exceeded.
     ;;; Action: Terminates the process.
-    $SIGXCPU
+    $sigxcpu
     ;;; File size limit exceeded.
     ;;; Action: Terminates the process.
-    $SIGXFSZ
+    $sigxfsz
     ;;; Virtual timer expired.
     ;;; Action: Terminates the process.
-    $SIGVTALRM
+    $sigvtalrm
     ;;; Profiling timer expired.
     ;;; Action: Terminates the process.
-    $SIGPROF
+    $sigprof
     ;;; Window changed.
     ;;; Action: Ignored.
-    $SIGWINCH
+    $sigwinch
     ;;; I/O possible.
     ;;; Action: Terminates the process.
-    $SIGPOLL
+    $sigpoll
     ;;; Power failure.
     ;;; Action: Terminates the process.
-    $SIGPWR
+    $sigpwr
     ;;; Bad system call.
     ;;; Action: Terminates the process.
-    $SIGSYS
+    $sigsys
   )
 )
 
@@ -704,9 +704,9 @@
 (typename $riflags
   (flags u16
     ;;; Returns the message without removing it from the socket's receive queue.
-    $SOCK_RECV_PEEK
+    $sock_recv_peek
     ;;; On byte-stream sockets, block until the full amount of data can be returned.
-    $SOCK_RECV_WAITALL
+    $sock_recv_waitall
   )
 )
 
@@ -714,7 +714,7 @@
 (typename $roflags
   (flags u16
     ;;; Returned by `sock_recv`: Message data has been truncated.
-    $SOCK_RECV_DATA_TRUNCATED
+    $sock_recv_data_truncated
   )
 )
 
@@ -726,9 +726,9 @@
 (typename $sdflags
   (flags u8
     ;;; Disables further receive operations.
-    $SHUT_RD
+    $shut_rd
     ;;; Disables further send operations.
-    $SHUT_WR
+    $shut_wr
   )
 )
 
@@ -736,7 +736,7 @@
 (typename $preopentype
   (enum u8
     ;;; A pre-opened directory.
-    $PREOPENTYPE_DIR
+    $preopentype_dir
   )
 )
 

--- a/phases/ephemeral/witx/typenames.witx
+++ b/phases/ephemeral/witx/typenames.witx
@@ -5,16 +5,16 @@
 ;; This is a `witx` file. See [here](https://github.com/WebAssembly/WASI/tree/master/docs/witx.md)
 ;; for an explanation of what that means.
 
-(typename $size_t u32)
+(typename $size u32)
 
 ;;; Non-negative file size or length of a region within a file.
-(typename $filesize_t u64)
+(typename $filesize u64)
 
 ;;; Timestamp in nanoseconds.
-(typename $timestamp_t u64)
+(typename $timestamp u64)
 
 ;;; Identifiers for clocks.
-(typename $clockid_t
+(typename $clockid
   (enum u32
     ;;; The clock measuring real time. Time value zero corresponds with
     ;;; 1970-01-01T00:00:00Z.
@@ -35,7 +35,7 @@
 ;;; Not all of these error codes are returned by the functions provided by this
 ;;; API; some are used in higher-level library layers, and others are provided
 ;;; merely for alignment with POSIX.
-(typename $errno_t
+(typename $errno
   (enum u16
     ;;; No error occurred. System call completed successfully.
     $ESUCCESS
@@ -195,7 +195,7 @@
 )
 
 ;;; File descriptor rights, determining which actions may be performed.
-(typename $rights_t
+(typename $rights
   (flags u64
     ;;; The right to invoke `fd_datasync`.
     ;;
@@ -274,36 +274,36 @@
 )
 
 ;;; A file descriptor index.
-(typename $fd_t u32)
+(typename $fd u32)
 
 ;;; A region of memory for scatter/gather reads.
-(typename $iovec_t
+(typename $iovec
   (struct
     ;;; The address of the buffer to be filled.
     (field $buf (@witx pointer u8))
     ;;; The length of the buffer to be filled.
-    (field $buf_len $size_t)
+    (field $buf_len $size)
   )
 )
 
 ;;; A region of memory for scatter/gather writes.
-(typename $ciovec_t
+(typename $ciovec
   (struct
     ;;; The address of the buffer to be written.
     (field $buf (@witx const_pointer u8))
     ;;; The length of the buffer to be written.
-    (field $buf_len $size_t)
+    (field $buf_len $size)
   )
 )
 
-(typename $iovec_t_array (array $iovec_t))
-(typename $ciovec_t_array (array $ciovec_t))
+(typename $iovec_array (array $iovec))
+(typename $ciovec_array (array $ciovec))
 
 ;;; Relative offset within a file.
-(typename $filedelta_t s64)
+(typename $filedelta s64)
 
 ;;; The position relative to which to set the offset of the file descriptor.
-(typename $whence_t
+(typename $whence
   (enum u8
     ;;; Seek relative to start-of-file.
     $WHENCE_SET
@@ -317,16 +317,16 @@
 ;;; A reference to the offset of a directory entry.
 ;;
 ;;; The value 0 signifies the start of the directory.
-(typename $dircookie_t u64)
+(typename $dircookie u64)
 
-;;; The type for the $d_namlen field of $dirent_t.
-(typename $dirnamlen_t u32)
+;;; The type for the $d_namlen field of $dirent.
+(typename $dirnamlen u32)
 
 ;;; File serial number that is unique within its file system.
-(typename $inode_t u64)
+(typename $inode u64)
 
 ;;; The type of a file descriptor or file.
-(typename $filetype_t
+(typename $filetype
   (enum u8
     ;;; The type of the file descriptor or file is unknown or is different from any of the other types specified.
     $FILETYPE_UNKNOWN
@@ -348,21 +348,21 @@
 )
 
 ;;; A directory entry.
-(typename $dirent_t
+(typename $dirent
   (struct
     ;;; The offset of the next directory entry stored in this directory.
-    (field $d_next $dircookie_t)
+    (field $d_next $dircookie)
     ;;; The serial number of the file referred to by this directory entry.
-    (field $d_ino $inode_t)
+    (field $d_ino $inode)
     ;;; The length of the name of the directory entry.
-    (field $d_namlen $dirnamlen_t)
+    (field $d_namlen $dirnamlen)
     ;;; The type of the file referred to by this directory entry.
-    (field $d_type $filetype_t)
+    (field $dype $filetype)
   )
 )
 
 ;;; File or memory access pattern advisory information.
-(typename $advice_t
+(typename $advice
   (enum u8
     ;;; The application has no advice to give on its behavior with respect to the specified data.
     $ADVICE_NORMAL
@@ -380,7 +380,7 @@
 )
 
 ;;; File descriptor flags.
-(typename $fdflags_t
+(typename $fdflags
   (flags u16
     ;;; Append mode: Data written to the file is always appended to the file's end.
     $FDFLAG_APPEND
@@ -398,26 +398,26 @@
 )
 
 ;;; File descriptor attributes.
-(typename $fdstat_t
+(typename $fdstat
   (struct
     ;;; File type.
-    (field $fs_filetype $filetype_t)
+    (field $fs_filetype $filetype)
     ;;; File descriptor flags.
-    (field $fs_flags $fdflags_t)
+    (field $fs_flags $fdflags)
     ;;; Rights that apply to this file descriptor.
-    (field $fs_rights_base $rights_t)
+    (field $fs_rights_base $rights)
     ;;; Maximum set of rights that may be installed on new file descriptors that
     ;;; are created through this file descriptor, e.g., through `path_open`.
-    (field $fs_rights_inheriting $rights_t)
+    (field $fs_rights_inheriting $rights)
   )
 )
 
 ;;; Identifier for a device containing a file system. Can be used in combination
 ;;; with `inode_t` to uniquely identify a file or directory in the filesystem.
-(typename $device_t u64)
+(typename $device u64)
 
 ;;; Which file time attributes to adjust.
-(typename $fstflags_t
+(typename $fstflags
   (flags u16
     ;;; Adjust the last data access timestamp to the value stored in `filestat_t::st_atim`.
     $FILESTAT_SET_ATIM
@@ -431,7 +431,7 @@
 )
 
 ;;; Flags determining the method of how paths are resolved.
-(typename $lookupflags_t
+(typename $lookupflags
   (flags u32
     ;;; As long as the resolved path corresponds to a symbolic link, it is expanded.
     $LOOKUP_SYMLINK_FOLLOW
@@ -439,7 +439,7 @@
 )
 
 ;;; Open flags used by `path_open`.
-(typename $oflags_t
+(typename $oflags
   (flags u16
     ;;; Create file if it does not exist.
     $O_CREAT
@@ -453,36 +453,36 @@
 )
 
 ;;; Number of hard links to an inode.
-(typename $linkcount_t u64)
+(typename $linkcount u64)
 
 ;;; File attributes.
-(typename $filestat_t
+(typename $filestat
   (struct
     ;;; Device ID of device containing the file.
-    (field $st_dev $device_t)
+    (field $st_dev $device)
     ;;; File serial number.
-    (field $st_ino $inode_t)
+    (field $st_ino $inode)
     ;;; File type.
-    (field $st_filetype $filetype_t)
+    (field $st_filetype $filetype)
     ;;; Number of hard links to the file.
-    (field $st_nlink $linkcount_t)
+    (field $st_nlink $linkcount)
     ;;; For regular files, the file size in bytes. For symbolic links, the length in bytes of the pathname contained in the symbolic link.
-    (field $st_size $filesize_t)
+    (field $st_size $filesize)
     ;;; Last data access timestamp.
-    (field $st_atim $timestamp_t)
+    (field $st_atim $timestamp)
     ;;; Last data modification timestamp.
-    (field $st_mtim $timestamp_t)
+    (field $st_mtim $timestamp)
     ;;; Last file status change timestamp.
-    (field $st_ctim $timestamp_t)
+    (field $st_ctim $timestamp)
   )
 )
 
 ;;; User-provided value that may be attached to objects that is retained when
 ;;; extracted from the implementation.
-(typename $userdata_t u64)
+(typename $userdata u64)
 
 ;;; Type of a subscription to an event or its occurrence.
-(typename $eventtype_t
+(typename $eventtype
   (enum u8
     ;;; The time value of clock `subscription_t::u.clock.clock_id` has
     ;;; reached timestamp `subscription_t::u.clock.timeout`.
@@ -498,41 +498,41 @@
 
 ;;; The state of the file descriptor subscribed to with
 ;;; `EVENTTYPE_FD_READ` or `EVENTTYPE_FD_WRITE`.
-(typename $eventrwflags_t
+(typename $eventrwflags
   (flags u16
     ;;; The peer of this socket has closed or disconnected.
     $EVENT_FD_READWRITE_HANGUP
   )
 )
 
-;;; The contents of an $event_t when type is `EVENTTYPE_FD_READ` or
+;;; The contents of an $event when type is `EVENTTYPE_FD_READ` or
 ;;; `EVENTTYPE_FD_WRITE`.
-(typename $event_fd_readwrite_t
+(typename $event_fd_readwrite
   (struct
     ;;; The number of bytes available for reading or writing.
-    (field $nbytes $filesize_t)
+    (field $nbytes $filesize)
     ;;; The state of the file descriptor.
-    (field $flags $eventrwflags_t)
+    (field $flags $eventrwflags)
   )
 )
 
-;;; The contents of an $event_t.
+;;; The contents of an $event.
 (typename $event_u
   (union
     ;;; When type is `EVENTTYPE_FD_READ` or `EVENTTYPE_FD_WRITE`:
-    (field $fd_readwrite $event_fd_readwrite_t)
+    (field $fd_readwrite $event_fd_readwrite)
   )
 )
 
 ;;; An event that occurred.
-(typename $event_t
+(typename $event
   (struct
     ;;; User-provided value that got attached to `subscription_t::userdata`.
-    (field $userdata $userdata_t)
+    (field $userdata $userdata)
     ;;; If non-zero, an error that occurred while processing the subscription request.
-    (field $error $errno_t)
+    (field $error $errno)
     ;;; The type of the event that occurred.
-    (field $type $eventtype_t)
+    (field $type $eventtype)
     ;;; The contents of the event.
     (field $u $event_u)
   )
@@ -540,7 +540,7 @@
 
 ;;; Flags determining how to interpret the timestamp provided in
 ;;; `subscription_t::u.clock.timeout.`
-(typename $subclockflags_t
+(typename $subclockflags
   (flags u16
     ;;; If set, treat the timestamp provided in
     ;;; `subscription_t::u.clock.timeout` as an absolute timestamp of clock
@@ -551,58 +551,58 @@
   )
 )
 
-;;; The contents of a $subscription_t when type is `EVENTTYPE_CLOCK`.
-(typename $subscription_clock_t
+;;; The contents of a $subscription when type is `EVENTTYPE_CLOCK`.
+(typename $subscription_clock
   (struct
     ;;; The clock against which to compare the timestamp.
-    (field $clock_id $clockid_t)
+    (field $clock_id $clockid)
     ;;; The absolute or relative timestamp.
-    (field $timeout $timestamp_t)
+    (field $timeout $timestamp)
     ;;; The amount of time that the implementation may wait additionally
     ;;; to coalesce with other events.
-    (field $precision $timestamp_t)
+    (field $precision $timestamp)
     ;;; Flags specifying whether the timeout is absolute or relative
-    (field $flags $subclockflags_t)
+    (field $flags $subclockflags)
   )
 )
 
-;;; The contents of a $subscription_t when type is type is
+;;; The contents of a $subscription when type is type is
 ;;; `EVENTTYPE_FD_READ` or `EVENTTYPE_FD_WRITE`.
-(typename $subscription_fd_readwrite_t
+(typename $subscription_fd_readwrite
   (struct
     ;;; The file descriptor on which to wait for it to become ready for reading or writing.
-    (field $file_descriptor $fd_t)
+    (field $file_descriptor $fd)
   )
 )
 
-;;; The contents of a $subscription_t.
+;;; The contents of a $subscription.
 (typename $subscription_u
   (union
     ;;; When type is `EVENTTYPE_CLOCK`:
-    (field $clock $subscription_clock_t)
+    (field $clock $subscription_clock)
     ;;; When type is `EVENTTYPE_FD_READ` or `EVENTTYPE_FD_WRITE`:
-    (field $fd_readwrite $subscription_fd_readwrite_t)
+    (field $fd_readwrite $subscription_fd_readwrite)
   )
 )
 
 ;;; Subscription to an event.
-(typename $subscription_t
+(typename $subscription
   (struct
     ;;; User-provided value that is attached to the subscription in the
     ;;; implementation and returned through `event_t::userdata`.
-    (field $userdata $userdata_t)
+    (field $userdata $userdata)
     ;;; The type of the event to which to subscribe.
-    (field $type $eventtype_t)
+    (field $type $eventtype)
     ;;; The contents of the subscription.
     (field $u $subscription_u)
   )
 )
 
 ;;; Exit code generated by a process when exiting.
-(typename $exitcode_t u32)
+(typename $exitcode u32)
 
 ;;; Signal condition.
-(typename $signal_t
+(typename $signal
   (enum u8
     ;;; No signal. Note that POSIX has special semantics for `kill(pid, 0)`,
     ;;; so this value is reserved.
@@ -701,7 +701,7 @@
 )
 
 ;;; Flags provided to `sock_recv`.
-(typename $riflags_t
+(typename $riflags
   (flags u16
     ;;; Returns the message without removing it from the socket's receive queue.
     $SOCK_RECV_PEEK
@@ -711,7 +711,7 @@
 )
 
 ;;; Flags returned by `sock_recv`.
-(typename $roflags_t
+(typename $roflags
   (flags u16
     ;;; Returned by `sock_recv`: Message data has been truncated.
     $SOCK_RECV_DATA_TRUNCATED
@@ -720,10 +720,10 @@
 
 ;;; Flags provided to `sock_send`. As there are currently no flags
 ;;; defined, it must be set to zero.
-(typename $siflags_t u16)
+(typename $siflags u16)
 
 ;;; Which channels on a socket to shut down.
-(typename $sdflags_t
+(typename $sdflags
   (flags u8
     ;;; Disables further receive operations.
     $SHUT_RD
@@ -733,22 +733,22 @@
 )
 
 ;;; Identifiers for preopened capabilities.
-(typename $preopentype_t
+(typename $preopentype
   (enum u8
     ;;; A pre-opened directory.
     $PREOPENTYPE_DIR
   )
 )
 
-;;; The contents of a $prestat_t when type is `PREOPENTYPE_DIR`.
+;;; The contents of a $prestat when type is `PREOPENTYPE_DIR`.
 (typename $prestat_dir
   (struct
     ;;; The length of the directory name for use with `fd_prestat_dir_name`.
-    (field $pr_name_len $size_t)
+    (field $pr_name_len $size)
   )
 )
 
-;;; The contents of an $prestat_t.
+;;; The contents of an $prestat.
 (typename $prestat_u
   (union
     ;;; When type is `PREOPENTYPE_DIR`:
@@ -757,10 +757,10 @@
 )
 
 ;;; Information about a pre-opened capability.
-(typename $prestat_t
+(typename $prestat
   (struct
     ;;; The type of the pre-opened capability.
-    (field $pr_type $preopentype_t)
+    (field $prype $preopentype)
     ;;; The contents of the information.
     (field $u $prestat_u)
   )

--- a/phases/ephemeral/witx/typenames.witx
+++ b/phases/ephemeral/witx/typenames.witx
@@ -357,7 +357,7 @@
     ;;; The length of the name of the directory entry.
     (field $d_namlen $dirnamlen)
     ;;; The type of the file referred to by this directory entry.
-    (field $dype $filetype)
+    (field $d_type $filetype)
   )
 )
 
@@ -760,7 +760,7 @@
 (typename $prestat
   (struct
     ;;; The type of the pre-opened capability.
-    (field $prype $preopentype)
+    (field $pr_type $preopentype)
     ;;; The contents of the information.
     (field $u $prestat_u)
   )

--- a/phases/ephemeral/witx/typenames.witx
+++ b/phases/ephemeral/witx/typenames.witx
@@ -501,7 +501,7 @@
 (typename $eventrwflags
   (flags u16
     ;;; The peer of this socket has closed or disconnected.
-    $event_fd_readwrite_hangup
+    $fd_readwrite_hangup
   )
 )
 

--- a/phases/ephemeral/witx/typenames.witx
+++ b/phases/ephemeral/witx/typenames.witx
@@ -38,159 +38,159 @@
 (typename $errno
   (enum u16
     ;;; No error occurred. System call completed successfully.
-    $esuccess
+    $success
     ;;; Argument list too long.
-    $e2big
+    $2big
     ;;; Permission denied.
-    $eacces
+    $acces
     ;;; Address in use.
-    $eaddrinuse
+    $addrinuse
     ;;; Address not available.
-    $eaddrnotavail
+    $addrnotavail
     ;;; Address family not supported.
-    $eafnosupport
+    $afnosupport
     ;;; Resource unavailable, or operation would block.
-    $eagain
+    $again
     ;;; Connection already in progress.
-    $ealready
+    $already
     ;;; Bad file descriptor.
-    $ebadf
+    $badf
     ;;; Bad message.
-    $ebadmsg
+    $badmsg
     ;;; Device or resource busy.
-    $ebusy
+    $busy
     ;;; Operation canceled.
-    $ecanceled
+    $canceled
     ;;; No child processes.
-    $echild
+    $child
     ;;; Connection aborted.
-    $econnaborted
+    $connaborted
     ;;; Connection refused.
-    $econnrefused
+    $connrefused
     ;;; Connection reset.
-    $econnreset
+    $connreset
     ;;; Resource deadlock would occur.
-    $edeadlk
+    $deadlk
     ;;; Destination address required.
-    $edestaddrreq
+    $destaddrreq
     ;;; Mathematics argument out of domain of function.
-    $edom
+    $dom
     ;;; Reserved.
-    $edquot
+    $dquot
     ;;; File exists.
-    $eexist
+    $exist
     ;;; Bad address.
-    $efault
+    $fault
     ;;; File too large.
-    $efbig
+    $fbig
     ;;; Host is unreachable.
-    $ehostunreach
+    $hostunreach
     ;;; Identifier removed.
-    $eidrm
+    $idrm
     ;;; Illegal byte sequence.
-    $eilseq
+    $ilseq
     ;;; Operation in progress.
-    $einprogress
+    $inprogress
     ;;; Interrupted function.
-    $eintr
+    $intr
     ;;; Invalid argument.
-    $einval
+    $inval
     ;;; I/O error.
-    $eio
+    $io
     ;;; Socket is connected.
-    $eisconn
+    $isconn
     ;;; Is a directory.
-    $eisdir
+    $isdir
     ;;; Too many levels of symbolic links.
-    $eloop
+    $loop
     ;;; File descriptor value too large.
-    $emfile
+    $mfile
     ;;; Too many links.
-    $emlink
+    $mlink
     ;;; Message too large.
-    $emsgsize
+    $msgsize
     ;;; Reserved.
-    $emultihop
+    $multihop
     ;;; Filename too long.
-    $enametoolong
+    $nametoolong
     ;;; Network is down.
-    $enetdown
+    $netdown
     ;;; Connection aborted by network.
-    $enetreset
+    $netreset
     ;;; Network unreachable.
-    $enetunreach
+    $netunreach
     ;;; Too many files open in system.
-    $enfile
+    $nfile
     ;;; No buffer space available.
-    $enobufs
+    $nobufs
     ;;; No such device.
-    $enodev
+    $nodev
     ;;; No such file or directory.
-    $enoent
+    $noent
     ;;; Executable file format error.
-    $enoexec
+    $noexec
     ;;; No locks available.
-    $enolck
+    $nolck
     ;;; Reserved.
-    $enolink
+    $nolink
     ;;; Not enough space.
-    $enomem
+    $nomem
     ;;; No message of the desired type.
-    $enomsg
+    $nomsg
     ;;; Protocol not available.
-    $enoprotoopt
+    $noprotoopt
     ;;; No space left on device.
-    $enospc
+    $nospc
     ;;; Function not supported.
-    $enosys
+    $nosys
     ;;; The socket is not connected.
-    $enotconn
+    $notconn
     ;;; Not a directory or a symbolic link to a directory.
-    $enotdir
+    $notdir
     ;;; Directory not empty.
-    $enotempty
+    $notempty
     ;;; State not recoverable.
-    $enotrecoverable
+    $notrecoverable
     ;;; Not a socket.
-    $enotsock
+    $notsock
     ;;; Not supported, or operation not supported on socket.
-    $enotsup
+    $notsup
     ;;; Inappropriate I/O control operation.
-    $enotty
+    $notty
     ;;; No such device or address.
-    $enxio
+    $nxio
     ;;; Value too large to be stored in data type.
-    $eoverflow
+    $overflow
     ;;; Previous owner died.
-    $eownerdead
+    $ownerdead
     ;;; Operation not permitted.
-    $eperm
+    $perm
     ;;; Broken pipe.
-    $epipe
+    $pipe
     ;;; Protocol error.
-    $eproto
+    $proto
     ;;; Protocol not supported.
-    $eprotonosupport
+    $protonosupport
     ;;; Protocol wrong type for socket.
-    $eprototype
+    $prototype
     ;;; Result too large.
-    $erange
+    $range
     ;;; Read-only file system.
-    $erofs
+    $rofs
     ;;; Invalid seek.
-    $espipe
+    $spipe
     ;;; No such process.
-    $esrch
+    $srch
     ;;; Reserved.
-    $estale
+    $stale
     ;;; Connection timed out.
-    $etimedout
+    $timedout
     ;;; Text file busy.
-    $etxtbsy
+    $txtbsy
     ;;; Cross-device link.
-    $exdev
+    $xdev
     ;;; Extension: Capabilities insufficient.
-    $enotcapable
+    $notcapable
   )
 )
 

--- a/phases/ephemeral/witx/typenames.witx
+++ b/phases/ephemeral/witx/typenames.witx
@@ -486,13 +486,13 @@
   (enum u8
     ;;; The time value of clock `subscription_t::u.clock.clock_id` has
     ;;; reached timestamp `subscription_t::u.clock.timeout`.
-    $eventtype_clock
+    $clock
     ;;; File descriptor `subscription_t::u.fd_readwrite.fd` has data
     ;;; available for reading. This event always triggers for regular files.
-    $eventtype_fd_read
+    $fd_read
     ;;; File descriptor `subscription_t::u.fd_readwrite.fd` has capacity
     ;;; available for writing. This event always triggers for regular files.
-    $eventtype_fd_write
+    $fd_write
   )
 )
 

--- a/phases/ephemeral/witx/typenames.witx
+++ b/phases/ephemeral/witx/typenames.witx
@@ -199,28 +199,28 @@
   (flags u64
     ;;; The right to invoke `fd_datasync`.
     ;;
-    ;;; If `RIGHT_PATH_OPEN` is set, includes the right to invoke
-    ;;; `path_open` with `FDFLAG_DSYNC`.
+    ;;; If `path_open` is set, includes the right to invoke
+    ;;; `path_open` with `fdflag::dsync`.
     $fd_datasync
     ;;; The right to invoke `fd_read` and `sock_recv`.
     ;;
-    ;;; If `RIGHT_FD_SEEK` is set, includes the right to invoke `fd_pread`.
+    ;;; If `rights::fd_seek` is set, includes the right to invoke `fd_pread`.
     $fd_read
-    ;;; The right to invoke `fd_seek`. This flag implies `RIGHT_FD_TELL`.
+    ;;; The right to invoke `fd_seek`. This flag implies `rights::fd_tell`.
     $fd_seek
     ;;; The right to invoke `fd_fdstat_set_flags`.
     $fd_fdstat_set_flags
     ;;; The right to invoke `fd_sync`.
     ;;
-    ;;; If `RIGHT_PATH_OPEN` is set, includes the right to invoke
-    ;;; `path_open` with `FDFLAG_RSYNC` and `FDFLAG_DSYNC`.
+    ;;; If `path_open` is set, includes the right to invoke
+    ;;; `path_open` with `fdflag::rsync` and `fdflag::dsync`.
     $fd_sync
     ;;; The right to invoke `fd_seek` in such a way that the file offset
     ;;; remains unaltered (i.e., `WHENCE_CUR` with offset zero), or to
     ;;; invoke `fd_tell`.
     $fd_tell
     ;;; The right to invoke `fd_write` and `sock_send`.
-    ;;; If `RIGHT_FD_SEEK` is set, includes the right to invoke `fd_pwrite`.
+    ;;; If `rights::fd_seek` is set, includes the right to invoke `fd_pwrite`.
     $fd_write
     ;;; The right to invoke `fd_advise`.
     $fd_advise
@@ -228,7 +228,7 @@
     $fd_allocate
     ;;; The right to invoke `path_create_directory`.
     $path_create_directory
-    ;;; If `RIGHT_PATH_OPEN` is set, the right to invoke `path_open` with `O_CREAT`.
+    ;;; If `path_open` is set, the right to invoke `path_open` with `oflags::creat`.
     $path_create_file
     ;;; The right to invoke `path_link` with the file descriptor as the
     ;;; source directory.
@@ -249,7 +249,7 @@
     ;;; The right to invoke `path_filestat_get`.
     $path_filestat_get
     ;;; The right to change a file's size (there is no `path_filestat_set_size`).
-    ;;; If `RIGHT_PATH_OPEN` is set, includes the right to invoke `path_open` with `O_TRUNC`.
+    ;;; If `path_open` is set, includes the right to invoke `path_open` with `oflags::trunc`.
     $path_filestat_set_size
     ;;; The right to invoke `path_filestat_set_times`.
     $path_filestat_set_times
@@ -265,8 +265,8 @@
     $path_remove_directory
     ;;; The right to invoke `path_unlink_file`.
     $path_unlink_file
-    ;;; If `RIGHT_FD_READ` is set, includes the right to invoke `poll_oneoff` to subscribe to `EVENTTYPE_FD_READ`.
-    ;;; If `RIGHT_FD_WRITE` is set, includes the right to invoke `poll_oneoff` to subscribe to `EVENTTYPE_FD_WRITE`.
+    ;;; If `rights::fd_read` is set, includes the right to invoke `poll_oneoff` to subscribe to `eventtype::fd_read`.
+    ;;; If `rights::fd_write` is set, includes the right to invoke `poll_oneoff` to subscribe to `eventtype::fd_write`.
     $poll_fd_readwrite
     ;;; The right to invoke `sock_shutdown`.
     $sock_shutdown
@@ -413,19 +413,19 @@
 )
 
 ;;; Identifier for a device containing a file system. Can be used in combination
-;;; with `inode_t` to uniquely identify a file or directory in the filesystem.
+;;; with `inode` to uniquely identify a file or directory in the filesystem.
 (typename $device u64)
 
 ;;; Which file time attributes to adjust.
 (typename $fstflags
   (flags u16
-    ;;; Adjust the last data access timestamp to the value stored in `filestat_t::st_atim`.
+    ;;; Adjust the last data access timestamp to the value stored in `filestat::st_atim`.
     $atim
-    ;;; Adjust the last data access timestamp to the time of clock `CLOCK_REALTIME`.
+    ;;; Adjust the last data access timestamp to the time of clock `clock::realtime`.
     $atim_now
-    ;;; Adjust the last data modification timestamp to the value stored in `filestat_t::st_mtim`.
+    ;;; Adjust the last data modification timestamp to the value stored in `filestat::st_mtim`.
     $mtim
-    ;;; Adjust the last data modification timestamp to the time of clock `CLOCK_REALTIME`.
+    ;;; Adjust the last data modification timestamp to the time of clock `clock::realtime`.
     $mtim_now
   )
 )
@@ -484,20 +484,20 @@
 ;;; Type of a subscription to an event or its occurrence.
 (typename $eventtype
   (enum u8
-    ;;; The time value of clock `subscription_t::u.clock.clock_id` has
-    ;;; reached timestamp `subscription_t::u.clock.timeout`.
+    ;;; The time value of clock `subscription::u.clock.clock_id` has
+    ;;; reached timestamp `subscription::u.clock.timeout`.
     $clock
-    ;;; File descriptor `subscription_t::u.fd_readwrite.fd` has data
+    ;;; File descriptor `subscription::u.fd_readwrite.fd` has data
     ;;; available for reading. This event always triggers for regular files.
     $fd_read
-    ;;; File descriptor `subscription_t::u.fd_readwrite.fd` has capacity
+    ;;; File descriptor `subscription::u.fd_readwrite.fd` has capacity
     ;;; available for writing. This event always triggers for regular files.
     $fd_write
   )
 )
 
 ;;; The state of the file descriptor subscribed to with
-;;; `EVENTTYPE_FD_READ` or `EVENTTYPE_FD_WRITE`.
+;;; `eventtype::fd_read` or `eventtype::fd_write`.
 (typename $eventrwflags
   (flags u16
     ;;; The peer of this socket has closed or disconnected.
@@ -505,8 +505,8 @@
   )
 )
 
-;;; The contents of an $event when type is `EVENTTYPE_FD_READ` or
-;;; `EVENTTYPE_FD_WRITE`.
+;;; The contents of an $event when type is `eventtype::fd_read` or
+;;; `eventtype::fd_write`.
 (typename $event_fd_readwrite
   (struct
     ;;; The number of bytes available for reading or writing.
@@ -519,7 +519,7 @@
 ;;; The contents of an $event.
 (typename $event_u
   (union
-    ;;; When type is `EVENTTYPE_FD_READ` or `EVENTTYPE_FD_WRITE`:
+    ;;; When type is `eventtype::fd_read` or `eventtype::fd_write`:
     (field $fd_readwrite $event_fd_readwrite)
   )
 )
@@ -527,7 +527,7 @@
 ;;; An event that occurred.
 (typename $event
   (struct
-    ;;; User-provided value that got attached to `subscription_t::userdata`.
+    ;;; User-provided value that got attached to `subscription::userdata`.
     (field $userdata $userdata)
     ;;; If non-zero, an error that occurred while processing the subscription request.
     (field $error $errno)
@@ -539,19 +539,19 @@
 )
 
 ;;; Flags determining how to interpret the timestamp provided in
-;;; `subscription_t::u.clock.timeout.`
+;;; `subscription::u.clock.timeout.`
 (typename $subclockflags
   (flags u16
     ;;; If set, treat the timestamp provided in
-    ;;; `subscription_t::u.clock.timeout` as an absolute timestamp of clock
-    ;;; `subscription_t::u.clock.clock_id.` If clear, treat the timestamp
-    ;;; provided in `subscription_t::u.clock.timeout` relative to the
-    ;;; current time value of clock `subscription_t::u.clock.clock_id.`
+    ;;; `subscription::u.clock.timeout` as an absolute timestamp of clock
+    ;;; `subscription::u.clock.clock_id.` If clear, treat the timestamp
+    ;;; provided in `subscription::u.clock.timeout` relative to the
+    ;;; current time value of clock `subscription::u.clock.clock_id.`
     $subscription_clock_abstime
   )
 )
 
-;;; The contents of a $subscription when type is `EVENTTYPE_CLOCK`.
+;;; The contents of a $subscription when type is `eventtype::clock`.
 (typename $subscription_clock
   (struct
     ;;; The clock against which to compare the timestamp.
@@ -567,7 +567,7 @@
 )
 
 ;;; The contents of a $subscription when type is type is
-;;; `EVENTTYPE_FD_READ` or `EVENTTYPE_FD_WRITE`.
+;;; `eventtype::fd_read` or `eventtype::fd_write`.
 (typename $subscription_fd_readwrite
   (struct
     ;;; The file descriptor on which to wait for it to become ready for reading or writing.
@@ -578,9 +578,9 @@
 ;;; The contents of a $subscription.
 (typename $subscription_u
   (union
-    ;;; When type is `EVENTTYPE_CLOCK`:
+    ;;; When type is `eventtype::clock`:
     (field $clock $subscription_clock)
-    ;;; When type is `EVENTTYPE_FD_READ` or `EVENTTYPE_FD_WRITE`:
+    ;;; When type is `eventtype::fd_read` or `eventtype::fd_write`:
     (field $fd_readwrite $subscription_fd_readwrite)
   )
 )
@@ -589,7 +589,7 @@
 (typename $subscription
   (struct
     ;;; User-provided value that is attached to the subscription in the
-    ;;; implementation and returned through `event_t::userdata`.
+    ;;; implementation and returned through `event::userdata`.
     (field $userdata $userdata)
     ;;; The type of the event to which to subscribe.
     (field $type $eventtype)
@@ -740,7 +740,7 @@
   )
 )
 
-;;; The contents of a $prestat when type is `PREOPENTYPE_DIR`.
+;;; The contents of a $prestat when type is `preopentype::dir`.
 (typename $prestat_dir
   (struct
     ;;; The length of the directory name for use with `fd_prestat_dir_name`.
@@ -751,7 +751,7 @@
 ;;; The contents of an $prestat.
 (typename $prestat_u
   (union
-    ;;; When type is `PREOPENTYPE_DIR`:
+    ;;; When type is `preopentype::dir`:
     (field $dir $prestat_dir)
   )
 )

--- a/phases/ephemeral/witx/typenames.witx
+++ b/phases/ephemeral/witx/typenames.witx
@@ -606,97 +606,97 @@
   (enum u8
     ;;; No signal. Note that POSIX has special semantics for `kill(pid, 0)`,
     ;;; so this value is reserved.
-    $signone
+    $none
     ;;; Hangup.
     ;;; Action: Terminates the process.
-    $sighup
+    $hup
     ;;; Terminate interrupt signal.
     ;;; Action: Terminates the process.
-    $sigint
+    $int
     ;;; Terminal quit signal.
     ;;; Action: Terminates the process.
-    $sigquit
+    $quit
     ;;; Illegal instruction.
     ;;; Action: Terminates the process.
-    $sigill
+    $ill
     ;;; Trace/breakpoint trap.
     ;;; Action: Terminates the process.
-    $sigtrap
+    $trap
     ;;; Process abort signal.
     ;;; Action: Terminates the process.
-    $sigabrt
+    $abrt
     ;;; Access to an undefined portion of a memory object.
     ;;; Action: Terminates the process.
-    $sigbus
+    $bus
     ;;; Erroneous arithmetic operation.
     ;;; Action: Terminates the process.
-    $sigfpe
+    $fpe
     ;;; Kill.
     ;;; Action: Terminates the process.
-    $sigkill
+    $kill
     ;;; User-defined signal 1.
     ;;; Action: Terminates the process.
-    $sigusr1
+    $usr1
     ;;; Invalid memory reference.
     ;;; Action: Terminates the process.
-    $sigsegv
+    $segv
     ;;; User-defined signal 2.
     ;;; Action: Terminates the process.
-    $sigusr2
+    $usr2
     ;;; Write on a pipe with no one to read it.
     ;;; Action: Ignored.
-    $sigpipe
+    $pipe
     ;;; Alarm clock.
     ;;; Action: Terminates the process.
-    $sigalrm
+    $alrm
     ;;; Termination signal.
     ;;; Action: Terminates the process.
-    $sigterm
+    $term
     ;;; Child process terminated, stopped, or continued.
     ;;; Action: Ignored.
-    $sigchld
+    $chld
     ;;; Continue executing, if stopped.
     ;;; Action: Continues executing, if stopped.
-    $sigcont
+    $cont
     ;;; Stop executing.
     ;;; Action: Stops executing.
-    $sigstop
+    $stop
     ;;; Terminal stop signal.
     ;;; Action: Stops executing.
-    $sigtstp
+    $tstp
     ;;; Background process attempting read.
     ;;; Action: Stops executing.
-    $sigttin
+    $ttin
     ;;; Background process attempting write.
     ;;; Action: Stops executing.
-    $sigttou
+    $ttou
     ;;; High bandwidth data is available at a socket.
     ;;; Action: Ignored.
-    $sigurg
+    $urg
     ;;; CPU time limit exceeded.
     ;;; Action: Terminates the process.
-    $sigxcpu
+    $xcpu
     ;;; File size limit exceeded.
     ;;; Action: Terminates the process.
-    $sigxfsz
+    $xfsz
     ;;; Virtual timer expired.
     ;;; Action: Terminates the process.
-    $sigvtalrm
+    $vtalrm
     ;;; Profiling timer expired.
     ;;; Action: Terminates the process.
-    $sigprof
+    $prof
     ;;; Window changed.
     ;;; Action: Ignored.
-    $sigwinch
+    $winch
     ;;; I/O possible.
     ;;; Action: Terminates the process.
-    $sigpoll
+    $poll
     ;;; Power failure.
     ;;; Action: Terminates the process.
-    $sigpwr
+    $pwr
     ;;; Bad system call.
     ;;; Action: Terminates the process.
-    $sigsys
+    $sys
   )
 )
 

--- a/phases/ephemeral/witx/wasi_ephemeral_preview.witx
+++ b/phases/ephemeral/witx/wasi_ephemeral_preview.witx
@@ -17,15 +17,15 @@
   (@interface func (export "args_get")
     (param $argv (@witx pointer (@witx pointer u8)))
     (param $argv_buf (@witx pointer u8))
-    (result $error $errno_t)
+    (result $error $errno)
   )
   ;;; Return command-line argument data sizes.
   (@interface func (export "args_sizes_get")
-    (result $error $errno_t)
+    (result $error $errno)
     ;;; The number of arguments.
-    (result $argc $size_t)
+    (result $argc $size)
     ;;; The size of the argument string data.
-    (result $argv_buf_size $size_t)
+    (result $argv_buf_size $size)
   )
 
   ;;; Read environment variable data.
@@ -33,187 +33,187 @@
   (@interface func (export "environ_get")
     (param $environ (@witx pointer (@witx pointer u8)))
     (param $environ_buf (@witx pointer u8))
-    (result $error $errno_t)
+    (result $error $errno)
   )
   ;;; Return command-line argument data sizes.
   (@interface func (export "environ_sizes_get")
-    (result $error $errno_t)
+    (result $error $errno)
     ;;; The number of arguments.
-    (result $argc $size_t)
+    (result $argc $size)
     ;;; The size of the argument string data.
-    (result $argv_buf_size $size_t)
+    (result $argv_buf_size $size)
   )
 
   ;;; Return the resolution of a clock.
   ;;; Implementations are required to provide a non-zero value for supported clocks. For unsupported clocks, return `WASI_EINVAL`
   ;;; Note: This is similar to `clock_getres` in POSIX.
   (@interface func (export "clock_res_get")
-    (result $error $errno_t)
+    (result $error $errno)
     ;;; The clock for which to return the resolution.
-    (param $clock_id $clockid_t)
+    (param $clock_id $clockid)
     ;;; The resolution of the clock.
-    (result $resolution $timestamp_t)
+    (result $resolution $timestamp)
   )
   ;;; Return the time value of a clock.
   ;;; Note: This is similar to `clock_gettime` in POSIX.
   (@interface func (export "clock_time_get")
     ;;; The clock for which to return the time.
-    (param $clock_id $clockid_t)
+    (param $clock_id $clockid)
     ;;; The maximum lag (exclusive) that the returned time value may have, compared to its actual value.
-    (param $precision $timestamp_t)
-    (result $error $errno_t)
+    (param $precision $timestamp)
+    (result $error $errno)
     ;;; The time value of the clock.
-    (result $time $timestamp_t)
+    (result $time $timestamp)
   )
 
   ;;; Provide file advisory information on a file descriptor.
   ;;; Note: This is similar to `posix_fadvise` in POSIX.
   (@interface func (export "fd_advise")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; The offset within the file to which the advisory applies.
-    (param $offset $filesize_t)
+    (param $offset $filesize)
     ;;; The length of the region to which the advisory applies.
-    (param $len $filesize_t)
+    (param $len $filesize)
     ;;; The advice.
-    (param $advice $advice_t)
-    (result $error $errno_t)
+    (param $advice $advice)
+    (result $error $errno)
   )
 
   ;;; Force the allocation of space in a file.
   ;;; Note: This is similar to `posix_fallocate` in POSIX.
   (@interface func (export "fd_allocate")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; The offset at which to start the allocation.
-    (param $offset $filesize_t)
+    (param $offset $filesize)
     ;;; The length of the area that is allocated.
-    (param $len $filesize_t)
-    (result $error $errno_t)
+    (param $len $filesize)
+    (result $error $errno)
   )
 
   ;;; Close a file descriptor.
   ;;; Note: This is similar to `close` in POSIX.
   (@interface func (export "fd_close")
-    (param $fd $fd_t)
-    (result $error $errno_t)
+    (param $fd $fd)
+    (result $error $errno)
   )
 
   ;;; Synchronize the data of a file to disk.
   ;;; Note: This is similar to `fdatasync` in POSIX.
   (@interface func (export "fd_datasync")
-    (param $fd $fd_t)
-    (result $error $errno_t)
+    (param $fd $fd)
+    (result $error $errno)
   )
 
   ;;; Get the attributes of a file descriptor.
   ;;; Note: This returns similar flags to `fsync(fd, F_GETFL)` in POSIX, as well as additional fields.
   (@interface func (export "fd_fdstat_get")
-    (param $fd $fd_t)
-    (result $error $errno_t)
+    (param $fd $fd)
+    (result $error $errno)
     ;;; The buffer where the file descriptor's attributes are stored.
-    (result $stat $fdstat_t)
+    (result $stat $fdstat)
   )
 
   ;;; Adjust the flags associated with a file descriptor.
   ;;; Note: This is similar to `fcntl(fd, F_SETFL, flags)` in POSIX.
   (@interface func (export "fd_fdstat_set_flags")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; The desired values of the file descriptor flags.
-    (param $flags $fdflags_t)
-    (result $error $errno_t)
+    (param $flags $fdflags)
+    (result $error $errno)
   )
 
   ;;; Adjust the rights associated with a file descriptor.
   ;;; This can only be used to remove rights, and returns `ENOTCAPABLE` if called in a way that would attempt to add rights
   (@interface func (export "fd_fdstat_set_rights")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; The desired rights of the file descriptor.
-    (param $fs_rights_base $rights_t)
-    (param $fs_rights_inheriting $rights_t)
-    (result $error $errno_t)
+    (param $fs_rights_base $rights)
+    (param $fs_rights_inheriting $rights)
+    (result $error $errno)
   )
 
   ;;; Return the attributes of an open file.
   (@interface func (export "fd_filestat_get")
-    (param $fd $fd_t)
-    (result $error $errno_t)
+    (param $fd $fd)
+    (result $error $errno)
     ;;; The buffer where the file's attributes are stored.
-    (result $buf $filestat_t)
+    (result $buf $filestat)
   )
 
   ;;; Adjust the size of an open file. If this increases the file's size, the extra bytes are filled with zeros.
   ;;; Note: This is similar to `ftruncate` in POSIX.
   (@interface func (export "fd_filestat_set_size")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; The desired file size.
-    (param $st_size $filesize_t)
-    (result $error $errno_t)
+    (param $st_size $filesize)
+    (result $error $errno)
   )
 
   ;;; Adjust the timestamps of an open file or directory.
   ;;; Note: This is similar to `futimens` in POSIX.
   (@interface func (export "fd_filestat_set_times")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; The desired values of the data access timestamp.
-    (param $st_atim $timestamp_t)
+    (param $st_atim $timestamp)
     ;;; The desired values of the data modification timestamp.
-    (param $st_mtim $timestamp_t)
+    (param $st_mtim $timestamp)
     ;;; A bitmask indicating which timestamps to adjust.
-    (param $fst_flags $fstflags_t)
-    (result $error $errno_t)
+    (param $fst_flags $fstflags)
+    (result $error $errno)
   )
 
   ;;; Read from a file descriptor, without using and updating the file descriptor's offset.
   ;;; Note: This is similar to `preadv` in POSIX.
   (@interface func (export "fd_pread")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; List of scatter/gather vectors in which to store data.
-    (param $iovs $iovec_t_array)
+    (param $iovs $iovec_array)
     ;;; The offset within the file at which to read.
-    (param $offset $filesize_t)
-    (result $error $errno_t)
+    (param $offset $filesize)
+    (result $error $errno)
     ;;; The number of bytes read.
-    (result $nread $size_t)
+    (result $nread $size)
   )
 
   ;;; Return a description of the given preopened file descriptor.
   (@interface func (export "fd_prestat_get")
-    (param $fd $fd_t)
-    (result $error $errno_t)
+    (param $fd $fd)
+    (result $error $errno)
     ;;; The buffer where the description is stored.
-    (result $buf $prestat_t)
+    (result $buf $prestat)
   )
 
   ;;; Return a description of the given preopened file descriptor.
   (@interface func (export "fd_prestat_dir_name")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; A buffer into which to write the preopened directory name.
     (param $path (@witx pointer u8))
-    (param $path_len $size_t)
-    (result $error $errno_t)
+    (param $path_len $size)
+    (result $error $errno)
   )
 
   ;;; Write to a file descriptor, without using and updating the file descriptor's offset.
   ;;; Note: This is similar to `pwritev` in POSIX.
   (@interface func (export "fd_pwrite")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; List of scatter/gather vectors from which to retrieve data.
-    (param $iovs $ciovec_t_array)
+    (param $iovs $ciovec_array)
     ;;; The offset within the file at which to write.
-    (param $offset $filesize_t)
-    (result $error $errno_t)
+    (param $offset $filesize)
+    (result $error $errno)
     ;;; The number of bytes written.
-    (result $nwritten $size_t)
+    (result $nwritten $size)
   )
 
   ;;; Read from a file descriptor.
   ;;; Note: This is similar to `readv` in POSIX.
   (@interface func (export "fd_read")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; List of scatter/gather vectors to which to store data.
-    (param $iovs $iovec_t_array)
-    (result $error $errno_t)
+    (param $iovs $iovec_array)
+    (result $error $errno)
     ;;; The number of bytes read.
-    (result $nread $size_t)
+    (result $nread $size)
   )
 
   ;;; Read directory entries from a directory.
@@ -227,15 +227,15 @@
   ;;; read buffer size in case it's too small to fit a single large directory
   ;;; entry, or skip the oversized directory entry.
   (@interface func (export "fd_readdir")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; The buffer where directory entries are stored
     (param $buf (@witx pointer u8))
-    (param $buf_len $size_t)
+    (param $buf_len $size)
     ;;; The location within the directory to start reading
-    (param $cookie $dircookie_t)
-    (result $error $errno_t)
+    (param $cookie $dircookie)
+    (result $error $errno)
     ;;; The number of bytes stored in the read buffer. If less than the size of the read buffer, the end of the directory has been reached.
-    (result $bufused $size_t)
+    (result $bufused $size)
   )
 
   ;;; Atomically replace a file descriptor by renumbering another file descriptor.
@@ -249,104 +249,104 @@
   ;;; This function provides a way to atomically renumber file descriptors, which
   ;;; would disappear if `dup2()` were to be removed entirely.
   (@interface func (export "fd_renumber")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; The file descriptor to overwrite.
-    (param $to $fd_t)
-    (result $error $errno_t)
+    (param $to $fd)
+    (result $error $errno)
   )
 
   ;;; Move the offset of a file descriptor.
   ;;; Note: This is similar to `lseek` in POSIX.
   (@interface func (export "fd_seek")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; The number of bytes to move.
-    (param $offset $filedelta_t)
+    (param $offset $filedelta)
     ;;; The base from which the offset is relative.
-    (param $whence $whence_t)
-    (result $error $errno_t)
+    (param $whence $whence)
+    (result $error $errno)
     ;;; The new offset of the file descriptor, relative to the start of the file.
-    (result $newoffset $filesize_t)
+    (result $newoffset $filesize)
   )
 
   ;;; Synchronize the data and metadata of a file to disk.
   ;;; Note: This is similar to `fsync` in POSIX.
   (@interface func (export "fd_sync")
-    (param $fd $fd_t)
-    (result $error $errno_t)
+    (param $fd $fd)
+    (result $error $errno)
   )
 
   ;;; Return the current offset of a file descriptor.
   ;;; Note: This is similar to `lseek(fd, 0, SEEK_CUR)` in POSIX.
   (@interface func (export "fd_tell")
-    (param $fd $fd_t)
-    (result $error $errno_t)
+    (param $fd $fd)
+    (result $error $errno)
     ;;; The current offset of the file descriptor, relative to the start of the file.
-    (result $offset $filesize_t)
+    (result $offset $filesize)
   )
 
   ;;; Write to a file descriptor.
   ;;; Note: This is similar to `writev` in POSIX.
   (@interface func (export "fd_write")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; List of scatter/gather vectors from which to retrieve data.
-    (param $iovs $ciovec_t_array)
-    (result $error $errno_t)
+    (param $iovs $ciovec_array)
+    (result $error $errno)
     ;;; The number of bytes written.
-    (result $nwritten $size_t)
+    (result $nwritten $size)
   )
 
   ;;; Create a directory.
   ;;; Note: This is similar to `mkdirat` in POSIX.
   (@interface func (export "path_create_directory")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; The path at which to create the directory.
     (param $path string)
-    (result $error $errno_t)
+    (result $error $errno)
   )
 
   ;;; Return the attributes of a file or directory.
   ;;; Note: This is similar to `stat` in POSIX.
   (@interface func (export "path_filestat_get")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; Flags determining the method of how the path is resolved.
-    (param $flags $lookupflags_t)
+    (param $flags $lookupflags)
     ;;; The path of the file or directory to inspect.
     (param $path string)
-    (result $error $errno_t)
+    (result $error $errno)
     ;;; The buffer where the file's attributes are stored.
-    (result $buf $filestat_t)
+    (result $buf $filestat)
   )
 
   ;;; Adjust the timestamps of a file or directory.
   ;;; Note: This is similar to `utimensat` in POSIX.
   (@interface func (export "path_filestat_set_times")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; Flags determining the method of how the path is resolved.
-    (param $flags $lookupflags_t)
+    (param $flags $lookupflags)
     ;;; The path of the file or directory to operate on.
     (param $path string)
     ;;; The desired values of the data access timestamp.
-    (param $st_atim $timestamp_t)
+    (param $st_atim $timestamp)
     ;;; The desired values of the data modification timestamp.
-    (param $st_mtim $timestamp_t)
+    (param $st_mtim $timestamp)
     ;;; A bitmask indicating which timestamps to adjust.
-    (param $fst_flags $fstflags_t)
-    (result $error $errno_t)
+    (param $fst_flags $fstflags)
+    (result $error $errno)
   )
 
   ;;; Create a hard link.
   ;;; Note: This is similar to `linkat` in POSIX.
   (@interface func (export "path_link")
-    (param $old_fd $fd_t)
+    (param $old_fd $fd)
     ;;; Flags determining the method of how the path is resolved.
-    (param $old_flags $lookupflags_t)
+    (param $old_flags $lookupflags)
     ;;; The source path from which to link.
     (param $old_path string)
     ;;; The working directory at which the resolution of the new path starts.
-    (param $new_fd $fd_t)
+    (param $new_fd $fd)
     ;;; The destination path at which to create the hard link.
     (param $new_path string)
-    (result $error $errno_t)
+    (result $error $errno)
   )
 
   ;;; Open a file or directory.
@@ -359,14 +359,14 @@
   ;;
   ;;; Note: This is similar to `openat` in POSIX.
   (@interface func (export "path_open")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; Flags determining the method of how the path is resolved.
-    (param $dirflags $lookupflags_t)
+    (param $dirflags $lookupflags)
     ;;; The relative path of the file or directory to open, relative to the
     ;;; `dirfd` directory.
     (param $path string)
     ;;; The method by which to open the file.
-    (param $o_flags $oflags_t)
+    (param $o_flags $oflags)
     ;;; The initial rights of the newly created file descriptor. The
     ;;; implementation is allowed to return a file descriptor with fewer rights
     ;;; than specified, if and only if those rights do not apply to the type of
@@ -375,49 +375,49 @@
     ;;; The *base* rights are rights that will apply to operations using the file
     ;;; descriptor itself, while the *inheriting* rights are rights that apply to
     ;;; file descriptors derived from it.
-    (param $fs_rights_base $rights_t)
-    (param $fs_rights_inherting $rights_t)
-    (param $flags $fdflags_t)
-    (result $error $errno_t)
+    (param $fs_rights_base $rights)
+    (param $fs_rights_inherting $rights)
+    (param $flags $fdflags)
+    (result $error $errno)
     ;;; The file descriptor of the file that has been opened.
-    (result $opened_fd $fd_t)
+    (result $opened_fd $fd)
   )
 
   ;;; Read the contents of a symbolic link.
   ;;; Note: This is similar to `readlinkat` in POSIX.
   (@interface func (export "path_readlink")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; The path of the symbolic link from which to read.
     (param $path string)
     ;;; The buffer to which to write the contents of the symbolic link.
     (param $buf (@witx pointer u8))
-    (param $buf_len $size_t)
-    (result $error $errno_t)
+    (param $buf_len $size)
+    (result $error $errno)
     ;;; The number of bytes placed in the buffer.
-    (result $bufused $size_t)
+    (result $bufused $size)
   )
 
   ;;; Remove a directory.
   ;;; Return `ENOTEMPTY` if the directory is not empty.
   ;;; Note: This is similar to `unlinkat(fd, path, AT_REMOVEDIR)` in POSIX.
   (@interface func (export "path_remove_directory")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; The path to a directory to remove.
     (param $path string)
-    (result $error $errno_t)
+    (result $error $errno)
   )
 
   ;;; Rename a file or directory.
   ;;; Note: This is similar to `renameat` in POSIX.
   (@interface func (export "path_rename")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; The source path of the file or directory to rename.
     (param $old_path string)
     ;;; The working directory at which the resolution of the new path starts.
-    (param $new_fd $fd_t)
+    (param $new_fd $fd)
     ;;; The destination path to which to rename the file or directory.
     (param $new_path string)
-    (result $error $errno_t)
+    (result $error $errno)
   )
 
   ;;; Create a symbolic link.
@@ -425,10 +425,10 @@
   (@interface func (export "path_symlink")
     ;;; The contents of the symbolic link.
     (param $old_path string)
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; The destination path at which to create the symbolic link.
     (param $new_path string)
-    (result $error $errno_t)
+    (result $error $errno)
   )
 
 
@@ -436,23 +436,23 @@
   ;;; Return `EISDIR` if the path refers to a directory.
   ;;; Note: This is similar to `unlinkat(fd, path, 0)` in POSIX.
   (@interface func (export "path_unlink_file")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; The path to a file to unlink.
     (param $path string)
-    (result $error $errno_t)
+    (result $error $errno)
   )
 
   ;;; Concurrently poll for the occurrence of a set of events.
   (@interface func (export "poll_oneoff")
     ;;; The events to which to subscribe.
-    (param $in (@witx const_pointer $subscription_t))
+    (param $in (@witx const_pointer $subscription))
     ;;; The events that have occurred.
-    (param $out (@witx pointer $event_t))
+    (param $out (@witx pointer $event))
     ;;; Both the number of subscriptions and events.
-    (param $nsubscriptions $size_t)
-    (result $error $errno_t)
+    (param $nsubscriptions $size)
+    (result $error $errno)
     ;;; The number of events stored.
-    (result $nevents $size_t)
+    (result $nevents $size)
   )
 
   ;;; Terminate the process normally. An exit code of 0 indicates successful
@@ -460,21 +460,21 @@
   ;;; the environment.
   (@interface func (export "proc_exit")
     ;;; The exit code returned by the process.
-    (param $rval $exitcode_t)
+    (param $rval $exitcode)
   )
 
   ;;; Send a signal to the process of the calling thread.
   ;;; Note: This is similar to `raise` in POSIX.
   (@interface func (export "proc_raise")
     ;;; The signal condition to trigger.
-    (param $sig $signal_t)
-    (result $error $errno_t)
+    (param $sig $signal)
+    (result $error $errno)
   )
 
   ;;; Temporarily yield execution of the calling thread.
   ;;; Note: This is similar to `sched_yield` in POSIX.
   (@interface func (export "sched_yield")
-    (result $error $errno_t)
+    (result $error $errno)
   )
 
   ;;; Write high-quality random data into a buffer.
@@ -486,46 +486,46 @@
   (@interface func (export "random_get")
     ;;; The buffer to fill with random data.
     (param $buf (@witx pointer u8))
-    (param $buf_len $size_t)
-    (result $error $errno_t)
+    (param $buf_len $size)
+    (result $error $errno)
   )
 
   ;;; Receive a message from a socket.
   ;;; Note: This is similar to `recv` in POSIX, though it also supports reading
   ;;; the data into multiple buffers in the manner of `readv`.
   (@interface func (export "sock_recv")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; List of scatter/gather vectors to which to store data.
-    (param $ri_data $iovec_t_array)
+    (param $ri_data $iovec_array)
     ;;; Message flags.
-    (param $ri_flags $riflags_t)
-    (result $error $errno_t)
+    (param $ri_flags $riflags)
+    (result $error $errno)
     ;;; Number of bytes stored in ri_data.
-    (result $ro_datalen $size_t)
+    (result $ro_datalen $size)
     ;;; Message flags.
-    (result $ro_flags $roflags_t)
+    (result $ro_flags $roflags)
   )
 
   ;;; Send a message on a socket.
   ;;; Note: This is similar to `send` in POSIX, though it also supports writing
   ;;; the data from multiple buffers in the manner of `writev`.
   (@interface func (export "sock_send")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; List of scatter/gather vectors to which to retrieve data
-    (param $si_data $ciovec_t_array)
+    (param $si_data $ciovec_array)
     ;;; Message flags.
-    (param $si_flags $siflags_t)
-    (result $error $errno_t)
+    (param $si_flags $siflags)
+    (result $error $errno)
     ;;; Number of bytes transmitted.
-    (result $so_datalen $size_t)
+    (result $so_datalen $size)
   )
 
   ;;; Shut down socket send and receive channels.
   ;;; Note: This is similar to `shutdown` in POSIX.
   (@interface func (export "sock_shutdown")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; Which channels on the socket to shut down.
-    (param $how $sdflags_t)
-    (result $error $errno_t)
+    (param $how $sdflags)
+    (result $error $errno)
   )
 )

--- a/phases/ephemeral/witx/wasi_ephemeral_preview.witx
+++ b/phases/ephemeral/witx/wasi_ephemeral_preview.witx
@@ -50,7 +50,7 @@
   (@interface func (export "clock_res_get")
     (result $error $errno)
     ;;; The clock for which to return the resolution.
-    (param $clock_id $clockid)
+    (param $id $clockid)
     ;;; The resolution of the clock.
     (result $resolution $timestamp)
   )
@@ -58,7 +58,7 @@
   ;;; Note: This is similar to `clock_gettime` in POSIX.
   (@interface func (export "clock_time_get")
     ;;; The clock for which to return the time.
-    (param $clock_id $clockid)
+    (param $id $clockid)
     ;;; The maximum lag (exclusive) that the returned time value may have, compared to its actual value.
     (param $precision $timestamp)
     (result $error $errno)
@@ -145,7 +145,7 @@
   (@interface func (export "fd_filestat_set_size")
     (param $fd $fd)
     ;;; The desired file size.
-    (param $st_size $filesize)
+    (param $size $filesize)
     (result $error $errno)
   )
 
@@ -154,9 +154,9 @@
   (@interface func (export "fd_filestat_set_times")
     (param $fd $fd)
     ;;; The desired values of the data access timestamp.
-    (param $st_atim $timestamp)
+    (param $atim $timestamp)
     ;;; The desired values of the data modification timestamp.
-    (param $st_mtim $timestamp)
+    (param $mtim $timestamp)
     ;;; A bitmask indicating which timestamps to adjust.
     (param $fst_flags $fstflags)
     (result $error $errno)
@@ -326,9 +326,9 @@
     ;;; The path of the file or directory to operate on.
     (param $path string)
     ;;; The desired values of the data access timestamp.
-    (param $st_atim $timestamp)
+    (param $atim $timestamp)
     ;;; The desired values of the data modification timestamp.
-    (param $st_mtim $timestamp)
+    (param $mtim $timestamp)
     ;;; A bitmask indicating which timestamps to adjust.
     (param $fst_flags $fstflags)
     (result $error $errno)
@@ -366,7 +366,7 @@
     ;;; `dirfd` directory.
     (param $path string)
     ;;; The method by which to open the file.
-    (param $o_flags $oflags)
+    (param $flags $oflags)
     ;;; The initial rights of the newly created file descriptor. The
     ;;; implementation is allowed to return a file descriptor with fewer rights
     ;;; than specified, if and only if those rights do not apply to the type of

--- a/phases/ephemeral/witx/wasi_ephemeral_preview.witx
+++ b/phases/ephemeral/witx/wasi_ephemeral_preview.witx
@@ -366,7 +366,7 @@
     ;;; `dirfd` directory.
     (param $path string)
     ;;; The method by which to open the file.
-    (param $flags $oflags)
+    (param $oflags $oflags)
     ;;; The initial rights of the newly created file descriptor. The
     ;;; implementation is allowed to return a file descriptor with fewer rights
     ;;; than specified, if and only if those rights do not apply to the type of
@@ -377,7 +377,7 @@
     ;;; file descriptors derived from it.
     (param $fs_rights_base $rights)
     (param $fs_rights_inherting $rights)
-    (param $flags $fdflags)
+    (param $fdflags $fdflags)
     (result $error $errno)
     ;;; The file descriptor of the file that has been opened.
     (result $opened_fd $fd)

--- a/phases/old/snapshot_0/witx/typenames.witx
+++ b/phases/old/snapshot_0/witx/typenames.witx
@@ -18,16 +18,16 @@
   (enum u32
     ;;; The clock measuring real time. Time value zero corresponds with
     ;;; 1970-01-01T00:00:00Z.
-    $CLOCK_REALTIME
+    $clock_realtime
     ;;; The store-wide monotonic clock, which is defined as a clock measuring
     ;;; real time, whose value cannot be adjusted and which cannot have negative
     ;;; clock jumps. The epoch of this clock is undefined. The absolute time
     ;;; value of this clock therefore has no meaning.
-    $CLOCK_MONOTONIC
+    $clock_monotonic
     ;;; The CPU-time clock associated with the current process.
-    $CLOCK_PROCESS_CPUTIME_ID
+    $clock_process_cputime_id
     ;;; The CPU-time clock associated with the current thread.
-    $CLOCK_THREAD_CPUTIME_ID
+    $clock_thread_cputime_id
   )
 )
 
@@ -38,159 +38,159 @@
 (typename $errno
   (enum u16
     ;;; No error occurred. System call completed successfully.
-    $ESUCCESS
+    $esuccess
     ;;; Argument list too long.
-    $E2BIG
+    $e2big
     ;;; Permission denied.
-    $EACCES
+    $eacces
     ;;; Address in use.
-    $EADDRINUSE
+    $eaddrinuse
     ;;; Address not available.
-    $EADDRNOTAVAIL
+    $eaddrnotavail
     ;;; Address family not supported.
-    $EAFNOSUPPORT
+    $eafnosupport
     ;;; Resource unavailable, or operation would block.
-    $EAGAIN
+    $eagain
     ;;; Connection already in progress.
-    $EALREADY
+    $ealready
     ;;; Bad file descriptor.
-    $EBADF
+    $ebadf
     ;;; Bad message.
-    $EBADMSG
+    $ebadmsg
     ;;; Device or resource busy.
-    $EBUSY
+    $ebusy
     ;;; Operation canceled.
-    $ECANCELED
+    $ecanceled
     ;;; No child processes.
-    $ECHILD
+    $echild
     ;;; Connection aborted.
-    $ECONNABORTED
+    $econnaborted
     ;;; Connection refused.
-    $ECONNREFUSED
+    $econnrefused
     ;;; Connection reset.
-    $ECONNRESET
+    $econnreset
     ;;; Resource deadlock would occur.
-    $EDEADLK
+    $edeadlk
     ;;; Destination address required.
-    $EDESTADDRREQ
+    $edestaddrreq
     ;;; Mathematics argument out of domain of function.
-    $EDOM
+    $edom
     ;;; Reserved.
-    $EDQUOT
+    $edquot
     ;;; File exists.
-    $EEXIST
+    $eexist
     ;;; Bad address.
-    $EFAULT
+    $efault
     ;;; File too large.
-    $EFBIG
+    $efbig
     ;;; Host is unreachable.
-    $EHOSTUNREACH
+    $ehostunreach
     ;;; Identifier removed.
-    $EIDRM
+    $eidrm
     ;;; Illegal byte sequence.
-    $EILSEQ
+    $eilseq
     ;;; Operation in progress.
-    $EINPROGRESS
+    $einprogress
     ;;; Interrupted function.
-    $EINTR
+    $eintr
     ;;; Invalid argument.
-    $EINVAL
+    $einval
     ;;; I/O error.
-    $EIO
+    $eio
     ;;; Socket is connected.
-    $EISCONN
+    $eisconn
     ;;; Is a directory.
-    $EISDIR
+    $eisdir
     ;;; Too many levels of symbolic links.
-    $ELOOP
+    $eloop
     ;;; File descriptor value too large.
-    $EMFILE
+    $emfile
     ;;; Too many links.
-    $EMLINK
+    $emlink
     ;;; Message too large.
-    $EMSGSIZE
+    $emsgsize
     ;;; Reserved.
-    $EMULTIHOP
+    $emultihop
     ;;; Filename too long.
-    $ENAMETOOLONG
+    $enametoolong
     ;;; Network is down.
-    $ENETDOWN
+    $enetdown
     ;;; Connection aborted by network.
-    $ENETRESET
+    $enetreset
     ;;; Network unreachable.
-    $ENETUNREACH
+    $enetunreach
     ;;; Too many files open in system.
-    $ENFILE
+    $enfile
     ;;; No buffer space available.
-    $ENOBUFS
+    $enobufs
     ;;; No such device.
-    $ENODEV
+    $enodev
     ;;; No such file or directory.
-    $ENOENT
+    $enoent
     ;;; Executable file format error.
-    $ENOEXEC
+    $enoexec
     ;;; No locks available.
-    $ENOLCK
+    $enolck
     ;;; Reserved.
-    $ENOLINK
+    $enolink
     ;;; Not enough space.
-    $ENOMEM
+    $enomem
     ;;; No message of the desired type.
-    $ENOMSG
+    $enomsg
     ;;; Protocol not available.
-    $ENOPROTOOPT
+    $enoprotoopt
     ;;; No space left on device.
-    $ENOSPC
+    $enospc
     ;;; Function not supported.
-    $ENOSYS
+    $enosys
     ;;; The socket is not connected.
-    $ENOTCONN
+    $enotconn
     ;;; Not a directory or a symbolic link to a directory.
-    $ENOTDIR
+    $enotdir
     ;;; Directory not empty.
-    $ENOTEMPTY
+    $enotempty
     ;;; State not recoverable.
-    $ENOTRECOVERABLE
+    $enotrecoverable
     ;;; Not a socket.
-    $ENOTSOCK
+    $enotsock
     ;;; Not supported, or operation not supported on socket.
-    $ENOTSUP
+    $enotsup
     ;;; Inappropriate I/O control operation.
-    $ENOTTY
+    $enotty
     ;;; No such device or address.
-    $ENXIO
+    $enxio
     ;;; Value too large to be stored in data type.
-    $EOVERFLOW
+    $eoverflow
     ;;; Previous owner died.
-    $EOWNERDEAD
+    $eownerdead
     ;;; Operation not permitted.
-    $EPERM
+    $eperm
     ;;; Broken pipe.
-    $EPIPE
+    $epipe
     ;;; Protocol error.
-    $EPROTO
+    $eproto
     ;;; Protocol not supported.
-    $EPROTONOSUPPORT
+    $eprotonosupport
     ;;; Protocol wrong type for socket.
-    $EPROTOTYPE
+    $eprototype
     ;;; Result too large.
-    $ERANGE
+    $erange
     ;;; Read-only file system.
-    $EROFS
+    $erofs
     ;;; Invalid seek.
-    $ESPIPE
+    $espipe
     ;;; No such process.
-    $ESRCH
+    $esrch
     ;;; Reserved.
-    $ESTALE
+    $estale
     ;;; Connection timed out.
-    $ETIMEDOUT
+    $etimedout
     ;;; Text file busy.
-    $ETXTBSY
+    $etxtbsy
     ;;; Cross-device link.
-    $EXDEV
+    $exdev
     ;;; Extension: Capabilities insufficient.
-    $ENOTCAPABLE
+    $enotcapable
   )
 )
 
@@ -201,75 +201,75 @@
     ;;
     ;;; If `RIGHT_PATH_OPEN` is set, includes the right to invoke
     ;;; `path_open` with `FDFLAG_DSYNC`.
-    $RIGHT_FD_DATASYNC
+    $right_fd_datasync
     ;;; The right to invoke `fd_read` and `sock_recv`.
     ;;
     ;;; If `RIGHT_FD_SEEK` is set, includes the right to invoke `fd_pread`.
-    $RIGHT_FD_READ
+    $right_fd_read
     ;;; The right to invoke `fd_seek`. This flag implies `RIGHT_FD_TELL`.
-    $RIGHT_FD_SEEK
+    $right_fd_seek
     ;;; The right to invoke `fd_fdstat_set_flags`.
-    $RIGHT_FD_FDSTAT_SET_FLAGS
+    $right_fd_fdstat_set_flags
     ;;; The right to invoke `fd_sync`.
     ;;
     ;;; If `RIGHT_PATH_OPEN` is set, includes the right to invoke
     ;;; `path_open` with `FDFLAG_RSYNC` and `FDFLAG_DSYNC`.
-    $RIGHT_FD_SYNC
+    $right_fd_sync
     ;;; The right to invoke `fd_seek` in such a way that the file offset
     ;;; remains unaltered (i.e., `WHENCE_CUR` with offset zero), or to
     ;;; invoke `fd_tell`.
-    $RIGHT_FD_TELL
+    $right_fd_tell
     ;;; The right to invoke `fd_write` and `sock_send`.
     ;;; If `RIGHT_FD_SEEK` is set, includes the right to invoke `fd_pwrite`.
-    $RIGHT_FD_WRITE
+    $right_fd_write
     ;;; The right to invoke `fd_advise`.
-    $RIGHT_FD_ADVISE
+    $right_fd_advise
     ;;; The right to invoke `fd_allocate`.
-    $RIGHT_FD_ALLOCATE
+    $right_fd_allocate
     ;;; The right to invoke `path_create_directory`.
-    $RIGHT_PATH_CREATE_DIRECTORY
+    $right_path_create_directory
     ;;; If `RIGHT_PATH_OPEN` is set, the right to invoke `path_open` with `O_CREAT`.
-    $RIGHT_PATH_CREATE_FILE
+    $right_path_create_file
     ;;; The right to invoke `path_link` with the file descriptor as the
     ;;; source directory.
-    $RIGHT_PATH_LINK_SOURCE
+    $right_path_link_source
     ;;; The right to invoke `path_link` with the file descriptor as the
     ;;; target directory.
-    $RIGHT_PATH_LINK_TARGET
+    $right_path_link_target
     ;;; The right to invoke `path_open`.
-    $RIGHT_PATH_OPEN
+    $right_path_open
     ;;; The right to invoke `fd_readdir`.
-    $RIGHT_FD_READDIR
+    $right_fd_readdir
     ;;; The right to invoke `path_readlink`.
-    $RIGHT_PATH_READLINK
+    $right_path_readlink
     ;;; The right to invoke `path_rename` with the file descriptor as the source directory.
-    $RIGHT_PATH_RENAME_SOURCE
+    $right_path_rename_source
     ;;; The right to invoke `path_rename` with the file descriptor as the target directory.
-    $RIGHT_PATH_RENAME_TARGET
+    $right_path_rename_target
     ;;; The right to invoke `path_filestat_get`.
-    $RIGHT_PATH_FILESTAT_GET
+    $right_path_filestat_get
     ;;; The right to change a file's size (there is no `path_filestat_set_size`).
     ;;; If `RIGHT_PATH_OPEN` is set, includes the right to invoke `path_open` with `O_TRUNC`.
-    $RIGHT_PATH_FILESTAT_SET_SIZE
+    $right_path_filestat_set_size
     ;;; The right to invoke `path_filestat_set_times`.
-    $RIGHT_PATH_FILESTAT_SET_TIMES
+    $right_path_filestat_set_times
     ;;; The right to invoke `fd_filestat_get`.
-    $RIGHT_FD_FILESTAT_GET
+    $right_fd_filestat_get
     ;;; The right to invoke `fd_filestat_set_size`.
-    $RIGHT_FD_FILESTAT_SET_SIZE
+    $right_fd_filestat_set_size
     ;;; The right to invoke `fd_filestat_set_times`.
-    $RIGHT_FD_FILESTAT_SET_TIMES
+    $right_fd_filestat_set_times
     ;;; The right to invoke `path_symlink`.
-    $RIGHT_PATH_SYMLINK
+    $right_path_symlink
     ;;; The right to invoke `path_remove_directory`.
-    $RIGHT_PATH_REMOVE_DIRECTORY
+    $right_path_remove_directory
     ;;; The right to invoke `path_unlink_file`.
-    $RIGHT_PATH_UNLINK_FILE
+    $right_path_unlink_file
     ;;; If `RIGHT_FD_READ` is set, includes the right to invoke `poll_oneoff` to subscribe to `EVENTTYPE_FD_READ`.
     ;;; If `RIGHT_FD_WRITE` is set, includes the right to invoke `poll_oneoff` to subscribe to `EVENTTYPE_FD_WRITE`.
-    $RIGHT_POLL_FD_READWRITE
+    $right_poll_fd_readwrite
     ;;; The right to invoke `sock_shutdown`.
-    $RIGHT_SOCK_SHUTDOWN
+    $right_sock_shutdown
   )
 )
 
@@ -306,11 +306,11 @@
 (typename $whence
   (enum u8
     ;;; Seek relative to current position.
-    $WHENCE_CUR
+    $whence_cur
     ;;; Seek relative to end-of-file.
-    $WHENCE_END
+    $whence_end
     ;;; Seek relative to start-of-file.
-    $WHENCE_SET
+    $whence_set
   )
 )
 
@@ -327,21 +327,21 @@
 (typename $filetype
   (enum u8
     ;;; The type of the file descriptor or file is unknown or is different from any of the other types specified.
-    $FILETYPE_UNKNOWN
+    $filetype_unknown
     ;;; The file descriptor or file refers to a block device inode.
-    $FILETYPE_BLOCK_DEVICE
+    $filetype_block_device
     ;;; The file descriptor or file refers to a character device inode.
-    $FILETYPE_CHARACTER_DEVICE
+    $filetype_character_device
     ;;; The file descriptor or file refers to a directory inode.
-    $FILETYPE_DIRECTORY
+    $filetype_directory
     ;;; The file descriptor or file refers to a regular file inode.
-    $FILETYPE_REGULAR_FILE
+    $filetype_regular_file
     ;;; The file descriptor or file refers to a datagram socket.
-    $FILETYPE_SOCKET_DGRAM
+    $filetype_socket_dgram
     ;;; The file descriptor or file refers to a byte-stream socket.
-    $FILETYPE_SOCKET_STREAM
+    $filetype_socket_stream
     ;;; The file refers to a symbolic link inode.
-    $FILETYPE_SYMBOLIC_LINK
+    $filetype_symbolic_link
   )
 )
 
@@ -363,17 +363,17 @@
 (typename $advice
   (enum u8
     ;;; The application has no advice to give on its behavior with respect to the specified data.
-    $ADVICE_NORMAL
+    $advice_normal
     ;;; The application expects to access the specified data sequentially from lower offsets to higher offsets.
-    $ADVICE_SEQUENTIAL
+    $advice_sequential
     ;;; The application expects to access the specified data in a random order.
-    $ADVICE_RANDOM
+    $advice_random
     ;;; The application expects to access the specified data in the near future.
-    $ADVICE_WILLNEED
+    $advice_willneed
     ;;; The application expects that it will not access the specified data in the near future.
-    $ADVICE_DONTNEED
+    $advice_dontneed
     ;;; The application expects to access the specified data once and then not reuse it thereafter.
-    $ADVICE_NOREUSE
+    $advice_noreuse
   )
 )
 
@@ -381,17 +381,17 @@
 (typename $fdflags
   (flags u16
     ;;; Append mode: Data written to the file is always appended to the file's end.
-    $FDFLAG_APPEND
+    $fdflag_append
     ;;; Write according to synchronized I/O data integrity completion. Only the data stored in the file is synchronized.
-    $FDFLAG_DSYNC
+    $fdflag_dsync
     ;;; Non-blocking mode.
-    $FDFLAG_NONBLOCK
+    $fdflag_nonblock
     ;;; Synchronized read I/O operations.
-    $FDFLAG_RSYNC
+    $fdflag_rsync
     ;;; Write according to synchronized I/O file integrity completion. In
     ;;; addition to synchronizing the data stored in the file, the implementation
     ;;; may also synchronously update the file's metadata.
-    $FDFLAG_SYNC
+    $fdflag_sync
   )
 )
 
@@ -418,13 +418,13 @@
 (typename $fstflags
   (flags u16
     ;;; Adjust the last data access timestamp to the value stored in `filestat_t::st_atim`.
-    $FILESTAT_SET_ATIM
+    $filestat_set_atim
     ;;; Adjust the last data access timestamp to the time of clock `CLOCK_REALTIME`.
-    $FILESTAT_SET_ATIM_NOW
+    $filestat_set_atim_now
     ;;; Adjust the last data modification timestamp to the value stored in `filestat_t::st_mtim`.
-    $FILESTAT_SET_MTIM
+    $filestat_set_mtim
     ;;; Adjust the last data modification timestamp to the time of clock `CLOCK_REALTIME`.
-    $FILESTAT_SET_MTIM_NOW
+    $filestat_set_mtim_now
   )
 )
 
@@ -432,7 +432,7 @@
 (typename $lookupflags
   (flags u32
     ;;; As long as the resolved path corresponds to a symbolic link, it is expanded.
-    $LOOKUP_SYMLINK_FOLLOW
+    $lookup_symlink_follow
   )
 )
 
@@ -440,13 +440,13 @@
 (typename $oflags
   (flags u16
     ;;; Create file if it does not exist.
-    $O_CREAT
+    $o_creat
     ;;; Fail if not a directory.
-    $O_DIRECTORY
+    $o_directory
     ;;; Fail if file already exists.
-    $O_EXCL
+    $o_excl
     ;;; Truncate file to size 0.
-    $O_TRUNC
+    $o_trunc
   )
 )
 
@@ -484,13 +484,13 @@
   (enum u8
     ;;; The time value of clock `subscription_t::u.clock.clock_id` has
     ;;; reached timestamp `subscription_t::u.clock.timeout`.
-    $EVENTTYPE_CLOCK
+    $eventtype_clock
     ;;; File descriptor `subscription_t::u.fd_readwrite.fd` has data
     ;;; available for reading. This event always triggers for regular files.
-    $EVENTTYPE_FD_READ
+    $eventtype_fd_read
     ;;; File descriptor `subscription_t::u.fd_readwrite.fd` has capacity
     ;;; available for writing. This event always triggers for regular files.
-    $EVENTTYPE_FD_WRITE
+    $eventtype_fd_write
   )
 )
 
@@ -499,7 +499,7 @@
 (typename $eventrwflags
   (flags u16
     ;;; The peer of this socket has closed or disconnected.
-    $EVENT_FD_READWRITE_HANGUP
+    $event_fd_readwrite_hangup
   )
 )
 
@@ -545,7 +545,7 @@
     ;;; `subscription_t::u.clock.clock_id.` If clear, treat the timestamp
     ;;; provided in `subscription_t::u.clock.timeout` relative to the
     ;;; current time value of clock `subscription_t::u.clock.clock_id.`
-    $SUBSCRIPTION_CLOCK_ABSTIME
+    $subscription_clock_abstime
   )
 )
 
@@ -606,97 +606,97 @@
   (enum u8
     ;;; No signal. Note that POSIX has special semantics for `kill(pid, 0)`,
     ;;; so this value is reserved.
-    $SIGNONE
+    $signone
     ;;; Hangup.
     ;;; Action: Terminates the process.
-    $SIGHUP
+    $sighup
     ;;; Terminate interrupt signal.
     ;;; Action: Terminates the process.
-    $SIGINT
+    $sigint
     ;;; Terminal quit signal.
     ;;; Action: Terminates the process.
-    $SIGQUIT
+    $sigquit
     ;;; Illegal instruction.
     ;;; Action: Terminates the process.
-    $SIGILL
+    $sigill
     ;;; Trace/breakpoint trap.
     ;;; Action: Terminates the process.
-    $SIGTRAP
+    $sigtrap
     ;;; Process abort signal.
     ;;; Action: Terminates the process.
-    $SIGABRT
+    $sigabrt
     ;;; Access to an undefined portion of a memory object.
     ;;; Action: Terminates the process.
-    $SIGBUS
+    $sigbus
     ;;; Erroneous arithmetic operation.
     ;;; Action: Terminates the process.
-    $SIGFPE
+    $sigfpe
     ;;; Kill.
     ;;; Action: Terminates the process.
-    $SIGKILL
+    $sigkill
     ;;; User-defined signal 1.
     ;;; Action: Terminates the process.
-    $SIGUSR1
+    $sigusr1
     ;;; Invalid memory reference.
     ;;; Action: Terminates the process.
-    $SIGSEGV
+    $sigsegv
     ;;; User-defined signal 2.
     ;;; Action: Terminates the process.
-    $SIGUSR2
+    $sigusr2
     ;;; Write on a pipe with no one to read it.
     ;;; Action: Ignored.
-    $SIGPIPE
+    $sigpipe
     ;;; Alarm clock.
     ;;; Action: Terminates the process.
-    $SIGALRM
+    $sigalrm
     ;;; Termination signal.
     ;;; Action: Terminates the process.
-    $SIGTERM
+    $sigterm
     ;;; Child process terminated, stopped, or continued.
     ;;; Action: Ignored.
-    $SIGCHLD
+    $sigchld
     ;;; Continue executing, if stopped.
     ;;; Action: Continues executing, if stopped.
-    $SIGCONT
+    $sigcont
     ;;; Stop executing.
     ;;; Action: Stops executing.
-    $SIGSTOP
+    $sigstop
     ;;; Terminal stop signal.
     ;;; Action: Stops executing.
-    $SIGTSTP
+    $sigtstp
     ;;; Background process attempting read.
     ;;; Action: Stops executing.
-    $SIGTTIN
+    $sigttin
     ;;; Background process attempting write.
     ;;; Action: Stops executing.
-    $SIGTTOU
+    $sigttou
     ;;; High bandwidth data is available at a socket.
     ;;; Action: Ignored.
-    $SIGURG
+    $sigurg
     ;;; CPU time limit exceeded.
     ;;; Action: Terminates the process.
-    $SIGXCPU
+    $sigxcpu
     ;;; File size limit exceeded.
     ;;; Action: Terminates the process.
-    $SIGXFSZ
+    $sigxfsz
     ;;; Virtual timer expired.
     ;;; Action: Terminates the process.
-    $SIGVTALRM
+    $sigvtalrm
     ;;; Profiling timer expired.
     ;;; Action: Terminates the process.
-    $SIGPROF
+    $sigprof
     ;;; Window changed.
     ;;; Action: Ignored.
-    $SIGWINCH
+    $sigwinch
     ;;; I/O possible.
     ;;; Action: Terminates the process.
-    $SIGPOLL
+    $sigpoll
     ;;; Power failure.
     ;;; Action: Terminates the process.
-    $SIGPWR
+    $sigpwr
     ;;; Bad system call.
     ;;; Action: Terminates the process.
-    $SIGSYS
+    $sigsys
   )
 )
 
@@ -704,9 +704,9 @@
 (typename $riflags
   (flags u16
     ;;; Returns the message without removing it from the socket's receive queue.
-    $SOCK_RECV_PEEK
+    $sock_recv_peek
     ;;; On byte-stream sockets, block until the full amount of data can be returned.
-    $SOCK_RECV_WAITALL
+    $sock_recv_waitall
   )
 )
 
@@ -714,7 +714,7 @@
 (typename $roflags
   (flags u16
     ;;; Returned by `sock_recv`: Message data has been truncated.
-    $SOCK_RECV_DATA_TRUNCATED
+    $sock_recv_data_truncated
   )
 )
 
@@ -726,9 +726,9 @@
 (typename $sdflags
   (flags u8
     ;;; Disables further receive operations.
-    $SHUT_RD
+    $shut_rd
     ;;; Disables further send operations.
-    $SHUT_WR
+    $shut_wr
   )
 )
 
@@ -736,7 +736,7 @@
 (typename $preopentype
   (enum u8
     ;;; A pre-opened directory.
-    $PREOPENTYPE_DIR
+    $preopentype_dir
   )
 )
 

--- a/phases/old/snapshot_0/witx/typenames.witx
+++ b/phases/old/snapshot_0/witx/typenames.witx
@@ -5,16 +5,16 @@
 ;; This is a `witx` file. See [here](https://github.com/WebAssembly/WASI/tree/master/docs/witx.md)
 ;; for an explanation of what that means.
 
-(typename $size_t u32)
+(typename $size u32)
 
 ;;; Non-negative file size or length of a region within a file.
-(typename $filesize_t u64)
+(typename $filesize u64)
 
 ;;; Timestamp in nanoseconds.
-(typename $timestamp_t u64)
+(typename $timestamp u64)
 
 ;;; Identifiers for clocks.
-(typename $clockid_t
+(typename $clockid
   (enum u32
     ;;; The clock measuring real time. Time value zero corresponds with
     ;;; 1970-01-01T00:00:00Z.
@@ -35,7 +35,7 @@
 ;;; Not all of these error codes are returned by the functions provided by this
 ;;; API; some are used in higher-level library layers, and others are provided
 ;;; merely for alignment with POSIX.
-(typename $errno_t
+(typename $errno
   (enum u16
     ;;; No error occurred. System call completed successfully.
     $ESUCCESS
@@ -195,7 +195,7 @@
 )
 
 ;;; File descriptor rights, determining which actions may be performed.
-(typename $rights_t
+(typename $rights
   (flags u64
     ;;; The right to invoke `fd_datasync`.
     ;;
@@ -274,36 +274,36 @@
 )
 
 ;;; A file descriptor index.
-(typename $fd_t u32)
+(typename $fd u32)
 
 ;;; A region of memory for scatter/gather reads.
-(typename $iovec_t
+(typename $iovec
   (struct
     ;;; The address of the buffer to be filled.
     (field $buf (@witx pointer u8))
     ;;; The length of the buffer to be filled.
-    (field $buf_len $size_t)
+    (field $buf_len $size)
   )
 )
 
 ;;; A region of memory for scatter/gather writes.
-(typename $ciovec_t
+(typename $ciovec
   (struct
     ;;; The address of the buffer to be written.
     (field $buf (@witx const_pointer u8))
     ;;; The length of the buffer to be written.
-    (field $buf_len $size_t)
+    (field $buf_len $size)
   )
 )
 
-(typename $iovec_t_array (array $iovec_t))
-(typename $ciovec_t_array (array $ciovec_t))
+(typename $iovec_array (array $iovec))
+(typename $ciovec_array (array $ciovec))
 
 ;;; Relative offset within a file.
-(typename $filedelta_t s64)
+(typename $filedelta s64)
 
 ;;; The position relative to which to set the offset of the file descriptor.
-(typename $whence_t
+(typename $whence
   (enum u8
     ;;; Seek relative to current position.
     $WHENCE_CUR
@@ -315,16 +315,16 @@
 )
 
 ;;; A reference to the offset of a directory entry.
-(typename $dircookie_t u64)
+(typename $dircookie u64)
 
-;;; The type for the $d_namlen field of $dirent_t.
-(typename $dirnamlen_t u32)
+;;; The type for the $d_namlen field of $dirent.
+(typename $dirnamlen u32)
 
 ;;; File serial number that is unique within its file system.
-(typename $inode_t u64)
+(typename $inode u64)
 
 ;;; The type of a file descriptor or file.
-(typename $filetype_t
+(typename $filetype
   (enum u8
     ;;; The type of the file descriptor or file is unknown or is different from any of the other types specified.
     $FILETYPE_UNKNOWN
@@ -346,21 +346,21 @@
 )
 
 ;;; A directory entry.
-(typename $dirent_t
+(typename $dirent
   (struct
     ;;; The offset of the next directory entry stored in this directory.
-    (field $d_next $dircookie_t)
+    (field $d_next $dircookie)
     ;;; The serial number of the file referred to by this directory entry.
-    (field $d_ino $inode_t)
+    (field $d_ino $inode)
     ;;; The length of the name of the directory entry.
-    (field $d_namlen $dirnamlen_t)
+    (field $d_namlen $dirnamlen)
     ;;; The type of the file referred to by this directory entry.
-    (field $d_type $filetype_t)
+    (field $dype $filetype)
   )
 )
 
 ;;; File or memory access pattern advisory information.
-(typename $advice_t
+(typename $advice
   (enum u8
     ;;; The application has no advice to give on its behavior with respect to the specified data.
     $ADVICE_NORMAL
@@ -378,7 +378,7 @@
 )
 
 ;;; File descriptor flags.
-(typename $fdflags_t
+(typename $fdflags
   (flags u16
     ;;; Append mode: Data written to the file is always appended to the file's end.
     $FDFLAG_APPEND
@@ -396,26 +396,26 @@
 )
 
 ;;; File descriptor attributes.
-(typename $fdstat_t
+(typename $fdstat
   (struct
     ;;; File type.
-    (field $fs_filetype $filetype_t)
+    (field $fs_filetype $filetype)
     ;;; File descriptor flags.
-    (field $fs_flags $fdflags_t)
+    (field $fs_flags $fdflags)
     ;;; Rights that apply to this file descriptor.
-    (field $fs_rights_base $rights_t)
+    (field $fs_rights_base $rights)
     ;;; Maximum set of rights that may be installed on new file descriptors that
     ;;; are created through this file descriptor, e.g., through `path_open`.
-    (field $fs_rights_inheriting $rights_t)
+    (field $fs_rights_inheriting $rights)
   )
 )
 
 ;;; Identifier for a device containing a file system. Can be used in combination
 ;;; with `inode_t` to uniquely identify a file or directory in the filesystem.
-(typename $device_t u64)
+(typename $device u64)
 
 ;;; Which file time attributes to adjust.
-(typename $fstflags_t
+(typename $fstflags
   (flags u16
     ;;; Adjust the last data access timestamp to the value stored in `filestat_t::st_atim`.
     $FILESTAT_SET_ATIM
@@ -429,7 +429,7 @@
 )
 
 ;;; Flags determining the method of how paths are resolved.
-(typename $lookupflags_t
+(typename $lookupflags
   (flags u32
     ;;; As long as the resolved path corresponds to a symbolic link, it is expanded.
     $LOOKUP_SYMLINK_FOLLOW
@@ -437,7 +437,7 @@
 )
 
 ;;; Open flags used by `path_open`.
-(typename $oflags_t
+(typename $oflags
   (flags u16
     ;;; Create file if it does not exist.
     $O_CREAT
@@ -451,36 +451,36 @@
 )
 
 ;;; Number of hard links to an inode.
-(typename $linkcount_t u32)
+(typename $linkcount u32)
 
 ;;; File attributes.
-(typename $filestat_t
+(typename $filestat
   (struct
     ;;; Device ID of device containing the file.
-    (field $st_dev $device_t)
+    (field $st_dev $device)
     ;;; File serial number.
-    (field $st_ino $inode_t)
+    (field $st_ino $inode)
     ;;; File type.
-    (field $st_filetype $filetype_t)
+    (field $st_filetype $filetype)
     ;;; Number of hard links to the file.
-    (field $st_nlink $linkcount_t)
+    (field $st_nlink $linkcount)
     ;;; For regular files, the file size in bytes. For symbolic links, the length in bytes of the pathname contained in the symbolic link.
-    (field $st_size $filesize_t)
+    (field $st_size $filesize)
     ;;; Last data access timestamp.
-    (field $st_atim $timestamp_t)
+    (field $st_atim $timestamp)
     ;;; Last data modification timestamp.
-    (field $st_mtim $timestamp_t)
+    (field $st_mtim $timestamp)
     ;;; Last file status change timestamp.
-    (field $st_ctim $timestamp_t)
+    (field $st_ctim $timestamp)
   )
 )
 
 ;;; User-provided value that may be attached to objects that is retained when
 ;;; extracted from the implementation.
-(typename $userdata_t u64)
+(typename $userdata u64)
 
 ;;; Type of a subscription to an event or its occurrence.
-(typename $eventtype_t
+(typename $eventtype
   (enum u8
     ;;; The time value of clock `subscription_t::u.clock.clock_id` has
     ;;; reached timestamp `subscription_t::u.clock.timeout`.
@@ -496,41 +496,41 @@
 
 ;;; The state of the file descriptor subscribed to with
 ;;; `EVENTTYPE_FD_READ` or `EVENTTYPE_FD_WRITE`.
-(typename $eventrwflags_t
+(typename $eventrwflags
   (flags u16
     ;;; The peer of this socket has closed or disconnected.
     $EVENT_FD_READWRITE_HANGUP
   )
 )
 
-;;; The contents of an $event_t when type is `EVENTTYPE_FD_READ` or
+;;; The contents of an $event when type is `EVENTTYPE_FD_READ` or
 ;;; `EVENTTYPE_FD_WRITE`.
-(typename $event_fd_readwrite_t
+(typename $event_fd_readwrite
   (struct
     ;;; The number of bytes available for reading or writing.
-    (field $nbytes $filesize_t)
+    (field $nbytes $filesize)
     ;;; The state of the file descriptor.
-    (field $flags $eventrwflags_t)
+    (field $flags $eventrwflags)
   )
 )
 
-;;; The contents of an $event_t.
+;;; The contents of an $event.
 (typename $event_u
   (union
     ;;; When type is `EVENTTYPE_FD_READ` or `EVENTTYPE_FD_WRITE`:
-    (field $fd_readwrite $event_fd_readwrite_t)
+    (field $fd_readwrite $event_fd_readwrite)
   )
 )
 
 ;;; An event that occurred.
-(typename $event_t
+(typename $event
   (struct
     ;;; User-provided value that got attached to `subscription_t::userdata`.
-    (field $userdata $userdata_t)
+    (field $userdata $userdata)
     ;;; If non-zero, an error that occurred while processing the subscription request.
-    (field $error $errno_t)
+    (field $error $errno)
     ;;; The type of the event that occurred.
-    (field $type $eventtype_t)
+    (field $type $eventtype)
     ;;; The contents of the event.
     (field $u $event_u)
   )
@@ -538,7 +538,7 @@
 
 ;;; Flags determining how to interpret the timestamp provided in
 ;;; `subscription_t::u.clock.timeout.`
-(typename $subclockflags_t
+(typename $subclockflags
   (flags u16
     ;;; If set, treat the timestamp provided in
     ;;; `subscription_t::u.clock.timeout` as an absolute timestamp of clock
@@ -549,60 +549,60 @@
   )
 )
 
-;;; The contents of a $subscription_t when type is `EVENTTYPE_CLOCK`.
-(typename $subscription_clock_t
+;;; The contents of a $subscription when type is `EVENTTYPE_CLOCK`.
+(typename $subscription_clock
   (struct
     ;;; The user-defined unique identifier of the clock.
-    (field $identifier $userdata_t)
+    (field $identifier $userdata)
     ;;; The clock against which to compare the timestamp.
-    (field $clock_id $clockid_t)
+    (field $clock_id $clockid)
     ;;; The absolute or relative timestamp.
-    (field $timeout $timestamp_t)
+    (field $timeout $timestamp)
     ;;; The amount of time that the implementation may wait additionally
     ;;; to coalesce with other events.
-    (field $precision $timestamp_t)
+    (field $precision $timestamp)
     ;;; Flags specifying whether the timeout is absolute or relative
-    (field $flags $subclockflags_t)
+    (field $flags $subclockflags)
   )
 )
 
-;;; The contents of a $subscription_t when type is type is
+;;; The contents of a $subscription when type is type is
 ;;; `EVENTTYPE_FD_READ` or `EVENTTYPE_FD_WRITE`.
-(typename $subscription_fd_readwrite_t
+(typename $subscription_fd_readwrite
   (struct
     ;;; The file descriptor on which to wait for it to become ready for reading or writing.
-    (field $file_descriptor $fd_t)
+    (field $file_descriptor $fd)
   )
 )
 
-;;; The contents of a $subscription_t.
+;;; The contents of a $subscription.
 (typename $subscription_u
   (union
     ;;; When type is `EVENTTYPE_CLOCK`:
-    (field $clock $subscription_clock_t)
+    (field $clock $subscription_clock)
     ;;; When type is `EVENTTYPE_FD_READ` or `EVENTTYPE_FD_WRITE`:
-    (field $fd_readwrite $subscription_fd_readwrite_t)
+    (field $fd_readwrite $subscription_fd_readwrite)
   )
 )
 
 ;;; Subscription to an event.
-(typename $subscription_t
+(typename $subscription
   (struct
     ;;; User-provided value that is attached to the subscription in the
     ;;; implementation and returned through `event_t::userdata`.
-    (field $userdata $userdata_t)
+    (field $userdata $userdata)
     ;;; The type of the event to which to subscribe.
-    (field $type $eventtype_t)
+    (field $type $eventtype)
     ;;; The contents of the subscription.
     (field $u $subscription_u)
   )
 )
 
 ;;; Exit code generated by a process when exiting.
-(typename $exitcode_t u32)
+(typename $exitcode u32)
 
 ;;; Signal condition.
-(typename $signal_t
+(typename $signal
   (enum u8
     ;;; No signal. Note that POSIX has special semantics for `kill(pid, 0)`,
     ;;; so this value is reserved.
@@ -701,7 +701,7 @@
 )
 
 ;;; Flags provided to `sock_recv`.
-(typename $riflags_t
+(typename $riflags
   (flags u16
     ;;; Returns the message without removing it from the socket's receive queue.
     $SOCK_RECV_PEEK
@@ -711,7 +711,7 @@
 )
 
 ;;; Flags returned by `sock_recv`.
-(typename $roflags_t
+(typename $roflags
   (flags u16
     ;;; Returned by `sock_recv`: Message data has been truncated.
     $SOCK_RECV_DATA_TRUNCATED
@@ -720,10 +720,10 @@
 
 ;;; Flags provided to `sock_send`. As there are currently no flags
 ;;; defined, it must be set to zero.
-(typename $siflags_t u16)
+(typename $siflags u16)
 
 ;;; Which channels on a socket to shut down.
-(typename $sdflags_t
+(typename $sdflags
   (flags u8
     ;;; Disables further receive operations.
     $SHUT_RD
@@ -733,22 +733,22 @@
 )
 
 ;;; Identifiers for preopened capabilities.
-(typename $preopentype_t
+(typename $preopentype
   (enum u8
     ;;; A pre-opened directory.
     $PREOPENTYPE_DIR
   )
 )
 
-;;; The contents of a $prestat_t when type is `PREOPENTYPE_DIR`.
+;;; The contents of a $prestat when type is `PREOPENTYPE_DIR`.
 (typename $prestat_dir
   (struct
     ;;; The length of the directory name for use with `fd_prestat_dir_name`.
-    (field $pr_name_len $size_t)
+    (field $pr_name_len $size)
   )
 )
 
-;;; The contents of an $prestat_t.
+;;; The contents of an $prestat.
 (typename $prestat_u
   (union
     ;;; When type is `PREOPENTYPE_DIR`:
@@ -757,10 +757,10 @@
 )
 
 ;;; Information about a pre-opened capability.
-(typename $prestat_t
+(typename $prestat
   (struct
     ;;; The type of the pre-opened capability.
-    (field $pr_type $preopentype_t)
+    (field $prype $preopentype)
     ;;; The contents of the information.
     (field $u $prestat_u)
   )

--- a/phases/old/snapshot_0/witx/typenames.witx
+++ b/phases/old/snapshot_0/witx/typenames.witx
@@ -199,20 +199,20 @@
   (flags u64
     ;;; The right to invoke `fd_datasync`.
     ;;
-    ;;; If `RIGHT_PATH_OPEN` is set, includes the right to invoke
+    ;;; If `rights::path_open` is set, includes the right to invoke
     ;;; `path_open` with `FDFLAG_DSYNC`.
     $fd_datasync
     ;;; The right to invoke `fd_read` and `sock_recv`.
     ;;
-    ;;; If `RIGHT_FD_SEEK` is set, includes the right to invoke `fd_pread`.
+    ;;; If `rights::fd_seek` is set, includes the right to invoke `fd_pread`.
     $fd_read
-    ;;; The right to invoke `fd_seek`. This flag implies `RIGHT_FD_TELL`.
+    ;;; The right to invoke `fd_seek`. This flag implies `rights::fd_tell`.
     $fd_seek
     ;;; The right to invoke `fd_fdstat_set_flags`.
     $fd_fdstat_set_flags
     ;;; The right to invoke `fd_sync`.
     ;;
-    ;;; If `RIGHT_PATH_OPEN` is set, includes the right to invoke
+    ;;; If `rights::path_open` is set, includes the right to invoke
     ;;; `path_open` with `FDFLAG_RSYNC` and `FDFLAG_DSYNC`.
     $fd_sync
     ;;; The right to invoke `fd_seek` in such a way that the file offset
@@ -220,7 +220,7 @@
     ;;; invoke `fd_tell`.
     $fd_tell
     ;;; The right to invoke `fd_write` and `sock_send`.
-    ;;; If `RIGHT_FD_SEEK` is set, includes the right to invoke `fd_pwrite`.
+    ;;; If `rights::fd_seek` is set, includes the right to invoke `fd_pwrite`.
     $fd_write
     ;;; The right to invoke `fd_advise`.
     $fd_advise
@@ -228,7 +228,7 @@
     $fd_allocate
     ;;; The right to invoke `path_create_directory`.
     $path_create_directory
-    ;;; If `RIGHT_PATH_OPEN` is set, the right to invoke `path_open` with `O_CREAT`.
+    ;;; If `rights::path_open` is set, the right to invoke `path_open` with `O_CREAT`.
     $path_create_file
     ;;; The right to invoke `path_link` with the file descriptor as the
     ;;; source directory.
@@ -249,7 +249,7 @@
     ;;; The right to invoke `path_filestat_get`.
     $path_filestat_get
     ;;; The right to change a file's size (there is no `path_filestat_set_size`).
-    ;;; If `RIGHT_PATH_OPEN` is set, includes the right to invoke `path_open` with `O_TRUNC`.
+    ;;; If `rights::path_open` is set, includes the right to invoke `path_open` with `O_TRUNC`.
     $path_filestat_set_size
     ;;; The right to invoke `path_filestat_set_times`.
     $path_filestat_set_times
@@ -265,8 +265,8 @@
     $path_remove_directory
     ;;; The right to invoke `path_unlink_file`.
     $path_unlink_file
-    ;;; If `RIGHT_FD_READ` is set, includes the right to invoke `poll_oneoff` to subscribe to `EVENTTYPE_FD_READ`.
-    ;;; If `RIGHT_FD_WRITE` is set, includes the right to invoke `poll_oneoff` to subscribe to `EVENTTYPE_FD_WRITE`.
+    ;;; If `rights::fd_read` is set, includes the right to invoke `poll_oneoff` to subscribe to `eventtype::fd_read`.
+    ;;; If `rights::fd_write` is set, includes the right to invoke `poll_oneoff` to subscribe to `eventtype::fd_write`.
     $poll_fd_readwrite
     ;;; The right to invoke `sock_shutdown`.
     $sock_shutdown
@@ -411,19 +411,19 @@
 )
 
 ;;; Identifier for a device containing a file system. Can be used in combination
-;;; with `inode_t` to uniquely identify a file or directory in the filesystem.
+;;; with `inode` to uniquely identify a file or directory in the filesystem.
 (typename $device u64)
 
 ;;; Which file time attributes to adjust.
 (typename $fstflags
   (flags u16
-    ;;; Adjust the last data access timestamp to the value stored in `filestat_t::st_atim`.
+    ;;; Adjust the last data access timestamp to the value stored in `filestat::st_atim`.
     $atim
-    ;;; Adjust the last data access timestamp to the time of clock `CLOCK_REALTIME`.
+    ;;; Adjust the last data access timestamp to the time of clock `clock::realtime`.
     $atim_now
-    ;;; Adjust the last data modification timestamp to the value stored in `filestat_t::st_mtim`.
+    ;;; Adjust the last data modification timestamp to the value stored in `filestat::st_mtim`.
     $mtim
-    ;;; Adjust the last data modification timestamp to the time of clock `CLOCK_REALTIME`.
+    ;;; Adjust the last data modification timestamp to the time of clock `clock::realtime`.
     $mtim_now
   )
 )
@@ -482,20 +482,20 @@
 ;;; Type of a subscription to an event or its occurrence.
 (typename $eventtype
   (enum u8
-    ;;; The time value of clock `subscription_t::u.clock.clock_id` has
-    ;;; reached timestamp `subscription_t::u.clock.timeout`.
+    ;;; The time value of clock `subscription::u.clock.clock_id` has
+    ;;; reached timestamp `subscription::u.clock.timeout`.
     $clock
-    ;;; File descriptor `subscription_t::u.fd_readwrite.fd` has data
+    ;;; File descriptor `subscription::u.fd_readwrite.fd` has data
     ;;; available for reading. This event always triggers for regular files.
     $fd_read
-    ;;; File descriptor `subscription_t::u.fd_readwrite.fd` has capacity
+    ;;; File descriptor `subscription::u.fd_readwrite.fd` has capacity
     ;;; available for writing. This event always triggers for regular files.
     $fd_write
   )
 )
 
 ;;; The state of the file descriptor subscribed to with
-;;; `EVENTTYPE_FD_READ` or `EVENTTYPE_FD_WRITE`.
+;;; `eventtype::fd_read` or `eventtype::fd_write`.
 (typename $eventrwflags
   (flags u16
     ;;; The peer of this socket has closed or disconnected.
@@ -503,8 +503,8 @@
   )
 )
 
-;;; The contents of an $event when type is `EVENTTYPE_FD_READ` or
-;;; `EVENTTYPE_FD_WRITE`.
+;;; The contents of an $event when type is `eventtype::fd_read` or
+;;; `eventtype::fd_write`.
 (typename $event_fd_readwrite
   (struct
     ;;; The number of bytes available for reading or writing.
@@ -517,7 +517,7 @@
 ;;; The contents of an $event.
 (typename $event_u
   (union
-    ;;; When type is `EVENTTYPE_FD_READ` or `EVENTTYPE_FD_WRITE`:
+    ;;; When type is `eventtype::fd_read` or `eventtype::fd_write`:
     (field $fd_readwrite $event_fd_readwrite)
   )
 )
@@ -525,7 +525,7 @@
 ;;; An event that occurred.
 (typename $event
   (struct
-    ;;; User-provided value that got attached to `subscription_t::userdata`.
+    ;;; User-provided value that got attached to `subscription::userdata`.
     (field $userdata $userdata)
     ;;; If non-zero, an error that occurred while processing the subscription request.
     (field $error $errno)
@@ -537,19 +537,19 @@
 )
 
 ;;; Flags determining how to interpret the timestamp provided in
-;;; `subscription_t::u.clock.timeout.`
+;;; `subscription::u.clock.timeout.`
 (typename $subclockflags
   (flags u16
     ;;; If set, treat the timestamp provided in
-    ;;; `subscription_t::u.clock.timeout` as an absolute timestamp of clock
-    ;;; `subscription_t::u.clock.clock_id.` If clear, treat the timestamp
-    ;;; provided in `subscription_t::u.clock.timeout` relative to the
-    ;;; current time value of clock `subscription_t::u.clock.clock_id.`
+    ;;; `subscription::u.clock.timeout` as an absolute timestamp of clock
+    ;;; `subscription::u.clock.clock_id.` If clear, treat the timestamp
+    ;;; provided in `subscription::u.clock.timeout` relative to the
+    ;;; current time value of clock `subscription::u.clock.clock_id.`
     $subscription_clock_abstime
   )
 )
 
-;;; The contents of a $subscription when type is `EVENTTYPE_CLOCK`.
+;;; The contents of a $subscription when type is `eventtype::clock`.
 (typename $subscription_clock
   (struct
     ;;; The user-defined unique identifier of the clock.
@@ -567,7 +567,7 @@
 )
 
 ;;; The contents of a $subscription when type is type is
-;;; `EVENTTYPE_FD_READ` or `EVENTTYPE_FD_WRITE`.
+;;; `eventtype::fd_read` or `eventtype::fd_write`.
 (typename $subscription_fd_readwrite
   (struct
     ;;; The file descriptor on which to wait for it to become ready for reading or writing.
@@ -578,9 +578,9 @@
 ;;; The contents of a $subscription.
 (typename $subscription_u
   (union
-    ;;; When type is `EVENTTYPE_CLOCK`:
+    ;;; When type is `eventtype::clock`:
     (field $clock $subscription_clock)
-    ;;; When type is `EVENTTYPE_FD_READ` or `EVENTTYPE_FD_WRITE`:
+    ;;; When type is `eventtype::fd_read` or `eventtype::fd_write`:
     (field $fd_readwrite $subscription_fd_readwrite)
   )
 )
@@ -589,7 +589,7 @@
 (typename $subscription
   (struct
     ;;; User-provided value that is attached to the subscription in the
-    ;;; implementation and returned through `event_t::userdata`.
+    ;;; implementation and returned through `event::userdata`.
     (field $userdata $userdata)
     ;;; The type of the event to which to subscribe.
     (field $type $eventtype)

--- a/phases/old/snapshot_0/witx/typenames.witx
+++ b/phases/old/snapshot_0/witx/typenames.witx
@@ -355,7 +355,7 @@
     ;;; The length of the name of the directory entry.
     (field $d_namlen $dirnamlen)
     ;;; The type of the file referred to by this directory entry.
-    (field $dype $filetype)
+    (field $d_type $filetype)
   )
 )
 
@@ -760,7 +760,7 @@
 (typename $prestat
   (struct
     ;;; The type of the pre-opened capability.
-    (field $prype $preopentype)
+    (field $pr_type $preopentype)
     ;;; The contents of the information.
     (field $u $prestat_u)
   )

--- a/phases/old/snapshot_0/witx/typenames.witx
+++ b/phases/old/snapshot_0/witx/typenames.witx
@@ -484,13 +484,13 @@
   (enum u8
     ;;; The time value of clock `subscription_t::u.clock.clock_id` has
     ;;; reached timestamp `subscription_t::u.clock.timeout`.
-    $eventtype_clock
+    $clock
     ;;; File descriptor `subscription_t::u.fd_readwrite.fd` has data
     ;;; available for reading. This event always triggers for regular files.
-    $eventtype_fd_read
+    $fd_read
     ;;; File descriptor `subscription_t::u.fd_readwrite.fd` has capacity
     ;;; available for writing. This event always triggers for regular files.
-    $eventtype_fd_write
+    $fd_write
   )
 )
 

--- a/phases/old/snapshot_0/witx/typenames.witx
+++ b/phases/old/snapshot_0/witx/typenames.witx
@@ -18,16 +18,16 @@
   (enum u32
     ;;; The clock measuring real time. Time value zero corresponds with
     ;;; 1970-01-01T00:00:00Z.
-    $clock_realtime
+    $realtime
     ;;; The store-wide monotonic clock, which is defined as a clock measuring
     ;;; real time, whose value cannot be adjusted and which cannot have negative
     ;;; clock jumps. The epoch of this clock is undefined. The absolute time
     ;;; value of this clock therefore has no meaning.
-    $clock_monotonic
+    $monotonic
     ;;; The CPU-time clock associated with the current process.
-    $clock_process_cputime_id
+    $process_cputime_id
     ;;; The CPU-time clock associated with the current thread.
-    $clock_thread_cputime_id
+    $thread_cputime_id
   )
 )
 
@@ -201,75 +201,75 @@
     ;;
     ;;; If `RIGHT_PATH_OPEN` is set, includes the right to invoke
     ;;; `path_open` with `FDFLAG_DSYNC`.
-    $right_fd_datasync
+    $fd_datasync
     ;;; The right to invoke `fd_read` and `sock_recv`.
     ;;
     ;;; If `RIGHT_FD_SEEK` is set, includes the right to invoke `fd_pread`.
-    $right_fd_read
+    $fd_read
     ;;; The right to invoke `fd_seek`. This flag implies `RIGHT_FD_TELL`.
-    $right_fd_seek
+    $fd_seek
     ;;; The right to invoke `fd_fdstat_set_flags`.
-    $right_fd_fdstat_set_flags
+    $fd_fdstat_set_flags
     ;;; The right to invoke `fd_sync`.
     ;;
     ;;; If `RIGHT_PATH_OPEN` is set, includes the right to invoke
     ;;; `path_open` with `FDFLAG_RSYNC` and `FDFLAG_DSYNC`.
-    $right_fd_sync
+    $fd_sync
     ;;; The right to invoke `fd_seek` in such a way that the file offset
     ;;; remains unaltered (i.e., `WHENCE_CUR` with offset zero), or to
     ;;; invoke `fd_tell`.
-    $right_fd_tell
+    $fd_tell
     ;;; The right to invoke `fd_write` and `sock_send`.
     ;;; If `RIGHT_FD_SEEK` is set, includes the right to invoke `fd_pwrite`.
-    $right_fd_write
+    $fd_write
     ;;; The right to invoke `fd_advise`.
-    $right_fd_advise
+    $fd_advise
     ;;; The right to invoke `fd_allocate`.
-    $right_fd_allocate
+    $fd_allocate
     ;;; The right to invoke `path_create_directory`.
-    $right_path_create_directory
+    $path_create_directory
     ;;; If `RIGHT_PATH_OPEN` is set, the right to invoke `path_open` with `O_CREAT`.
-    $right_path_create_file
+    $path_create_file
     ;;; The right to invoke `path_link` with the file descriptor as the
     ;;; source directory.
-    $right_path_link_source
+    $path_link_source
     ;;; The right to invoke `path_link` with the file descriptor as the
     ;;; target directory.
-    $right_path_link_target
+    $path_link_target
     ;;; The right to invoke `path_open`.
-    $right_path_open
+    $path_open
     ;;; The right to invoke `fd_readdir`.
-    $right_fd_readdir
+    $fd_readdir
     ;;; The right to invoke `path_readlink`.
-    $right_path_readlink
+    $path_readlink
     ;;; The right to invoke `path_rename` with the file descriptor as the source directory.
-    $right_path_rename_source
+    $path_rename_source
     ;;; The right to invoke `path_rename` with the file descriptor as the target directory.
-    $right_path_rename_target
+    $path_rename_target
     ;;; The right to invoke `path_filestat_get`.
-    $right_path_filestat_get
+    $path_filestat_get
     ;;; The right to change a file's size (there is no `path_filestat_set_size`).
     ;;; If `RIGHT_PATH_OPEN` is set, includes the right to invoke `path_open` with `O_TRUNC`.
-    $right_path_filestat_set_size
+    $path_filestat_set_size
     ;;; The right to invoke `path_filestat_set_times`.
-    $right_path_filestat_set_times
+    $path_filestat_set_times
     ;;; The right to invoke `fd_filestat_get`.
-    $right_fd_filestat_get
+    $fd_filestat_get
     ;;; The right to invoke `fd_filestat_set_size`.
-    $right_fd_filestat_set_size
+    $fd_filestat_set_size
     ;;; The right to invoke `fd_filestat_set_times`.
-    $right_fd_filestat_set_times
+    $fd_filestat_set_times
     ;;; The right to invoke `path_symlink`.
-    $right_path_symlink
+    $path_symlink
     ;;; The right to invoke `path_remove_directory`.
-    $right_path_remove_directory
+    $path_remove_directory
     ;;; The right to invoke `path_unlink_file`.
-    $right_path_unlink_file
+    $path_unlink_file
     ;;; If `RIGHT_FD_READ` is set, includes the right to invoke `poll_oneoff` to subscribe to `EVENTTYPE_FD_READ`.
     ;;; If `RIGHT_FD_WRITE` is set, includes the right to invoke `poll_oneoff` to subscribe to `EVENTTYPE_FD_WRITE`.
-    $right_poll_fd_readwrite
+    $poll_fd_readwrite
     ;;; The right to invoke `sock_shutdown`.
-    $right_sock_shutdown
+    $sock_shutdown
   )
 )
 
@@ -306,11 +306,11 @@
 (typename $whence
   (enum u8
     ;;; Seek relative to current position.
-    $whence_cur
+    $cur
     ;;; Seek relative to end-of-file.
-    $whence_end
+    $end
     ;;; Seek relative to start-of-file.
-    $whence_set
+    $set
   )
 )
 
@@ -327,21 +327,21 @@
 (typename $filetype
   (enum u8
     ;;; The type of the file descriptor or file is unknown or is different from any of the other types specified.
-    $filetype_unknown
+    $unknown
     ;;; The file descriptor or file refers to a block device inode.
-    $filetype_block_device
+    $block_device
     ;;; The file descriptor or file refers to a character device inode.
-    $filetype_character_device
+    $character_device
     ;;; The file descriptor or file refers to a directory inode.
-    $filetype_directory
+    $directory
     ;;; The file descriptor or file refers to a regular file inode.
-    $filetype_regular_file
+    $regular_file
     ;;; The file descriptor or file refers to a datagram socket.
-    $filetype_socket_dgram
+    $socket_dgram
     ;;; The file descriptor or file refers to a byte-stream socket.
-    $filetype_socket_stream
+    $socket_stream
     ;;; The file refers to a symbolic link inode.
-    $filetype_symbolic_link
+    $symbolic_link
   )
 )
 
@@ -363,17 +363,17 @@
 (typename $advice
   (enum u8
     ;;; The application has no advice to give on its behavior with respect to the specified data.
-    $advice_normal
+    $normal
     ;;; The application expects to access the specified data sequentially from lower offsets to higher offsets.
-    $advice_sequential
+    $sequential
     ;;; The application expects to access the specified data in a random order.
-    $advice_random
+    $random
     ;;; The application expects to access the specified data in the near future.
-    $advice_willneed
+    $willneed
     ;;; The application expects that it will not access the specified data in the near future.
-    $advice_dontneed
+    $dontneed
     ;;; The application expects to access the specified data once and then not reuse it thereafter.
-    $advice_noreuse
+    $noreuse
   )
 )
 
@@ -381,17 +381,17 @@
 (typename $fdflags
   (flags u16
     ;;; Append mode: Data written to the file is always appended to the file's end.
-    $fdflag_append
+    $append
     ;;; Write according to synchronized I/O data integrity completion. Only the data stored in the file is synchronized.
-    $fdflag_dsync
+    $dsync
     ;;; Non-blocking mode.
-    $fdflag_nonblock
+    $nonblock
     ;;; Synchronized read I/O operations.
-    $fdflag_rsync
+    $rsync
     ;;; Write according to synchronized I/O file integrity completion. In
     ;;; addition to synchronizing the data stored in the file, the implementation
     ;;; may also synchronously update the file's metadata.
-    $fdflag_sync
+    $sync
   )
 )
 
@@ -418,13 +418,13 @@
 (typename $fstflags
   (flags u16
     ;;; Adjust the last data access timestamp to the value stored in `filestat_t::st_atim`.
-    $filestat_set_atim
+    $atim
     ;;; Adjust the last data access timestamp to the time of clock `CLOCK_REALTIME`.
-    $filestat_set_atim_now
+    $atim_now
     ;;; Adjust the last data modification timestamp to the value stored in `filestat_t::st_mtim`.
-    $filestat_set_mtim
+    $mtim
     ;;; Adjust the last data modification timestamp to the time of clock `CLOCK_REALTIME`.
-    $filestat_set_mtim_now
+    $mtim_now
   )
 )
 
@@ -432,7 +432,7 @@
 (typename $lookupflags
   (flags u32
     ;;; As long as the resolved path corresponds to a symbolic link, it is expanded.
-    $lookup_symlink_follow
+    $symlink_follow
   )
 )
 
@@ -440,13 +440,13 @@
 (typename $oflags
   (flags u16
     ;;; Create file if it does not exist.
-    $o_creat
+    $creat
     ;;; Fail if not a directory.
-    $o_directory
+    $directory
     ;;; Fail if file already exists.
-    $o_excl
+    $excl
     ;;; Truncate file to size 0.
-    $o_trunc
+    $trunc
   )
 )
 
@@ -457,21 +457,21 @@
 (typename $filestat
   (struct
     ;;; Device ID of device containing the file.
-    (field $st_dev $device)
+    (field $dev $device)
     ;;; File serial number.
-    (field $st_ino $inode)
+    (field $ino $inode)
     ;;; File type.
-    (field $st_filetype $filetype)
+    (field $filetype $filetype)
     ;;; Number of hard links to the file.
-    (field $st_nlink $linkcount)
+    (field $nlink $linkcount)
     ;;; For regular files, the file size in bytes. For symbolic links, the length in bytes of the pathname contained in the symbolic link.
-    (field $st_size $filesize)
+    (field $size $filesize)
     ;;; Last data access timestamp.
-    (field $st_atim $timestamp)
+    (field $atim $timestamp)
     ;;; Last data modification timestamp.
-    (field $st_mtim $timestamp)
+    (field $mtim $timestamp)
     ;;; Last file status change timestamp.
-    (field $st_ctim $timestamp)
+    (field $ctim $timestamp)
   )
 )
 
@@ -555,7 +555,7 @@
     ;;; The user-defined unique identifier of the clock.
     (field $identifier $userdata)
     ;;; The clock against which to compare the timestamp.
-    (field $clock_id $clockid)
+    (field $id $clockid)
     ;;; The absolute or relative timestamp.
     (field $timeout $timestamp)
     ;;; The amount of time that the implementation may wait additionally
@@ -704,9 +704,9 @@
 (typename $riflags
   (flags u16
     ;;; Returns the message without removing it from the socket's receive queue.
-    $sock_recv_peek
+    $recv_peek
     ;;; On byte-stream sockets, block until the full amount of data can be returned.
-    $sock_recv_waitall
+    $recv_waitall
   )
 )
 
@@ -714,7 +714,7 @@
 (typename $roflags
   (flags u16
     ;;; Returned by `sock_recv`: Message data has been truncated.
-    $sock_recv_data_truncated
+    $recv_data_truncated
   )
 )
 
@@ -726,9 +726,9 @@
 (typename $sdflags
   (flags u8
     ;;; Disables further receive operations.
-    $shut_rd
+    $rd
     ;;; Disables further send operations.
-    $shut_wr
+    $wr
   )
 )
 
@@ -736,7 +736,7 @@
 (typename $preopentype
   (enum u8
     ;;; A pre-opened directory.
-    $preopentype_dir
+    $dir
   )
 )
 

--- a/phases/old/snapshot_0/witx/typenames.witx
+++ b/phases/old/snapshot_0/witx/typenames.witx
@@ -38,159 +38,159 @@
 (typename $errno
   (enum u16
     ;;; No error occurred. System call completed successfully.
-    $esuccess
+    $success
     ;;; Argument list too long.
-    $e2big
+    $2big
     ;;; Permission denied.
-    $eacces
+    $acces
     ;;; Address in use.
-    $eaddrinuse
+    $addrinuse
     ;;; Address not available.
-    $eaddrnotavail
+    $addrnotavail
     ;;; Address family not supported.
-    $eafnosupport
+    $afnosupport
     ;;; Resource unavailable, or operation would block.
-    $eagain
+    $again
     ;;; Connection already in progress.
-    $ealready
+    $already
     ;;; Bad file descriptor.
-    $ebadf
+    $badf
     ;;; Bad message.
-    $ebadmsg
+    $badmsg
     ;;; Device or resource busy.
-    $ebusy
+    $busy
     ;;; Operation canceled.
-    $ecanceled
+    $canceled
     ;;; No child processes.
-    $echild
+    $child
     ;;; Connection aborted.
-    $econnaborted
+    $connaborted
     ;;; Connection refused.
-    $econnrefused
+    $connrefused
     ;;; Connection reset.
-    $econnreset
+    $connreset
     ;;; Resource deadlock would occur.
-    $edeadlk
+    $deadlk
     ;;; Destination address required.
-    $edestaddrreq
+    $destaddrreq
     ;;; Mathematics argument out of domain of function.
-    $edom
+    $dom
     ;;; Reserved.
-    $edquot
+    $dquot
     ;;; File exists.
-    $eexist
+    $exist
     ;;; Bad address.
-    $efault
+    $fault
     ;;; File too large.
-    $efbig
+    $fbig
     ;;; Host is unreachable.
-    $ehostunreach
+    $hostunreach
     ;;; Identifier removed.
-    $eidrm
+    $idrm
     ;;; Illegal byte sequence.
-    $eilseq
+    $ilseq
     ;;; Operation in progress.
-    $einprogress
+    $inprogress
     ;;; Interrupted function.
-    $eintr
+    $intr
     ;;; Invalid argument.
-    $einval
+    $inval
     ;;; I/O error.
-    $eio
+    $io
     ;;; Socket is connected.
-    $eisconn
+    $isconn
     ;;; Is a directory.
-    $eisdir
+    $isdir
     ;;; Too many levels of symbolic links.
-    $eloop
+    $loop
     ;;; File descriptor value too large.
-    $emfile
+    $mfile
     ;;; Too many links.
-    $emlink
+    $mlink
     ;;; Message too large.
-    $emsgsize
+    $msgsize
     ;;; Reserved.
-    $emultihop
+    $multihop
     ;;; Filename too long.
-    $enametoolong
+    $nametoolong
     ;;; Network is down.
-    $enetdown
+    $netdown
     ;;; Connection aborted by network.
-    $enetreset
+    $netreset
     ;;; Network unreachable.
-    $enetunreach
+    $netunreach
     ;;; Too many files open in system.
-    $enfile
+    $nfile
     ;;; No buffer space available.
-    $enobufs
+    $nobufs
     ;;; No such device.
-    $enodev
+    $nodev
     ;;; No such file or directory.
-    $enoent
+    $noent
     ;;; Executable file format error.
-    $enoexec
+    $noexec
     ;;; No locks available.
-    $enolck
+    $nolck
     ;;; Reserved.
-    $enolink
+    $nolink
     ;;; Not enough space.
-    $enomem
+    $nomem
     ;;; No message of the desired type.
-    $enomsg
+    $nomsg
     ;;; Protocol not available.
-    $enoprotoopt
+    $noprotoopt
     ;;; No space left on device.
-    $enospc
+    $nospc
     ;;; Function not supported.
-    $enosys
+    $nosys
     ;;; The socket is not connected.
-    $enotconn
+    $notconn
     ;;; Not a directory or a symbolic link to a directory.
-    $enotdir
+    $notdir
     ;;; Directory not empty.
-    $enotempty
+    $notempty
     ;;; State not recoverable.
-    $enotrecoverable
+    $notrecoverable
     ;;; Not a socket.
-    $enotsock
+    $notsock
     ;;; Not supported, or operation not supported on socket.
-    $enotsup
+    $notsup
     ;;; Inappropriate I/O control operation.
-    $enotty
+    $notty
     ;;; No such device or address.
-    $enxio
+    $nxio
     ;;; Value too large to be stored in data type.
-    $eoverflow
+    $overflow
     ;;; Previous owner died.
-    $eownerdead
+    $ownerdead
     ;;; Operation not permitted.
-    $eperm
+    $perm
     ;;; Broken pipe.
-    $epipe
+    $pipe
     ;;; Protocol error.
-    $eproto
+    $proto
     ;;; Protocol not supported.
-    $eprotonosupport
+    $protonosupport
     ;;; Protocol wrong type for socket.
-    $eprototype
+    $prototype
     ;;; Result too large.
-    $erange
+    $range
     ;;; Read-only file system.
-    $erofs
+    $rofs
     ;;; Invalid seek.
-    $espipe
+    $spipe
     ;;; No such process.
-    $esrch
+    $srch
     ;;; Reserved.
-    $estale
+    $stale
     ;;; Connection timed out.
-    $etimedout
+    $timedout
     ;;; Text file busy.
-    $etxtbsy
+    $txtbsy
     ;;; Cross-device link.
-    $exdev
+    $xdev
     ;;; Extension: Capabilities insufficient.
-    $enotcapable
+    $notcapable
   )
 )
 

--- a/phases/old/snapshot_0/witx/typenames.witx
+++ b/phases/old/snapshot_0/witx/typenames.witx
@@ -499,7 +499,7 @@
 (typename $eventrwflags
   (flags u16
     ;;; The peer of this socket has closed or disconnected.
-    $event_fd_readwrite_hangup
+    $fd_readwrite_hangup
   )
 )
 

--- a/phases/old/snapshot_0/witx/typenames.witx
+++ b/phases/old/snapshot_0/witx/typenames.witx
@@ -606,97 +606,97 @@
   (enum u8
     ;;; No signal. Note that POSIX has special semantics for `kill(pid, 0)`,
     ;;; so this value is reserved.
-    $signone
+    $none
     ;;; Hangup.
     ;;; Action: Terminates the process.
-    $sighup
+    $hup
     ;;; Terminate interrupt signal.
     ;;; Action: Terminates the process.
-    $sigint
+    $int
     ;;; Terminal quit signal.
     ;;; Action: Terminates the process.
-    $sigquit
+    $quit
     ;;; Illegal instruction.
     ;;; Action: Terminates the process.
-    $sigill
+    $ill
     ;;; Trace/breakpoint trap.
     ;;; Action: Terminates the process.
-    $sigtrap
+    $trap
     ;;; Process abort signal.
     ;;; Action: Terminates the process.
-    $sigabrt
+    $abrt
     ;;; Access to an undefined portion of a memory object.
     ;;; Action: Terminates the process.
-    $sigbus
+    $bus
     ;;; Erroneous arithmetic operation.
     ;;; Action: Terminates the process.
-    $sigfpe
+    $fpe
     ;;; Kill.
     ;;; Action: Terminates the process.
-    $sigkill
+    $kill
     ;;; User-defined signal 1.
     ;;; Action: Terminates the process.
-    $sigusr1
+    $usr1
     ;;; Invalid memory reference.
     ;;; Action: Terminates the process.
-    $sigsegv
+    $segv
     ;;; User-defined signal 2.
     ;;; Action: Terminates the process.
-    $sigusr2
+    $usr2
     ;;; Write on a pipe with no one to read it.
     ;;; Action: Ignored.
-    $sigpipe
+    $pipe
     ;;; Alarm clock.
     ;;; Action: Terminates the process.
-    $sigalrm
+    $alrm
     ;;; Termination signal.
     ;;; Action: Terminates the process.
-    $sigterm
+    $term
     ;;; Child process terminated, stopped, or continued.
     ;;; Action: Ignored.
-    $sigchld
+    $chld
     ;;; Continue executing, if stopped.
     ;;; Action: Continues executing, if stopped.
-    $sigcont
+    $cont
     ;;; Stop executing.
     ;;; Action: Stops executing.
-    $sigstop
+    $stop
     ;;; Terminal stop signal.
     ;;; Action: Stops executing.
-    $sigtstp
+    $tstp
     ;;; Background process attempting read.
     ;;; Action: Stops executing.
-    $sigttin
+    $ttin
     ;;; Background process attempting write.
     ;;; Action: Stops executing.
-    $sigttou
+    $ttou
     ;;; High bandwidth data is available at a socket.
     ;;; Action: Ignored.
-    $sigurg
+    $urg
     ;;; CPU time limit exceeded.
     ;;; Action: Terminates the process.
-    $sigxcpu
+    $xcpu
     ;;; File size limit exceeded.
     ;;; Action: Terminates the process.
-    $sigxfsz
+    $xfsz
     ;;; Virtual timer expired.
     ;;; Action: Terminates the process.
-    $sigvtalrm
+    $vtalrm
     ;;; Profiling timer expired.
     ;;; Action: Terminates the process.
-    $sigprof
+    $prof
     ;;; Window changed.
     ;;; Action: Ignored.
-    $sigwinch
+    $winch
     ;;; I/O possible.
     ;;; Action: Terminates the process.
-    $sigpoll
+    $poll
     ;;; Power failure.
     ;;; Action: Terminates the process.
-    $sigpwr
+    $pwr
     ;;; Bad system call.
     ;;; Action: Terminates the process.
-    $sigsys
+    $sys
   )
 )
 

--- a/phases/old/snapshot_0/witx/wasi_unstable.witx
+++ b/phases/old/snapshot_0/witx/wasi_unstable.witx
@@ -20,15 +20,15 @@
   (@interface func (export "args_get")
     (param $argv (@witx pointer (@witx pointer u8)))
     (param $argv_buf (@witx pointer u8))
-    (result $error $errno_t)
+    (result $error $errno)
   )
   ;;; Return command-line argument data sizes.
   (@interface func (export "args_sizes_get")
-    (result $error $errno_t)
+    (result $error $errno)
     ;;; The number of arguments.
-    (result $argc $size_t)
+    (result $argc $size)
     ;;; The size of the argument string data.
-    (result $argv_buf_size $size_t)
+    (result $argv_buf_size $size)
   )
 
   ;;; Read environment variable data.
@@ -36,187 +36,187 @@
   (@interface func (export "environ_get")
     (param $environ (@witx pointer (@witx pointer u8)))
     (param $environ_buf (@witx pointer u8))
-    (result $error $errno_t)
+    (result $error $errno)
   )
   ;;; Return command-line argument data sizes.
   (@interface func (export "environ_sizes_get")
-    (result $error $errno_t)
+    (result $error $errno)
     ;;; The number of arguments.
-    (result $argc $size_t)
+    (result $argc $size)
     ;;; The size of the argument string data.
-    (result $argv_buf_size $size_t)
+    (result $argv_buf_size $size)
   )
 
   ;;; Return the resolution of a clock.
   ;;; Implementations are required to provide a non-zero value for supported clocks. For unsupported clocks, return `WASI_EINVAL`
   ;;; Note: This is similar to `clock_getres` in POSIX.
   (@interface func (export "clock_res_get")
-    (result $error $errno_t)
+    (result $error $errno)
     ;;; The clock for which to return the resolution.
-    (param $clock_id $clockid_t)
+    (param $clock_id $clockid)
     ;;; The resolution of the clock.
-    (result $resolution $timestamp_t)
+    (result $resolution $timestamp)
   )
   ;;; Return the time value of a clock.
   ;;; Note: This is similar to `clock_gettime` in POSIX.
   (@interface func (export "clock_time_get")
     ;;; The clock for which to return the time.
-    (param $clock_id $clockid_t)
+    (param $clock_id $clockid)
     ;;; The maximum lag (exclusive) that the returned time value may have, compared to its actual value.
-    (param $precision $timestamp_t)
-    (result $error $errno_t)
+    (param $precision $timestamp)
+    (result $error $errno)
     ;;; The time value of the clock.
-    (result $time $timestamp_t)
+    (result $time $timestamp)
   )
 
   ;;; Provide file advisory information on a file descriptor.
   ;;; Note: This is similar to `posix_fadvise` in POSIX.
   (@interface func (export "fd_advise")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; The offset within the file to which the advisory applies.
-    (param $offset $filesize_t)
+    (param $offset $filesize)
     ;;; The length of the region to which the advisory applies.
-    (param $len $filesize_t)
+    (param $len $filesize)
     ;;; The advice.
-    (param $advice $advice_t)
-    (result $error $errno_t)
+    (param $advice $advice)
+    (result $error $errno)
   )
 
   ;;; Force the allocation of space in a file.
   ;;; Note: This is similar to `posix_fallocate` in POSIX.
   (@interface func (export "fd_allocate")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; The offset at which to start the allocation.
-    (param $offset $filesize_t)
+    (param $offset $filesize)
     ;;; The length of the area that is allocated.
-    (param $len $filesize_t)
-    (result $error $errno_t)
+    (param $len $filesize)
+    (result $error $errno)
   )
 
   ;;; Close a file descriptor.
   ;;; Note: This is similar to `close` in POSIX.
   (@interface func (export "fd_close")
-    (param $fd $fd_t)
-    (result $error $errno_t)
+    (param $fd $fd)
+    (result $error $errno)
   )
 
   ;;; Synchronize the data of a file to disk.
   ;;; Note: This is similar to `fdatasync` in POSIX.
   (@interface func (export "fd_datasync")
-    (param $fd $fd_t)
-    (result $error $errno_t)
+    (param $fd $fd)
+    (result $error $errno)
   )
 
   ;;; Get the attributes of a file descriptor.
   ;;; Note: This returns similar flags to `fsync(fd, F_GETFL)` in POSIX, as well as additional fields.
   (@interface func (export "fd_fdstat_get")
-    (param $fd $fd_t)
-    (result $error $errno_t)
+    (param $fd $fd)
+    (result $error $errno)
     ;;; The buffer where the file descriptor's attributes are stored.
-    (result $stat $fdstat_t)
+    (result $stat $fdstat)
   )
 
   ;;; Adjust the flags associated with a file descriptor.
   ;;; Note: This is similar to `fcntl(fd, F_SETFL, flags)` in POSIX.
   (@interface func (export "fd_fdstat_set_flags")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; The desired values of the file descriptor flags.
-    (param $flags $fdflags_t)
-    (result $error $errno_t)
+    (param $flags $fdflags)
+    (result $error $errno)
   )
 
   ;;; Adjust the rights associated with a file descriptor.
   ;;; This can only be used to remove rights, and returns `ENOTCAPABLE` if called in a way that would attempt to add rights
   (@interface func (export "fd_fdstat_set_rights")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; The desired rights of the file descriptor.
-    (param $fs_rights_base $rights_t)
-    (param $fs_rights_inheriting $rights_t)
-    (result $error $errno_t)
+    (param $fs_rights_base $rights)
+    (param $fs_rights_inheriting $rights)
+    (result $error $errno)
   )
 
   ;;; Return the attributes of an open file.
   (@interface func (export "fd_filestat_get")
-    (param $fd $fd_t)
-    (result $error $errno_t)
+    (param $fd $fd)
+    (result $error $errno)
     ;;; The buffer where the file's attributes are stored.
-    (result $buf $filestat_t)
+    (result $buf $filestat)
   )
 
   ;;; Adjust the size of an open file. If this increases the file's size, the extra bytes are filled with zeros.
   ;;; Note: This is similar to `ftruncate` in POSIX.
   (@interface func (export "fd_filestat_set_size")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; The desired file size.
-    (param $st_size $filesize_t)
-    (result $error $errno_t)
+    (param $st_size $filesize)
+    (result $error $errno)
   )
 
   ;;; Adjust the timestamps of an open file or directory.
   ;;; Note: This is similar to `futimens` in POSIX.
   (@interface func (export "fd_filestat_set_times")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; The desired values of the data access timestamp.
-    (param $st_atim $timestamp_t)
+    (param $st_atim $timestamp)
     ;;; The desired values of the data modification timestamp.
-    (param $st_mtim $timestamp_t)
+    (param $st_mtim $timestamp)
     ;;; A bitmask indicating which timestamps to adjust.
-    (param $fst_flags $fstflags_t)
-    (result $error $errno_t)
+    (param $fst_flags $fstflags)
+    (result $error $errno)
   )
 
   ;;; Read from a file descriptor, without using and updating the file descriptor's offset.
   ;;; Note: This is similar to `preadv` in POSIX.
   (@interface func (export "fd_pread")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; List of scatter/gather vectors in which to store data.
-    (param $iovs $iovec_t_array)
+    (param $iovs $iovec_array)
     ;;; The offset within the file at which to read.
-    (param $offset $filesize_t)
-    (result $error $errno_t)
+    (param $offset $filesize)
+    (result $error $errno)
     ;;; The number of bytes read.
-    (result $nread $size_t)
+    (result $nread $size)
   )
 
   ;;; Return a description of the given preopened file descriptor.
   (@interface func (export "fd_prestat_get")
-    (param $fd $fd_t)
-    (result $error $errno_t)
+    (param $fd $fd)
+    (result $error $errno)
     ;;; The buffer where the description is stored.
-    (result $buf $prestat_t)
+    (result $buf $prestat)
   )
 
   ;;; Return a description of the given preopened file descriptor.
   (@interface func (export "fd_prestat_dir_name")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; A buffer into which to write the preopened directory name.
     (param $path (@witx pointer u8))
-    (param $path_len $size_t)
-    (result $error $errno_t)
+    (param $path_len $size)
+    (result $error $errno)
   )
 
   ;;; Write to a file descriptor, without using and updating the file descriptor's offset.
   ;;; Note: This is similar to `pwritev` in POSIX.
   (@interface func (export "fd_pwrite")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; List of scatter/gather vectors from which to retrieve data.
-    (param $iovs $ciovec_t_array)
+    (param $iovs $ciovec_array)
     ;;; The offset within the file at which to write.
-    (param $offset $filesize_t)
-    (result $error $errno_t)
+    (param $offset $filesize)
+    (result $error $errno)
     ;;; The number of bytes written.
-    (result $nwritten $size_t)
+    (result $nwritten $size)
   )
 
   ;;; Read from a file descriptor.
   ;;; Note: This is similar to `readv` in POSIX.
   (@interface func (export "fd_read")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; List of scatter/gather vectors to which to store data.
-    (param $iovs $iovec_t_array)
-    (result $error $errno_t)
+    (param $iovs $iovec_array)
+    (result $error $errno)
     ;;; The number of bytes read.
-    (result $nread $size_t)
+    (result $nread $size)
   )
 
   ;;; Read directory entries from a directory.
@@ -230,15 +230,15 @@
   ;;; read buffer size in case it's too small to fit a single large directory
   ;;; entry, or skip the oversized directory entry.
   (@interface func (export "fd_readdir")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; The buffer where directory entries are stored
     (param $buf (@witx pointer u8))
-    (param $buf_len $size_t)
+    (param $buf_len $size)
     ;;; The location within the directory to start reading
-    (param $cookie $dircookie_t)
-    (result $error $errno_t)
+    (param $cookie $dircookie)
+    (result $error $errno)
     ;;; The number of bytes stored in the read buffer. If less than the size of the read buffer, the end of the directory has been reached.
-    (result $bufused $size_t)
+    (result $bufused $size)
   )
 
   ;;; Atomically replace a file descriptor by renumbering another file descriptor.
@@ -252,104 +252,104 @@
   ;;; This function provides a way to atomically renumber file descriptors, which
   ;;; would disappear if `dup2()` were to be removed entirely.
   (@interface func (export "fd_renumber")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; The file descriptor to overwrite.
-    (param $to $fd_t)
-    (result $error $errno_t)
+    (param $to $fd)
+    (result $error $errno)
   )
 
   ;;; Move the offset of a file descriptor.
   ;;; Note: This is similar to `lseek` in POSIX.
   (@interface func (export "fd_seek")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; The number of bytes to move.
-    (param $offset $filedelta_t)
+    (param $offset $filedelta)
     ;;; The base from which the offset is relative.
-    (param $whence $whence_t)
-    (result $error $errno_t)
+    (param $whence $whence)
+    (result $error $errno)
     ;;; The new offset of the file descriptor, relative to the start of the file.
-    (result $newoffset $filesize_t)
+    (result $newoffset $filesize)
   )
 
   ;;; Synchronize the data and metadata of a file to disk.
   ;;; Note: This is similar to `fsync` in POSIX.
   (@interface func (export "fd_sync")
-    (param $fd $fd_t)
-    (result $error $errno_t)
+    (param $fd $fd)
+    (result $error $errno)
   )
 
   ;;; Return the current offset of a file descriptor.
   ;;; Note: This is similar to `lseek(fd, 0, SEEK_CUR)` in POSIX.
   (@interface func (export "fd_tell")
-    (param $fd $fd_t)
-    (result $error $errno_t)
+    (param $fd $fd)
+    (result $error $errno)
     ;;; The current offset of the file descriptor, relative to the start of the file.
-    (result $offset $filesize_t)
+    (result $offset $filesize)
   )
 
   ;;; Write to a file descriptor.
   ;;; Note: This is similar to `writev` in POSIX.
   (@interface func (export "fd_write")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; List of scatter/gather vectors from which to retrieve data.
-    (param $iovs $ciovec_t_array)
-    (result $error $errno_t)
+    (param $iovs $ciovec_array)
+    (result $error $errno)
     ;;; The number of bytes written.
-    (result $nwritten $size_t)
+    (result $nwritten $size)
   )
 
   ;;; Create a directory.
   ;;; Note: This is similar to `mkdirat` in POSIX.
   (@interface func (export "path_create_directory")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; The path at which to create the directory.
     (param $path string)
-    (result $error $errno_t)
+    (result $error $errno)
   )
 
   ;;; Return the attributes of a file or directory.
   ;;; Note: This is similar to `stat` in POSIX.
   (@interface func (export "path_filestat_get")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; Flags determining the method of how the path is resolved.
-    (param $flags $lookupflags_t)
+    (param $flags $lookupflags)
     ;;; The path of the file or directory to inspect.
     (param $path string)
-    (result $error $errno_t)
+    (result $error $errno)
     ;;; The buffer where the file's attributes are stored.
-    (result $buf $filestat_t)
+    (result $buf $filestat)
   )
 
   ;;; Adjust the timestamps of a file or directory.
   ;;; Note: This is similar to `utimensat` in POSIX.
   (@interface func (export "path_filestat_set_times")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; Flags determining the method of how the path is resolved.
-    (param $flags $lookupflags_t)
+    (param $flags $lookupflags)
     ;;; The path of the file or directory to operate on.
     (param $path string)
     ;;; The desired values of the data access timestamp.
-    (param $st_atim $timestamp_t)
+    (param $st_atim $timestamp)
     ;;; The desired values of the data modification timestamp.
-    (param $st_mtim $timestamp_t)
+    (param $st_mtim $timestamp)
     ;;; A bitmask indicating which timestamps to adjust.
-    (param $fst_flags $fstflags_t)
-    (result $error $errno_t)
+    (param $fst_flags $fstflags)
+    (result $error $errno)
   )
 
   ;;; Create a hard link.
   ;;; Note: This is similar to `linkat` in POSIX.
   (@interface func (export "path_link")
-    (param $old_fd $fd_t)
+    (param $old_fd $fd)
     ;;; Flags determining the method of how the path is resolved.
-    (param $old_flags $lookupflags_t)
+    (param $old_flags $lookupflags)
     ;;; The source path from which to link.
     (param $old_path string)
     ;;; The working directory at which the resolution of the new path starts.
-    (param $new_fd $fd_t)
+    (param $new_fd $fd)
     ;;; The destination path at which to create the hard link.
     (param $new_path string)
-    (result $error $errno_t)
+    (result $error $errno)
   )
 
   ;;; Open a file or directory.
@@ -362,14 +362,14 @@
   ;;
   ;;; Note: This is similar to `openat` in POSIX.
   (@interface func (export "path_open")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; Flags determining the method of how the path is resolved.
-    (param $dirflags $lookupflags_t)
+    (param $dirflags $lookupflags)
     ;;; The relative path of the file or directory to open, relative to the
     ;;; `dirfd` directory.
     (param $path string)
     ;;; The method by which to open the file.
-    (param $o_flags $oflags_t)
+    (param $o_flags $oflags)
     ;;; The initial rights of the newly created file descriptor. The
     ;;; implementation is allowed to return a file descriptor with fewer rights
     ;;; than specified, if and only if those rights do not apply to the type of
@@ -378,49 +378,49 @@
     ;;; The *base* rights are rights that will apply to operations using the file
     ;;; descriptor itself, while the *inheriting* rights are rights that apply to
     ;;; file descriptors derived from it.
-    (param $fs_rights_base $rights_t)
-    (param $fs_rights_inherting $rights_t)
-    (param $flags $fdflags_t)
-    (result $error $errno_t)
+    (param $fs_rights_base $rights)
+    (param $fs_rights_inherting $rights)
+    (param $flags $fdflags)
+    (result $error $errno)
     ;;; The file descriptor of the file that has been opened.
-    (result $opened_fd $fd_t)
+    (result $opened_fd $fd)
   )
 
   ;;; Read the contents of a symbolic link.
   ;;; Note: This is similar to `readlinkat` in POSIX.
   (@interface func (export "path_readlink")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; The path of the symbolic link from which to read.
     (param $path string)
     ;;; The buffer to which to write the contents of the symbolic link.
     (param $buf (@witx pointer u8))
-    (param $buf_len $size_t)
-    (result $error $errno_t)
+    (param $buf_len $size)
+    (result $error $errno)
     ;;; The number of bytes placed in the buffer.
-    (result $bufused $size_t)
+    (result $bufused $size)
   )
 
   ;;; Remove a directory.
   ;;; Return `ENOTEMPTY` if the directory is not empty.
   ;;; Note: This is similar to `unlinkat(fd, path, AT_REMOVEDIR)` in POSIX.
   (@interface func (export "path_remove_directory")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; The path to a directory to remove.
     (param $path string)
-    (result $error $errno_t)
+    (result $error $errno)
   )
 
   ;;; Rename a file or directory.
   ;;; Note: This is similar to `renameat` in POSIX.
   (@interface func (export "path_rename")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; The source path of the file or directory to rename.
     (param $old_path string)
     ;;; The working directory at which the resolution of the new path starts.
-    (param $new_fd $fd_t)
+    (param $new_fd $fd)
     ;;; The destination path to which to rename the file or directory.
     (param $new_path string)
-    (result $error $errno_t)
+    (result $error $errno)
   )
 
   ;;; Create a symbolic link.
@@ -428,10 +428,10 @@
   (@interface func (export "path_symlink")
     ;;; The contents of the symbolic link.
     (param $old_path string)
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; The destination path at which to create the symbolic link.
     (param $new_path string)
-    (result $error $errno_t)
+    (result $error $errno)
   )
 
 
@@ -439,23 +439,23 @@
   ;;; Return `EISDIR` if the path refers to a directory.
   ;;; Note: This is similar to `unlinkat(fd, path, 0)` in POSIX.
   (@interface func (export "path_unlink_file")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; The path to a file to unlink.
     (param $path string)
-    (result $error $errno_t)
+    (result $error $errno)
   )
 
   ;;; Concurrently poll for the occurrence of a set of events.
   (@interface func (export "poll_oneoff")
     ;;; The events to which to subscribe.
-    (param $in (@witx const_pointer $subscription_t))
+    (param $in (@witx const_pointer $subscription))
     ;;; The events that have occurred.
-    (param $out (@witx pointer $event_t))
+    (param $out (@witx pointer $event))
     ;;; Both the number of subscriptions and events.
-    (param $nsubscriptions $size_t)
-    (result $error $errno_t)
+    (param $nsubscriptions $size)
+    (result $error $errno)
     ;;; The number of events stored.
-    (result $nevents $size_t)
+    (result $nevents $size)
   )
 
   ;;; Terminate the process normally. An exit code of 0 indicates successful
@@ -463,21 +463,21 @@
   ;;; the environment.
   (@interface func (export "proc_exit")
     ;;; The exit code returned by the process.
-    (param $rval $exitcode_t)
+    (param $rval $exitcode)
   )
 
   ;;; Send a signal to the process of the calling thread.
   ;;; Note: This is similar to `raise` in POSIX.
   (@interface func (export "proc_raise")
     ;;; The signal condition to trigger.
-    (param $sig $signal_t)
-    (result $error $errno_t)
+    (param $sig $signal)
+    (result $error $errno)
   )
 
   ;;; Temporarily yield execution of the calling thread.
   ;;; Note: This is similar to `sched_yield` in POSIX.
   (@interface func (export "sched_yield")
-    (result $error $errno_t)
+    (result $error $errno)
   )
 
   ;;; Write high-quality random data into a buffer.
@@ -489,46 +489,46 @@
   (@interface func (export "random_get")
     ;;; The buffer to fill with random data.
     (param $buf (@witx pointer u8))
-    (param $buf_len $size_t)
-    (result $error $errno_t)
+    (param $buf_len $size)
+    (result $error $errno)
   )
 
   ;;; Receive a message from a socket.
   ;;; Note: This is similar to `recv` in POSIX, though it also supports reading
   ;;; the data into multiple buffers in the manner of `readv`.
   (@interface func (export "sock_recv")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; List of scatter/gather vectors to which to store data.
-    (param $ri_data $iovec_t_array)
+    (param $ri_data $iovec_array)
     ;;; Message flags.
-    (param $ri_flags $riflags_t)
-    (result $error $errno_t)
+    (param $ri_flags $riflags)
+    (result $error $errno)
     ;;; Number of bytes stored in ri_data.
-    (result $ro_datalen $size_t)
+    (result $ro_datalen $size)
     ;;; Message flags.
-    (result $ro_flags $roflags_t)
+    (result $ro_flags $roflags)
   )
 
   ;;; Send a message on a socket.
   ;;; Note: This is similar to `send` in POSIX, though it also supports writing
   ;;; the data from multiple buffers in the manner of `writev`.
   (@interface func (export "sock_send")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; List of scatter/gather vectors to which to retrieve data
-    (param $si_data $ciovec_t_array)
+    (param $si_data $ciovec_array)
     ;;; Message flags.
-    (param $si_flags $siflags_t)
-    (result $error $errno_t)
+    (param $si_flags $siflags)
+    (result $error $errno)
     ;;; Number of bytes transmitted.
-    (result $so_datalen $size_t)
+    (result $so_datalen $size)
   )
 
   ;;; Shut down socket send and receive channels.
   ;;; Note: This is similar to `shutdown` in POSIX.
   (@interface func (export "sock_shutdown")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; Which channels on the socket to shut down.
-    (param $how $sdflags_t)
-    (result $error $errno_t)
+    (param $how $sdflags)
+    (result $error $errno)
   )
 )

--- a/phases/old/snapshot_0/witx/wasi_unstable.witx
+++ b/phases/old/snapshot_0/witx/wasi_unstable.witx
@@ -53,7 +53,7 @@
   (@interface func (export "clock_res_get")
     (result $error $errno)
     ;;; The clock for which to return the resolution.
-    (param $clock_id $clockid)
+    (param $id $clockid)
     ;;; The resolution of the clock.
     (result $resolution $timestamp)
   )
@@ -61,7 +61,7 @@
   ;;; Note: This is similar to `clock_gettime` in POSIX.
   (@interface func (export "clock_time_get")
     ;;; The clock for which to return the time.
-    (param $clock_id $clockid)
+    (param $id $clockid)
     ;;; The maximum lag (exclusive) that the returned time value may have, compared to its actual value.
     (param $precision $timestamp)
     (result $error $errno)
@@ -148,7 +148,7 @@
   (@interface func (export "fd_filestat_set_size")
     (param $fd $fd)
     ;;; The desired file size.
-    (param $st_size $filesize)
+    (param $size $filesize)
     (result $error $errno)
   )
 
@@ -157,9 +157,9 @@
   (@interface func (export "fd_filestat_set_times")
     (param $fd $fd)
     ;;; The desired values of the data access timestamp.
-    (param $st_atim $timestamp)
+    (param $atim $timestamp)
     ;;; The desired values of the data modification timestamp.
-    (param $st_mtim $timestamp)
+    (param $mtim $timestamp)
     ;;; A bitmask indicating which timestamps to adjust.
     (param $fst_flags $fstflags)
     (result $error $errno)
@@ -329,9 +329,9 @@
     ;;; The path of the file or directory to operate on.
     (param $path string)
     ;;; The desired values of the data access timestamp.
-    (param $st_atim $timestamp)
+    (param $atim $timestamp)
     ;;; The desired values of the data modification timestamp.
-    (param $st_mtim $timestamp)
+    (param $mtim $timestamp)
     ;;; A bitmask indicating which timestamps to adjust.
     (param $fst_flags $fstflags)
     (result $error $errno)
@@ -369,7 +369,7 @@
     ;;; `dirfd` directory.
     (param $path string)
     ;;; The method by which to open the file.
-    (param $o_flags $oflags)
+    (param $flags $oflags)
     ;;; The initial rights of the newly created file descriptor. The
     ;;; implementation is allowed to return a file descriptor with fewer rights
     ;;; than specified, if and only if those rights do not apply to the type of

--- a/phases/old/snapshot_0/witx/wasi_unstable.witx
+++ b/phases/old/snapshot_0/witx/wasi_unstable.witx
@@ -369,7 +369,7 @@
     ;;; `dirfd` directory.
     (param $path string)
     ;;; The method by which to open the file.
-    (param $flags $oflags)
+    (param $oflags $oflags)
     ;;; The initial rights of the newly created file descriptor. The
     ;;; implementation is allowed to return a file descriptor with fewer rights
     ;;; than specified, if and only if those rights do not apply to the type of
@@ -380,7 +380,7 @@
     ;;; file descriptors derived from it.
     (param $fs_rights_base $rights)
     (param $fs_rights_inherting $rights)
-    (param $flags $fdflags)
+    (param $fdflags $fdflags)
     (result $error $errno)
     ;;; The file descriptor of the file that has been opened.
     (result $opened_fd $fd)

--- a/phases/snapshot/witx/typenames.witx
+++ b/phases/snapshot/witx/typenames.witx
@@ -18,16 +18,16 @@
   (enum u32
     ;;; The clock measuring real time. Time value zero corresponds with
     ;;; 1970-01-01T00:00:00Z.
-    $clock_realtime
+    $realtime
     ;;; The store-wide monotonic clock, which is defined as a clock measuring
     ;;; real time, whose value cannot be adjusted and which cannot have negative
     ;;; clock jumps. The epoch of this clock is undefined. The absolute time
     ;;; value of this clock therefore has no meaning.
-    $clock_monotonic
+    $monotonic
     ;;; The CPU-time clock associated with the current process.
-    $clock_process_cputime_id
+    $process_cputime_id
     ;;; The CPU-time clock associated with the current thread.
-    $clock_thread_cputime_id
+    $thread_cputime_id
   )
 )
 
@@ -201,75 +201,75 @@
     ;;
     ;;; If `RIGHT_PATH_OPEN` is set, includes the right to invoke
     ;;; `path_open` with `FDFLAG_DSYNC`.
-    $right_fd_datasync
+    $fd_datasync
     ;;; The right to invoke `fd_read` and `sock_recv`.
     ;;
     ;;; If `RIGHT_FD_SEEK` is set, includes the right to invoke `fd_pread`.
-    $right_fd_read
+    $fd_read
     ;;; The right to invoke `fd_seek`. This flag implies `RIGHT_FD_TELL`.
-    $right_fd_seek
+    $fd_seek
     ;;; The right to invoke `fd_fdstat_set_flags`.
-    $right_fd_fdstat_set_flags
+    $fd_fdstat_set_flags
     ;;; The right to invoke `fd_sync`.
     ;;
     ;;; If `RIGHT_PATH_OPEN` is set, includes the right to invoke
     ;;; `path_open` with `FDFLAG_RSYNC` and `FDFLAG_DSYNC`.
-    $right_fd_sync
+    $fd_sync
     ;;; The right to invoke `fd_seek` in such a way that the file offset
     ;;; remains unaltered (i.e., `WHENCE_CUR` with offset zero), or to
     ;;; invoke `fd_tell`.
-    $right_fd_tell
+    $fd_tell
     ;;; The right to invoke `fd_write` and `sock_send`.
     ;;; If `RIGHT_FD_SEEK` is set, includes the right to invoke `fd_pwrite`.
-    $right_fd_write
+    $fd_write
     ;;; The right to invoke `fd_advise`.
-    $right_fd_advise
+    $fd_advise
     ;;; The right to invoke `fd_allocate`.
-    $right_fd_allocate
+    $fd_allocate
     ;;; The right to invoke `path_create_directory`.
-    $right_path_create_directory
+    $path_create_directory
     ;;; If `RIGHT_PATH_OPEN` is set, the right to invoke `path_open` with `O_CREAT`.
-    $right_path_create_file
+    $path_create_file
     ;;; The right to invoke `path_link` with the file descriptor as the
     ;;; source directory.
-    $right_path_link_source
+    $path_link_source
     ;;; The right to invoke `path_link` with the file descriptor as the
     ;;; target directory.
-    $right_path_link_target
+    $path_link_target
     ;;; The right to invoke `path_open`.
-    $right_path_open
+    $path_open
     ;;; The right to invoke `fd_readdir`.
-    $right_fd_readdir
+    $fd_readdir
     ;;; The right to invoke `path_readlink`.
-    $right_path_readlink
+    $path_readlink
     ;;; The right to invoke `path_rename` with the file descriptor as the source directory.
-    $right_path_rename_source
+    $path_rename_source
     ;;; The right to invoke `path_rename` with the file descriptor as the target directory.
-    $right_path_rename_target
+    $path_rename_target
     ;;; The right to invoke `path_filestat_get`.
-    $right_path_filestat_get
+    $path_filestat_get
     ;;; The right to change a file's size (there is no `path_filestat_set_size`).
     ;;; If `RIGHT_PATH_OPEN` is set, includes the right to invoke `path_open` with `O_TRUNC`.
-    $right_path_filestat_set_size
+    $path_filestat_set_size
     ;;; The right to invoke `path_filestat_set_times`.
-    $right_path_filestat_set_times
+    $path_filestat_set_times
     ;;; The right to invoke `fd_filestat_get`.
-    $right_fd_filestat_get
+    $fd_filestat_get
     ;;; The right to invoke `fd_filestat_set_size`.
-    $right_fd_filestat_set_size
+    $fd_filestat_set_size
     ;;; The right to invoke `fd_filestat_set_times`.
-    $right_fd_filestat_set_times
+    $fd_filestat_set_times
     ;;; The right to invoke `path_symlink`.
-    $right_path_symlink
+    $path_symlink
     ;;; The right to invoke `path_remove_directory`.
-    $right_path_remove_directory
+    $path_remove_directory
     ;;; The right to invoke `path_unlink_file`.
-    $right_path_unlink_file
+    $path_unlink_file
     ;;; If `RIGHT_FD_READ` is set, includes the right to invoke `poll_oneoff` to subscribe to `EVENTTYPE_FD_READ`.
     ;;; If `RIGHT_FD_WRITE` is set, includes the right to invoke `poll_oneoff` to subscribe to `EVENTTYPE_FD_WRITE`.
-    $right_poll_fd_readwrite
+    $poll_fd_readwrite
     ;;; The right to invoke `sock_shutdown`.
-    $right_sock_shutdown
+    $sock_shutdown
   )
 )
 
@@ -306,11 +306,11 @@
 (typename $whence
   (enum u8
     ;;; Seek relative to start-of-file.
-    $whence_set
+    $set
     ;;; Seek relative to current position.
-    $whence_cur
+    $cur
     ;;; Seek relative to end-of-file.
-    $whence_end
+    $end
   )
 )
 
@@ -329,21 +329,21 @@
 (typename $filetype
   (enum u8
     ;;; The type of the file descriptor or file is unknown or is different from any of the other types specified.
-    $filetype_unknown
+    $unknown
     ;;; The file descriptor or file refers to a block device inode.
-    $filetype_block_device
+    $block_device
     ;;; The file descriptor or file refers to a character device inode.
-    $filetype_character_device
+    $character_device
     ;;; The file descriptor or file refers to a directory inode.
-    $filetype_directory
+    $directory
     ;;; The file descriptor or file refers to a regular file inode.
-    $filetype_regular_file
+    $regular_file
     ;;; The file descriptor or file refers to a datagram socket.
-    $filetype_socket_dgram
+    $socket_dgram
     ;;; The file descriptor or file refers to a byte-stream socket.
-    $filetype_socket_stream
+    $socket_stream
     ;;; The file refers to a symbolic link inode.
-    $filetype_symbolic_link
+    $symbolic_link
   )
 )
 
@@ -365,17 +365,17 @@
 (typename $advice
   (enum u8
     ;;; The application has no advice to give on its behavior with respect to the specified data.
-    $advice_normal
+    $normal
     ;;; The application expects to access the specified data sequentially from lower offsets to higher offsets.
-    $advice_sequential
+    $sequential
     ;;; The application expects to access the specified data in a random order.
-    $advice_random
+    $random
     ;;; The application expects to access the specified data in the near future.
-    $advice_willneed
+    $willneed
     ;;; The application expects that it will not access the specified data in the near future.
-    $advice_dontneed
+    $dontneed
     ;;; The application expects to access the specified data once and then not reuse it thereafter.
-    $advice_noreuse
+    $noreuse
   )
 )
 
@@ -383,17 +383,17 @@
 (typename $fdflags
   (flags u16
     ;;; Append mode: Data written to the file is always appended to the file's end.
-    $fdflag_append
+    $append
     ;;; Write according to synchronized I/O data integrity completion. Only the data stored in the file is synchronized.
-    $fdflag_dsync
+    $dsync
     ;;; Non-blocking mode.
-    $fdflag_nonblock
+    $nonblock
     ;;; Synchronized read I/O operations.
-    $fdflag_rsync
+    $rsync
     ;;; Write according to synchronized I/O file integrity completion. In
     ;;; addition to synchronizing the data stored in the file, the implementation
     ;;; may also synchronously update the file's metadata.
-    $fdflag_sync
+    $sync
   )
 )
 
@@ -420,13 +420,13 @@
 (typename $fstflags
   (flags u16
     ;;; Adjust the last data access timestamp to the value stored in `filestat_t::st_atim`.
-    $filestat_set_atim
+    $atim
     ;;; Adjust the last data access timestamp to the time of clock `CLOCK_REALTIME`.
-    $filestat_set_atim_now
+    $atim_now
     ;;; Adjust the last data modification timestamp to the value stored in `filestat_t::st_mtim`.
-    $filestat_set_mtim
+    $mtim
     ;;; Adjust the last data modification timestamp to the time of clock `CLOCK_REALTIME`.
-    $filestat_set_mtim_now
+    $mtim_now
   )
 )
 
@@ -434,7 +434,7 @@
 (typename $lookupflags
   (flags u32
     ;;; As long as the resolved path corresponds to a symbolic link, it is expanded.
-    $lookup_symlink_follow
+    $symlink_follow
   )
 )
 
@@ -442,13 +442,13 @@
 (typename $oflags
   (flags u16
     ;;; Create file if it does not exist.
-    $o_creat
+    $creat
     ;;; Fail if not a directory.
-    $o_directory
+    $directory
     ;;; Fail if file already exists.
-    $o_excl
+    $excl
     ;;; Truncate file to size 0.
-    $o_trunc
+    $trunc
   )
 )
 
@@ -459,21 +459,21 @@
 (typename $filestat
   (struct
     ;;; Device ID of device containing the file.
-    (field $st_dev $device)
+    (field $dev $device)
     ;;; File serial number.
-    (field $st_ino $inode)
+    (field $ino $inode)
     ;;; File type.
-    (field $st_filetype $filetype)
+    (field $filetype $filetype)
     ;;; Number of hard links to the file.
-    (field $st_nlink $linkcount)
+    (field $nlink $linkcount)
     ;;; For regular files, the file size in bytes. For symbolic links, the length in bytes of the pathname contained in the symbolic link.
-    (field $st_size $filesize)
+    (field $size $filesize)
     ;;; Last data access timestamp.
-    (field $st_atim $timestamp)
+    (field $atim $timestamp)
     ;;; Last data modification timestamp.
-    (field $st_mtim $timestamp)
+    (field $mtim $timestamp)
     ;;; Last file status change timestamp.
-    (field $st_ctim $timestamp)
+    (field $ctim $timestamp)
   )
 )
 
@@ -555,7 +555,7 @@
 (typename $subscription_clock
   (struct
     ;;; The clock against which to compare the timestamp.
-    (field $clock_id $clockid)
+    (field $id $clockid)
     ;;; The absolute or relative timestamp.
     (field $timeout $timestamp)
     ;;; The amount of time that the implementation may wait additionally
@@ -704,9 +704,9 @@
 (typename $riflags
   (flags u16
     ;;; Returns the message without removing it from the socket's receive queue.
-    $sock_recv_peek
+    $recv_peek
     ;;; On byte-stream sockets, block until the full amount of data can be returned.
-    $sock_recv_waitall
+    $recv_waitall
   )
 )
 
@@ -714,7 +714,7 @@
 (typename $roflags
   (flags u16
     ;;; Returned by `sock_recv`: Message data has been truncated.
-    $sock_recv_data_truncated
+    $recv_data_truncated
   )
 )
 
@@ -726,9 +726,9 @@
 (typename $sdflags
   (flags u8
     ;;; Disables further receive operations.
-    $shut_rd
+    $rd
     ;;; Disables further send operations.
-    $shut_wr
+    $wr
   )
 )
 
@@ -736,7 +736,7 @@
 (typename $preopentype
   (enum u8
     ;;; A pre-opened directory.
-    $preopentype_dir
+    $dir
   )
 )
 

--- a/phases/snapshot/witx/typenames.witx
+++ b/phases/snapshot/witx/typenames.witx
@@ -18,16 +18,16 @@
   (enum u32
     ;;; The clock measuring real time. Time value zero corresponds with
     ;;; 1970-01-01T00:00:00Z.
-    $CLOCK_REALTIME
+    $clock_realtime
     ;;; The store-wide monotonic clock, which is defined as a clock measuring
     ;;; real time, whose value cannot be adjusted and which cannot have negative
     ;;; clock jumps. The epoch of this clock is undefined. The absolute time
     ;;; value of this clock therefore has no meaning.
-    $CLOCK_MONOTONIC
+    $clock_monotonic
     ;;; The CPU-time clock associated with the current process.
-    $CLOCK_PROCESS_CPUTIME_ID
+    $clock_process_cputime_id
     ;;; The CPU-time clock associated with the current thread.
-    $CLOCK_THREAD_CPUTIME_ID
+    $clock_thread_cputime_id
   )
 )
 
@@ -38,159 +38,159 @@
 (typename $errno
   (enum u16
     ;;; No error occurred. System call completed successfully.
-    $ESUCCESS
+    $esuccess
     ;;; Argument list too long.
-    $E2BIG
+    $e2big
     ;;; Permission denied.
-    $EACCES
+    $eacces
     ;;; Address in use.
-    $EADDRINUSE
+    $eaddrinuse
     ;;; Address not available.
-    $EADDRNOTAVAIL
+    $eaddrnotavail
     ;;; Address family not supported.
-    $EAFNOSUPPORT
+    $eafnosupport
     ;;; Resource unavailable, or operation would block.
-    $EAGAIN
+    $eagain
     ;;; Connection already in progress.
-    $EALREADY
+    $ealready
     ;;; Bad file descriptor.
-    $EBADF
+    $ebadf
     ;;; Bad message.
-    $EBADMSG
+    $ebadmsg
     ;;; Device or resource busy.
-    $EBUSY
+    $ebusy
     ;;; Operation canceled.
-    $ECANCELED
+    $ecanceled
     ;;; No child processes.
-    $ECHILD
+    $echild
     ;;; Connection aborted.
-    $ECONNABORTED
+    $econnaborted
     ;;; Connection refused.
-    $ECONNREFUSED
+    $econnrefused
     ;;; Connection reset.
-    $ECONNRESET
+    $econnreset
     ;;; Resource deadlock would occur.
-    $EDEADLK
+    $edeadlk
     ;;; Destination address required.
-    $EDESTADDRREQ
+    $edestaddrreq
     ;;; Mathematics argument out of domain of function.
-    $EDOM
+    $edom
     ;;; Reserved.
-    $EDQUOT
+    $edquot
     ;;; File exists.
-    $EEXIST
+    $eexist
     ;;; Bad address.
-    $EFAULT
+    $efault
     ;;; File too large.
-    $EFBIG
+    $efbig
     ;;; Host is unreachable.
-    $EHOSTUNREACH
+    $ehostunreach
     ;;; Identifier removed.
-    $EIDRM
+    $eidrm
     ;;; Illegal byte sequence.
-    $EILSEQ
+    $eilseq
     ;;; Operation in progress.
-    $EINPROGRESS
+    $einprogress
     ;;; Interrupted function.
-    $EINTR
+    $eintr
     ;;; Invalid argument.
-    $EINVAL
+    $einval
     ;;; I/O error.
-    $EIO
+    $eio
     ;;; Socket is connected.
-    $EISCONN
+    $eisconn
     ;;; Is a directory.
-    $EISDIR
+    $eisdir
     ;;; Too many levels of symbolic links.
-    $ELOOP
+    $eloop
     ;;; File descriptor value too large.
-    $EMFILE
+    $emfile
     ;;; Too many links.
-    $EMLINK
+    $emlink
     ;;; Message too large.
-    $EMSGSIZE
+    $emsgsize
     ;;; Reserved.
-    $EMULTIHOP
+    $emultihop
     ;;; Filename too long.
-    $ENAMETOOLONG
+    $enametoolong
     ;;; Network is down.
-    $ENETDOWN
+    $enetdown
     ;;; Connection aborted by network.
-    $ENETRESET
+    $enetreset
     ;;; Network unreachable.
-    $ENETUNREACH
+    $enetunreach
     ;;; Too many files open in system.
-    $ENFILE
+    $enfile
     ;;; No buffer space available.
-    $ENOBUFS
+    $enobufs
     ;;; No such device.
-    $ENODEV
+    $enodev
     ;;; No such file or directory.
-    $ENOENT
+    $enoent
     ;;; Executable file format error.
-    $ENOEXEC
+    $enoexec
     ;;; No locks available.
-    $ENOLCK
+    $enolck
     ;;; Reserved.
-    $ENOLINK
+    $enolink
     ;;; Not enough space.
-    $ENOMEM
+    $enomem
     ;;; No message of the desired type.
-    $ENOMSG
+    $enomsg
     ;;; Protocol not available.
-    $ENOPROTOOPT
+    $enoprotoopt
     ;;; No space left on device.
-    $ENOSPC
+    $enospc
     ;;; Function not supported.
-    $ENOSYS
+    $enosys
     ;;; The socket is not connected.
-    $ENOTCONN
+    $enotconn
     ;;; Not a directory or a symbolic link to a directory.
-    $ENOTDIR
+    $enotdir
     ;;; Directory not empty.
-    $ENOTEMPTY
+    $enotempty
     ;;; State not recoverable.
-    $ENOTRECOVERABLE
+    $enotrecoverable
     ;;; Not a socket.
-    $ENOTSOCK
+    $enotsock
     ;;; Not supported, or operation not supported on socket.
-    $ENOTSUP
+    $enotsup
     ;;; Inappropriate I/O control operation.
-    $ENOTTY
+    $enotty
     ;;; No such device or address.
-    $ENXIO
+    $enxio
     ;;; Value too large to be stored in data type.
-    $EOVERFLOW
+    $eoverflow
     ;;; Previous owner died.
-    $EOWNERDEAD
+    $eownerdead
     ;;; Operation not permitted.
-    $EPERM
+    $eperm
     ;;; Broken pipe.
-    $EPIPE
+    $epipe
     ;;; Protocol error.
-    $EPROTO
+    $eproto
     ;;; Protocol not supported.
-    $EPROTONOSUPPORT
+    $eprotonosupport
     ;;; Protocol wrong type for socket.
-    $EPROTOTYPE
+    $eprototype
     ;;; Result too large.
-    $ERANGE
+    $erange
     ;;; Read-only file system.
-    $EROFS
+    $erofs
     ;;; Invalid seek.
-    $ESPIPE
+    $espipe
     ;;; No such process.
-    $ESRCH
+    $esrch
     ;;; Reserved.
-    $ESTALE
+    $estale
     ;;; Connection timed out.
-    $ETIMEDOUT
+    $etimedout
     ;;; Text file busy.
-    $ETXTBSY
+    $etxtbsy
     ;;; Cross-device link.
-    $EXDEV
+    $exdev
     ;;; Extension: Capabilities insufficient.
-    $ENOTCAPABLE
+    $enotcapable
   )
 )
 
@@ -201,75 +201,75 @@
     ;;
     ;;; If `RIGHT_PATH_OPEN` is set, includes the right to invoke
     ;;; `path_open` with `FDFLAG_DSYNC`.
-    $RIGHT_FD_DATASYNC
+    $right_fd_datasync
     ;;; The right to invoke `fd_read` and `sock_recv`.
     ;;
     ;;; If `RIGHT_FD_SEEK` is set, includes the right to invoke `fd_pread`.
-    $RIGHT_FD_READ
+    $right_fd_read
     ;;; The right to invoke `fd_seek`. This flag implies `RIGHT_FD_TELL`.
-    $RIGHT_FD_SEEK
+    $right_fd_seek
     ;;; The right to invoke `fd_fdstat_set_flags`.
-    $RIGHT_FD_FDSTAT_SET_FLAGS
+    $right_fd_fdstat_set_flags
     ;;; The right to invoke `fd_sync`.
     ;;
     ;;; If `RIGHT_PATH_OPEN` is set, includes the right to invoke
     ;;; `path_open` with `FDFLAG_RSYNC` and `FDFLAG_DSYNC`.
-    $RIGHT_FD_SYNC
+    $right_fd_sync
     ;;; The right to invoke `fd_seek` in such a way that the file offset
     ;;; remains unaltered (i.e., `WHENCE_CUR` with offset zero), or to
     ;;; invoke `fd_tell`.
-    $RIGHT_FD_TELL
+    $right_fd_tell
     ;;; The right to invoke `fd_write` and `sock_send`.
     ;;; If `RIGHT_FD_SEEK` is set, includes the right to invoke `fd_pwrite`.
-    $RIGHT_FD_WRITE
+    $right_fd_write
     ;;; The right to invoke `fd_advise`.
-    $RIGHT_FD_ADVISE
+    $right_fd_advise
     ;;; The right to invoke `fd_allocate`.
-    $RIGHT_FD_ALLOCATE
+    $right_fd_allocate
     ;;; The right to invoke `path_create_directory`.
-    $RIGHT_PATH_CREATE_DIRECTORY
+    $right_path_create_directory
     ;;; If `RIGHT_PATH_OPEN` is set, the right to invoke `path_open` with `O_CREAT`.
-    $RIGHT_PATH_CREATE_FILE
+    $right_path_create_file
     ;;; The right to invoke `path_link` with the file descriptor as the
     ;;; source directory.
-    $RIGHT_PATH_LINK_SOURCE
+    $right_path_link_source
     ;;; The right to invoke `path_link` with the file descriptor as the
     ;;; target directory.
-    $RIGHT_PATH_LINK_TARGET
+    $right_path_link_target
     ;;; The right to invoke `path_open`.
-    $RIGHT_PATH_OPEN
+    $right_path_open
     ;;; The right to invoke `fd_readdir`.
-    $RIGHT_FD_READDIR
+    $right_fd_readdir
     ;;; The right to invoke `path_readlink`.
-    $RIGHT_PATH_READLINK
+    $right_path_readlink
     ;;; The right to invoke `path_rename` with the file descriptor as the source directory.
-    $RIGHT_PATH_RENAME_SOURCE
+    $right_path_rename_source
     ;;; The right to invoke `path_rename` with the file descriptor as the target directory.
-    $RIGHT_PATH_RENAME_TARGET
+    $right_path_rename_target
     ;;; The right to invoke `path_filestat_get`.
-    $RIGHT_PATH_FILESTAT_GET
+    $right_path_filestat_get
     ;;; The right to change a file's size (there is no `path_filestat_set_size`).
     ;;; If `RIGHT_PATH_OPEN` is set, includes the right to invoke `path_open` with `O_TRUNC`.
-    $RIGHT_PATH_FILESTAT_SET_SIZE
+    $right_path_filestat_set_size
     ;;; The right to invoke `path_filestat_set_times`.
-    $RIGHT_PATH_FILESTAT_SET_TIMES
+    $right_path_filestat_set_times
     ;;; The right to invoke `fd_filestat_get`.
-    $RIGHT_FD_FILESTAT_GET
+    $right_fd_filestat_get
     ;;; The right to invoke `fd_filestat_set_size`.
-    $RIGHT_FD_FILESTAT_SET_SIZE
+    $right_fd_filestat_set_size
     ;;; The right to invoke `fd_filestat_set_times`.
-    $RIGHT_FD_FILESTAT_SET_TIMES
+    $right_fd_filestat_set_times
     ;;; The right to invoke `path_symlink`.
-    $RIGHT_PATH_SYMLINK
+    $right_path_symlink
     ;;; The right to invoke `path_remove_directory`.
-    $RIGHT_PATH_REMOVE_DIRECTORY
+    $right_path_remove_directory
     ;;; The right to invoke `path_unlink_file`.
-    $RIGHT_PATH_UNLINK_FILE
+    $right_path_unlink_file
     ;;; If `RIGHT_FD_READ` is set, includes the right to invoke `poll_oneoff` to subscribe to `EVENTTYPE_FD_READ`.
     ;;; If `RIGHT_FD_WRITE` is set, includes the right to invoke `poll_oneoff` to subscribe to `EVENTTYPE_FD_WRITE`.
-    $RIGHT_POLL_FD_READWRITE
+    $right_poll_fd_readwrite
     ;;; The right to invoke `sock_shutdown`.
-    $RIGHT_SOCK_SHUTDOWN
+    $right_sock_shutdown
   )
 )
 
@@ -306,11 +306,11 @@
 (typename $whence
   (enum u8
     ;;; Seek relative to start-of-file.
-    $WHENCE_SET
+    $whence_set
     ;;; Seek relative to current position.
-    $WHENCE_CUR
+    $whence_cur
     ;;; Seek relative to end-of-file.
-    $WHENCE_END
+    $whence_end
   )
 )
 
@@ -329,21 +329,21 @@
 (typename $filetype
   (enum u8
     ;;; The type of the file descriptor or file is unknown or is different from any of the other types specified.
-    $FILETYPE_UNKNOWN
+    $filetype_unknown
     ;;; The file descriptor or file refers to a block device inode.
-    $FILETYPE_BLOCK_DEVICE
+    $filetype_block_device
     ;;; The file descriptor or file refers to a character device inode.
-    $FILETYPE_CHARACTER_DEVICE
+    $filetype_character_device
     ;;; The file descriptor or file refers to a directory inode.
-    $FILETYPE_DIRECTORY
+    $filetype_directory
     ;;; The file descriptor or file refers to a regular file inode.
-    $FILETYPE_REGULAR_FILE
+    $filetype_regular_file
     ;;; The file descriptor or file refers to a datagram socket.
-    $FILETYPE_SOCKET_DGRAM
+    $filetype_socket_dgram
     ;;; The file descriptor or file refers to a byte-stream socket.
-    $FILETYPE_SOCKET_STREAM
+    $filetype_socket_stream
     ;;; The file refers to a symbolic link inode.
-    $FILETYPE_SYMBOLIC_LINK
+    $filetype_symbolic_link
   )
 )
 
@@ -365,17 +365,17 @@
 (typename $advice
   (enum u8
     ;;; The application has no advice to give on its behavior with respect to the specified data.
-    $ADVICE_NORMAL
+    $advice_normal
     ;;; The application expects to access the specified data sequentially from lower offsets to higher offsets.
-    $ADVICE_SEQUENTIAL
+    $advice_sequential
     ;;; The application expects to access the specified data in a random order.
-    $ADVICE_RANDOM
+    $advice_random
     ;;; The application expects to access the specified data in the near future.
-    $ADVICE_WILLNEED
+    $advice_willneed
     ;;; The application expects that it will not access the specified data in the near future.
-    $ADVICE_DONTNEED
+    $advice_dontneed
     ;;; The application expects to access the specified data once and then not reuse it thereafter.
-    $ADVICE_NOREUSE
+    $advice_noreuse
   )
 )
 
@@ -383,17 +383,17 @@
 (typename $fdflags
   (flags u16
     ;;; Append mode: Data written to the file is always appended to the file's end.
-    $FDFLAG_APPEND
+    $fdflag_append
     ;;; Write according to synchronized I/O data integrity completion. Only the data stored in the file is synchronized.
-    $FDFLAG_DSYNC
+    $fdflag_dsync
     ;;; Non-blocking mode.
-    $FDFLAG_NONBLOCK
+    $fdflag_nonblock
     ;;; Synchronized read I/O operations.
-    $FDFLAG_RSYNC
+    $fdflag_rsync
     ;;; Write according to synchronized I/O file integrity completion. In
     ;;; addition to synchronizing the data stored in the file, the implementation
     ;;; may also synchronously update the file's metadata.
-    $FDFLAG_SYNC
+    $fdflag_sync
   )
 )
 
@@ -420,13 +420,13 @@
 (typename $fstflags
   (flags u16
     ;;; Adjust the last data access timestamp to the value stored in `filestat_t::st_atim`.
-    $FILESTAT_SET_ATIM
+    $filestat_set_atim
     ;;; Adjust the last data access timestamp to the time of clock `CLOCK_REALTIME`.
-    $FILESTAT_SET_ATIM_NOW
+    $filestat_set_atim_now
     ;;; Adjust the last data modification timestamp to the value stored in `filestat_t::st_mtim`.
-    $FILESTAT_SET_MTIM
+    $filestat_set_mtim
     ;;; Adjust the last data modification timestamp to the time of clock `CLOCK_REALTIME`.
-    $FILESTAT_SET_MTIM_NOW
+    $filestat_set_mtim_now
   )
 )
 
@@ -434,7 +434,7 @@
 (typename $lookupflags
   (flags u32
     ;;; As long as the resolved path corresponds to a symbolic link, it is expanded.
-    $LOOKUP_SYMLINK_FOLLOW
+    $lookup_symlink_follow
   )
 )
 
@@ -442,13 +442,13 @@
 (typename $oflags
   (flags u16
     ;;; Create file if it does not exist.
-    $O_CREAT
+    $o_creat
     ;;; Fail if not a directory.
-    $O_DIRECTORY
+    $o_directory
     ;;; Fail if file already exists.
-    $O_EXCL
+    $o_excl
     ;;; Truncate file to size 0.
-    $O_TRUNC
+    $o_trunc
   )
 )
 
@@ -486,13 +486,13 @@
   (enum u8
     ;;; The time value of clock `subscription_t::u.clock.clock_id` has
     ;;; reached timestamp `subscription_t::u.clock.timeout`.
-    $EVENTTYPE_CLOCK
+    $eventtype_clock
     ;;; File descriptor `subscription_t::u.fd_readwrite.fd` has data
     ;;; available for reading. This event always triggers for regular files.
-    $EVENTTYPE_FD_READ
+    $eventtype_fd_read
     ;;; File descriptor `subscription_t::u.fd_readwrite.fd` has capacity
     ;;; available for writing. This event always triggers for regular files.
-    $EVENTTYPE_FD_WRITE
+    $eventtype_fd_write
   )
 )
 
@@ -501,7 +501,7 @@
 (typename $eventrwflags
   (flags u16
     ;;; The peer of this socket has closed or disconnected.
-    $EVENT_FD_READWRITE_HANGUP
+    $event_fd_readwrite_hangup
   )
 )
 
@@ -547,7 +547,7 @@
     ;;; `subscription_t::u.clock.clock_id.` If clear, treat the timestamp
     ;;; provided in `subscription_t::u.clock.timeout` relative to the
     ;;; current time value of clock `subscription_t::u.clock.clock_id.`
-    $SUBSCRIPTION_CLOCK_ABSTIME
+    $subscription_clock_abstime
   )
 )
 
@@ -606,97 +606,97 @@
   (enum u8
     ;;; No signal. Note that POSIX has special semantics for `kill(pid, 0)`,
     ;;; so this value is reserved.
-    $SIGNONE
+    $signone
     ;;; Hangup.
     ;;; Action: Terminates the process.
-    $SIGHUP
+    $sighup
     ;;; Terminate interrupt signal.
     ;;; Action: Terminates the process.
-    $SIGINT
+    $sigint
     ;;; Terminal quit signal.
     ;;; Action: Terminates the process.
-    $SIGQUIT
+    $sigquit
     ;;; Illegal instruction.
     ;;; Action: Terminates the process.
-    $SIGILL
+    $sigill
     ;;; Trace/breakpoint trap.
     ;;; Action: Terminates the process.
-    $SIGTRAP
+    $sigtrap
     ;;; Process abort signal.
     ;;; Action: Terminates the process.
-    $SIGABRT
+    $sigabrt
     ;;; Access to an undefined portion of a memory object.
     ;;; Action: Terminates the process.
-    $SIGBUS
+    $sigbus
     ;;; Erroneous arithmetic operation.
     ;;; Action: Terminates the process.
-    $SIGFPE
+    $sigfpe
     ;;; Kill.
     ;;; Action: Terminates the process.
-    $SIGKILL
+    $sigkill
     ;;; User-defined signal 1.
     ;;; Action: Terminates the process.
-    $SIGUSR1
+    $sigusr1
     ;;; Invalid memory reference.
     ;;; Action: Terminates the process.
-    $SIGSEGV
+    $sigsegv
     ;;; User-defined signal 2.
     ;;; Action: Terminates the process.
-    $SIGUSR2
+    $sigusr2
     ;;; Write on a pipe with no one to read it.
     ;;; Action: Ignored.
-    $SIGPIPE
+    $sigpipe
     ;;; Alarm clock.
     ;;; Action: Terminates the process.
-    $SIGALRM
+    $sigalrm
     ;;; Termination signal.
     ;;; Action: Terminates the process.
-    $SIGTERM
+    $sigterm
     ;;; Child process terminated, stopped, or continued.
     ;;; Action: Ignored.
-    $SIGCHLD
+    $sigchld
     ;;; Continue executing, if stopped.
     ;;; Action: Continues executing, if stopped.
-    $SIGCONT
+    $sigcont
     ;;; Stop executing.
     ;;; Action: Stops executing.
-    $SIGSTOP
+    $sigstop
     ;;; Terminal stop signal.
     ;;; Action: Stops executing.
-    $SIGTSTP
+    $sigtstp
     ;;; Background process attempting read.
     ;;; Action: Stops executing.
-    $SIGTTIN
+    $sigttin
     ;;; Background process attempting write.
     ;;; Action: Stops executing.
-    $SIGTTOU
+    $sigttou
     ;;; High bandwidth data is available at a socket.
     ;;; Action: Ignored.
-    $SIGURG
+    $sigurg
     ;;; CPU time limit exceeded.
     ;;; Action: Terminates the process.
-    $SIGXCPU
+    $sigxcpu
     ;;; File size limit exceeded.
     ;;; Action: Terminates the process.
-    $SIGXFSZ
+    $sigxfsz
     ;;; Virtual timer expired.
     ;;; Action: Terminates the process.
-    $SIGVTALRM
+    $sigvtalrm
     ;;; Profiling timer expired.
     ;;; Action: Terminates the process.
-    $SIGPROF
+    $sigprof
     ;;; Window changed.
     ;;; Action: Ignored.
-    $SIGWINCH
+    $sigwinch
     ;;; I/O possible.
     ;;; Action: Terminates the process.
-    $SIGPOLL
+    $sigpoll
     ;;; Power failure.
     ;;; Action: Terminates the process.
-    $SIGPWR
+    $sigpwr
     ;;; Bad system call.
     ;;; Action: Terminates the process.
-    $SIGSYS
+    $sigsys
   )
 )
 
@@ -704,9 +704,9 @@
 (typename $riflags
   (flags u16
     ;;; Returns the message without removing it from the socket's receive queue.
-    $SOCK_RECV_PEEK
+    $sock_recv_peek
     ;;; On byte-stream sockets, block until the full amount of data can be returned.
-    $SOCK_RECV_WAITALL
+    $sock_recv_waitall
   )
 )
 
@@ -714,7 +714,7 @@
 (typename $roflags
   (flags u16
     ;;; Returned by `sock_recv`: Message data has been truncated.
-    $SOCK_RECV_DATA_TRUNCATED
+    $sock_recv_data_truncated
   )
 )
 
@@ -726,9 +726,9 @@
 (typename $sdflags
   (flags u8
     ;;; Disables further receive operations.
-    $SHUT_RD
+    $shut_rd
     ;;; Disables further send operations.
-    $SHUT_WR
+    $shut_wr
   )
 )
 
@@ -736,7 +736,7 @@
 (typename $preopentype
   (enum u8
     ;;; A pre-opened directory.
-    $PREOPENTYPE_DIR
+    $preopentype_dir
   )
 )
 

--- a/phases/snapshot/witx/typenames.witx
+++ b/phases/snapshot/witx/typenames.witx
@@ -5,16 +5,16 @@
 ;; This is a `witx` file. See [here](https://github.com/WebAssembly/WASI/tree/master/docs/witx.md)
 ;; for an explanation of what that means.
 
-(typename $size_t u32)
+(typename $size u32)
 
 ;;; Non-negative file size or length of a region within a file.
-(typename $filesize_t u64)
+(typename $filesize u64)
 
 ;;; Timestamp in nanoseconds.
-(typename $timestamp_t u64)
+(typename $timestamp u64)
 
 ;;; Identifiers for clocks.
-(typename $clockid_t
+(typename $clockid
   (enum u32
     ;;; The clock measuring real time. Time value zero corresponds with
     ;;; 1970-01-01T00:00:00Z.
@@ -35,7 +35,7 @@
 ;;; Not all of these error codes are returned by the functions provided by this
 ;;; API; some are used in higher-level library layers, and others are provided
 ;;; merely for alignment with POSIX.
-(typename $errno_t
+(typename $errno
   (enum u16
     ;;; No error occurred. System call completed successfully.
     $ESUCCESS
@@ -195,7 +195,7 @@
 )
 
 ;;; File descriptor rights, determining which actions may be performed.
-(typename $rights_t
+(typename $rights
   (flags u64
     ;;; The right to invoke `fd_datasync`.
     ;;
@@ -274,36 +274,36 @@
 )
 
 ;;; A file descriptor index.
-(typename $fd_t u32)
+(typename $fd u32)
 
 ;;; A region of memory for scatter/gather reads.
-(typename $iovec_t
+(typename $iovec
   (struct
     ;;; The address of the buffer to be filled.
     (field $buf (@witx pointer u8))
     ;;; The length of the buffer to be filled.
-    (field $buf_len $size_t)
+    (field $buf_len $size)
   )
 )
 
 ;;; A region of memory for scatter/gather writes.
-(typename $ciovec_t
+(typename $ciovec
   (struct
     ;;; The address of the buffer to be written.
     (field $buf (@witx const_pointer u8))
     ;;; The length of the buffer to be written.
-    (field $buf_len $size_t)
+    (field $buf_len $size)
   )
 )
 
-(typename $iovec_t_array (array $iovec_t))
-(typename $ciovec_t_array (array $ciovec_t))
+(typename $iovec_array (array $iovec))
+(typename $ciovec_array (array $ciovec))
 
 ;;; Relative offset within a file.
-(typename $filedelta_t s64)
+(typename $filedelta s64)
 
 ;;; The position relative to which to set the offset of the file descriptor.
-(typename $whence_t
+(typename $whence
   (enum u8
     ;;; Seek relative to start-of-file.
     $WHENCE_SET
@@ -317,16 +317,16 @@
 ;;; A reference to the offset of a directory entry.
 ;;;
 ;;; The value 0 signifies the start of the directory.
-(typename $dircookie_t u64)
+(typename $dircookie u64)
 
-;;; The type for the $d_namlen field of $dirent_t.
-(typename $dirnamlen_t u32)
+;;; The type for the $d_namlen field of $dirent.
+(typename $dirnamlen u32)
 
 ;;; File serial number that is unique within its file system.
-(typename $inode_t u64)
+(typename $inode u64)
 
 ;;; The type of a file descriptor or file.
-(typename $filetype_t
+(typename $filetype
   (enum u8
     ;;; The type of the file descriptor or file is unknown or is different from any of the other types specified.
     $FILETYPE_UNKNOWN
@@ -348,21 +348,21 @@
 )
 
 ;;; A directory entry.
-(typename $dirent_t
+(typename $dirent
   (struct
     ;;; The offset of the next directory entry stored in this directory.
-    (field $d_next $dircookie_t)
+    (field $d_next $dircookie)
     ;;; The serial number of the file referred to by this directory entry.
-    (field $d_ino $inode_t)
+    (field $d_ino $inode)
     ;;; The length of the name of the directory entry.
-    (field $d_namlen $dirnamlen_t)
+    (field $d_namlen $dirnamlen)
     ;;; The type of the file referred to by this directory entry.
-    (field $d_type $filetype_t)
+    (field $dype $filetype)
   )
 )
 
 ;;; File or memory access pattern advisory information.
-(typename $advice_t
+(typename $advice
   (enum u8
     ;;; The application has no advice to give on its behavior with respect to the specified data.
     $ADVICE_NORMAL
@@ -380,7 +380,7 @@
 )
 
 ;;; File descriptor flags.
-(typename $fdflags_t
+(typename $fdflags
   (flags u16
     ;;; Append mode: Data written to the file is always appended to the file's end.
     $FDFLAG_APPEND
@@ -398,26 +398,26 @@
 )
 
 ;;; File descriptor attributes.
-(typename $fdstat_t
+(typename $fdstat
   (struct
     ;;; File type.
-    (field $fs_filetype $filetype_t)
+    (field $fs_filetype $filetype)
     ;;; File descriptor flags.
-    (field $fs_flags $fdflags_t)
+    (field $fs_flags $fdflags)
     ;;; Rights that apply to this file descriptor.
-    (field $fs_rights_base $rights_t)
+    (field $fs_rights_base $rights)
     ;;; Maximum set of rights that may be installed on new file descriptors that
     ;;; are created through this file descriptor, e.g., through `path_open`.
-    (field $fs_rights_inheriting $rights_t)
+    (field $fs_rights_inheriting $rights)
   )
 )
 
 ;;; Identifier for a device containing a file system. Can be used in combination
 ;;; with `inode_t` to uniquely identify a file or directory in the filesystem.
-(typename $device_t u64)
+(typename $device u64)
 
 ;;; Which file time attributes to adjust.
-(typename $fstflags_t
+(typename $fstflags
   (flags u16
     ;;; Adjust the last data access timestamp to the value stored in `filestat_t::st_atim`.
     $FILESTAT_SET_ATIM
@@ -431,7 +431,7 @@
 )
 
 ;;; Flags determining the method of how paths are resolved.
-(typename $lookupflags_t
+(typename $lookupflags
   (flags u32
     ;;; As long as the resolved path corresponds to a symbolic link, it is expanded.
     $LOOKUP_SYMLINK_FOLLOW
@@ -439,7 +439,7 @@
 )
 
 ;;; Open flags used by `path_open`.
-(typename $oflags_t
+(typename $oflags
   (flags u16
     ;;; Create file if it does not exist.
     $O_CREAT
@@ -453,36 +453,36 @@
 )
 
 ;;; Number of hard links to an inode.
-(typename $linkcount_t u64)
+(typename $linkcount u64)
 
 ;;; File attributes.
-(typename $filestat_t
+(typename $filestat
   (struct
     ;;; Device ID of device containing the file.
-    (field $st_dev $device_t)
+    (field $st_dev $device)
     ;;; File serial number.
-    (field $st_ino $inode_t)
+    (field $st_ino $inode)
     ;;; File type.
-    (field $st_filetype $filetype_t)
+    (field $st_filetype $filetype)
     ;;; Number of hard links to the file.
-    (field $st_nlink $linkcount_t)
+    (field $st_nlink $linkcount)
     ;;; For regular files, the file size in bytes. For symbolic links, the length in bytes of the pathname contained in the symbolic link.
-    (field $st_size $filesize_t)
+    (field $st_size $filesize)
     ;;; Last data access timestamp.
-    (field $st_atim $timestamp_t)
+    (field $st_atim $timestamp)
     ;;; Last data modification timestamp.
-    (field $st_mtim $timestamp_t)
+    (field $st_mtim $timestamp)
     ;;; Last file status change timestamp.
-    (field $st_ctim $timestamp_t)
+    (field $st_ctim $timestamp)
   )
 )
 
 ;;; User-provided value that may be attached to objects that is retained when
 ;;; extracted from the implementation.
-(typename $userdata_t u64)
+(typename $userdata u64)
 
 ;;; Type of a subscription to an event or its occurrence.
-(typename $eventtype_t
+(typename $eventtype
   (enum u8
     ;;; The time value of clock `subscription_t::u.clock.clock_id` has
     ;;; reached timestamp `subscription_t::u.clock.timeout`.
@@ -498,41 +498,41 @@
 
 ;;; The state of the file descriptor subscribed to with
 ;;; `EVENTTYPE_FD_READ` or `EVENTTYPE_FD_WRITE`.
-(typename $eventrwflags_t
+(typename $eventrwflags
   (flags u16
     ;;; The peer of this socket has closed or disconnected.
     $EVENT_FD_READWRITE_HANGUP
   )
 )
 
-;;; The contents of an $event_t when type is `EVENTTYPE_FD_READ` or
+;;; The contents of an $event when type is `EVENTTYPE_FD_READ` or
 ;;; `EVENTTYPE_FD_WRITE`.
-(typename $event_fd_readwrite_t
+(typename $event_fd_readwrite
   (struct
     ;;; The number of bytes available for reading or writing.
-    (field $nbytes $filesize_t)
+    (field $nbytes $filesize)
     ;;; The state of the file descriptor.
-    (field $flags $eventrwflags_t)
+    (field $flags $eventrwflags)
   )
 )
 
-;;; The contents of an $event_t.
+;;; The contents of an $event.
 (typename $event_u
   (union
     ;;; When type is `EVENTTYPE_FD_READ` or `EVENTTYPE_FD_WRITE`:
-    (field $fd_readwrite $event_fd_readwrite_t)
+    (field $fd_readwrite $event_fd_readwrite)
   )
 )
 
 ;;; An event that occurred.
-(typename $event_t
+(typename $event
   (struct
     ;;; User-provided value that got attached to `subscription_t::userdata`.
-    (field $userdata $userdata_t)
+    (field $userdata $userdata)
     ;;; If non-zero, an error that occurred while processing the subscription request.
-    (field $error $errno_t)
+    (field $error $errno)
     ;;; The type of the event that occurred.
-    (field $type $eventtype_t)
+    (field $type $eventtype)
     ;;; The contents of the event.
     (field $u $event_u)
   )
@@ -540,7 +540,7 @@
 
 ;;; Flags determining how to interpret the timestamp provided in
 ;;; `subscription_t::u.clock.timeout.`
-(typename $subclockflags_t
+(typename $subclockflags
   (flags u16
     ;;; If set, treat the timestamp provided in
     ;;; `subscription_t::u.clock.timeout` as an absolute timestamp of clock
@@ -551,58 +551,58 @@
   )
 )
 
-;;; The contents of a $subscription_t when type is `EVENTTYPE_CLOCK`.
-(typename $subscription_clock_t
+;;; The contents of a $subscription when type is `EVENTTYPE_CLOCK`.
+(typename $subscription_clock
   (struct
     ;;; The clock against which to compare the timestamp.
-    (field $clock_id $clockid_t)
+    (field $clock_id $clockid)
     ;;; The absolute or relative timestamp.
-    (field $timeout $timestamp_t)
+    (field $timeout $timestamp)
     ;;; The amount of time that the implementation may wait additionally
     ;;; to coalesce with other events.
-    (field $precision $timestamp_t)
+    (field $precision $timestamp)
     ;;; Flags specifying whether the timeout is absolute or relative
-    (field $flags $subclockflags_t)
+    (field $flags $subclockflags)
   )
 )
 
-;;; The contents of a $subscription_t when type is type is
+;;; The contents of a $subscription when type is type is
 ;;; `EVENTTYPE_FD_READ` or `EVENTTYPE_FD_WRITE`.
-(typename $subscription_fd_readwrite_t
+(typename $subscription_fd_readwrite
   (struct
     ;;; The file descriptor on which to wait for it to become ready for reading or writing.
-    (field $file_descriptor $fd_t)
+    (field $file_descriptor $fd)
   )
 )
 
-;;; The contents of a $subscription_t.
+;;; The contents of a $subscription.
 (typename $subscription_u
   (union
     ;;; When type is `EVENTTYPE_CLOCK`:
-    (field $clock $subscription_clock_t)
+    (field $clock $subscription_clock)
     ;;; When type is `EVENTTYPE_FD_READ` or `EVENTTYPE_FD_WRITE`:
-    (field $fd_readwrite $subscription_fd_readwrite_t)
+    (field $fd_readwrite $subscription_fd_readwrite)
   )
 )
 
 ;;; Subscription to an event.
-(typename $subscription_t
+(typename $subscription
   (struct
     ;;; User-provided value that is attached to the subscription in the
     ;;; implementation and returned through `event_t::userdata`.
-    (field $userdata $userdata_t)
+    (field $userdata $userdata)
     ;;; The type of the event to which to subscribe.
-    (field $type $eventtype_t)
+    (field $type $eventtype)
     ;;; The contents of the subscription.
     (field $u $subscription_u)
   )
 )
 
 ;;; Exit code generated by a process when exiting.
-(typename $exitcode_t u32)
+(typename $exitcode u32)
 
 ;;; Signal condition.
-(typename $signal_t
+(typename $signal
   (enum u8
     ;;; No signal. Note that POSIX has special semantics for `kill(pid, 0)`,
     ;;; so this value is reserved.
@@ -701,7 +701,7 @@
 )
 
 ;;; Flags provided to `sock_recv`.
-(typename $riflags_t
+(typename $riflags
   (flags u16
     ;;; Returns the message without removing it from the socket's receive queue.
     $SOCK_RECV_PEEK
@@ -711,7 +711,7 @@
 )
 
 ;;; Flags returned by `sock_recv`.
-(typename $roflags_t
+(typename $roflags
   (flags u16
     ;;; Returned by `sock_recv`: Message data has been truncated.
     $SOCK_RECV_DATA_TRUNCATED
@@ -720,10 +720,10 @@
 
 ;;; Flags provided to `sock_send`. As there are currently no flags
 ;;; defined, it must be set to zero.
-(typename $siflags_t u16)
+(typename $siflags u16)
 
 ;;; Which channels on a socket to shut down.
-(typename $sdflags_t
+(typename $sdflags
   (flags u8
     ;;; Disables further receive operations.
     $SHUT_RD
@@ -733,22 +733,22 @@
 )
 
 ;;; Identifiers for preopened capabilities.
-(typename $preopentype_t
+(typename $preopentype
   (enum u8
     ;;; A pre-opened directory.
     $PREOPENTYPE_DIR
   )
 )
 
-;;; The contents of a $prestat_t when type is `PREOPENTYPE_DIR`.
+;;; The contents of a $prestat when type is `PREOPENTYPE_DIR`.
 (typename $prestat_dir
   (struct
     ;;; The length of the directory name for use with `fd_prestat_dir_name`.
-    (field $pr_name_len $size_t)
+    (field $pr_name_len $size)
   )
 )
 
-;;; The contents of an $prestat_t.
+;;; The contents of an $prestat.
 (typename $prestat_u
   (union
     ;;; When type is `PREOPENTYPE_DIR`:
@@ -757,10 +757,10 @@
 )
 
 ;;; Information about a pre-opened capability.
-(typename $prestat_t
+(typename $prestat
   (struct
     ;;; The type of the pre-opened capability.
-    (field $pr_type $preopentype_t)
+    (field $prype $preopentype)
     ;;; The contents of the information.
     (field $u $prestat_u)
   )

--- a/phases/snapshot/witx/typenames.witx
+++ b/phases/snapshot/witx/typenames.witx
@@ -357,7 +357,7 @@
     ;;; The length of the name of the directory entry.
     (field $d_namlen $dirnamlen)
     ;;; The type of the file referred to by this directory entry.
-    (field $dype $filetype)
+    (field $d_type $filetype)
   )
 )
 
@@ -760,7 +760,7 @@
 (typename $prestat
   (struct
     ;;; The type of the pre-opened capability.
-    (field $prype $preopentype)
+    (field $pr_type $preopentype)
     ;;; The contents of the information.
     (field $u $prestat_u)
   )

--- a/phases/snapshot/witx/typenames.witx
+++ b/phases/snapshot/witx/typenames.witx
@@ -501,7 +501,7 @@
 (typename $eventrwflags
   (flags u16
     ;;; The peer of this socket has closed or disconnected.
-    $event_fd_readwrite_hangup
+    $fd_readwrite_hangup
   )
 )
 

--- a/phases/snapshot/witx/typenames.witx
+++ b/phases/snapshot/witx/typenames.witx
@@ -38,159 +38,159 @@
 (typename $errno
   (enum u16
     ;;; No error occurred. System call completed successfully.
-    $esuccess
+    $success
     ;;; Argument list too long.
-    $e2big
+    $2big
     ;;; Permission denied.
-    $eacces
+    $acces
     ;;; Address in use.
-    $eaddrinuse
+    $addrinuse
     ;;; Address not available.
-    $eaddrnotavail
+    $addrnotavail
     ;;; Address family not supported.
-    $eafnosupport
+    $afnosupport
     ;;; Resource unavailable, or operation would block.
-    $eagain
+    $again
     ;;; Connection already in progress.
-    $ealready
+    $already
     ;;; Bad file descriptor.
-    $ebadf
+    $badf
     ;;; Bad message.
-    $ebadmsg
+    $badmsg
     ;;; Device or resource busy.
-    $ebusy
+    $busy
     ;;; Operation canceled.
-    $ecanceled
+    $canceled
     ;;; No child processes.
-    $echild
+    $child
     ;;; Connection aborted.
-    $econnaborted
+    $connaborted
     ;;; Connection refused.
-    $econnrefused
+    $connrefused
     ;;; Connection reset.
-    $econnreset
+    $connreset
     ;;; Resource deadlock would occur.
-    $edeadlk
+    $deadlk
     ;;; Destination address required.
-    $edestaddrreq
+    $destaddrreq
     ;;; Mathematics argument out of domain of function.
-    $edom
+    $dom
     ;;; Reserved.
-    $edquot
+    $dquot
     ;;; File exists.
-    $eexist
+    $exist
     ;;; Bad address.
-    $efault
+    $fault
     ;;; File too large.
-    $efbig
+    $fbig
     ;;; Host is unreachable.
-    $ehostunreach
+    $hostunreach
     ;;; Identifier removed.
-    $eidrm
+    $idrm
     ;;; Illegal byte sequence.
-    $eilseq
+    $ilseq
     ;;; Operation in progress.
-    $einprogress
+    $inprogress
     ;;; Interrupted function.
-    $eintr
+    $intr
     ;;; Invalid argument.
-    $einval
+    $inval
     ;;; I/O error.
-    $eio
+    $io
     ;;; Socket is connected.
-    $eisconn
+    $isconn
     ;;; Is a directory.
-    $eisdir
+    $isdir
     ;;; Too many levels of symbolic links.
-    $eloop
+    $loop
     ;;; File descriptor value too large.
-    $emfile
+    $mfile
     ;;; Too many links.
-    $emlink
+    $mlink
     ;;; Message too large.
-    $emsgsize
+    $msgsize
     ;;; Reserved.
-    $emultihop
+    $multihop
     ;;; Filename too long.
-    $enametoolong
+    $nametoolong
     ;;; Network is down.
-    $enetdown
+    $netdown
     ;;; Connection aborted by network.
-    $enetreset
+    $netreset
     ;;; Network unreachable.
-    $enetunreach
+    $netunreach
     ;;; Too many files open in system.
-    $enfile
+    $nfile
     ;;; No buffer space available.
-    $enobufs
+    $nobufs
     ;;; No such device.
-    $enodev
+    $nodev
     ;;; No such file or directory.
-    $enoent
+    $noent
     ;;; Executable file format error.
-    $enoexec
+    $noexec
     ;;; No locks available.
-    $enolck
+    $nolck
     ;;; Reserved.
-    $enolink
+    $nolink
     ;;; Not enough space.
-    $enomem
+    $nomem
     ;;; No message of the desired type.
-    $enomsg
+    $nomsg
     ;;; Protocol not available.
-    $enoprotoopt
+    $noprotoopt
     ;;; No space left on device.
-    $enospc
+    $nospc
     ;;; Function not supported.
-    $enosys
+    $nosys
     ;;; The socket is not connected.
-    $enotconn
+    $notconn
     ;;; Not a directory or a symbolic link to a directory.
-    $enotdir
+    $notdir
     ;;; Directory not empty.
-    $enotempty
+    $notempty
     ;;; State not recoverable.
-    $enotrecoverable
+    $notrecoverable
     ;;; Not a socket.
-    $enotsock
+    $notsock
     ;;; Not supported, or operation not supported on socket.
-    $enotsup
+    $notsup
     ;;; Inappropriate I/O control operation.
-    $enotty
+    $notty
     ;;; No such device or address.
-    $enxio
+    $nxio
     ;;; Value too large to be stored in data type.
-    $eoverflow
+    $overflow
     ;;; Previous owner died.
-    $eownerdead
+    $ownerdead
     ;;; Operation not permitted.
-    $eperm
+    $perm
     ;;; Broken pipe.
-    $epipe
+    $pipe
     ;;; Protocol error.
-    $eproto
+    $proto
     ;;; Protocol not supported.
-    $eprotonosupport
+    $protonosupport
     ;;; Protocol wrong type for socket.
-    $eprototype
+    $prototype
     ;;; Result too large.
-    $erange
+    $range
     ;;; Read-only file system.
-    $erofs
+    $rofs
     ;;; Invalid seek.
-    $espipe
+    $spipe
     ;;; No such process.
-    $esrch
+    $srch
     ;;; Reserved.
-    $estale
+    $stale
     ;;; Connection timed out.
-    $etimedout
+    $timedout
     ;;; Text file busy.
-    $etxtbsy
+    $txtbsy
     ;;; Cross-device link.
-    $exdev
+    $xdev
     ;;; Extension: Capabilities insufficient.
-    $enotcapable
+    $notcapable
   )
 )
 

--- a/phases/snapshot/witx/typenames.witx
+++ b/phases/snapshot/witx/typenames.witx
@@ -486,13 +486,13 @@
   (enum u8
     ;;; The time value of clock `subscription_t::u.clock.clock_id` has
     ;;; reached timestamp `subscription_t::u.clock.timeout`.
-    $eventtype_clock
+    $clock
     ;;; File descriptor `subscription_t::u.fd_readwrite.fd` has data
     ;;; available for reading. This event always triggers for regular files.
-    $eventtype_fd_read
+    $fd_read
     ;;; File descriptor `subscription_t::u.fd_readwrite.fd` has capacity
     ;;; available for writing. This event always triggers for regular files.
-    $eventtype_fd_write
+    $fd_write
   )
 )
 

--- a/phases/snapshot/witx/typenames.witx
+++ b/phases/snapshot/witx/typenames.witx
@@ -199,28 +199,28 @@
   (flags u64
     ;;; The right to invoke `fd_datasync`.
     ;;
-    ;;; If `RIGHT_PATH_OPEN` is set, includes the right to invoke
-    ;;; `path_open` with `FDFLAG_DSYNC`.
+    ;;; If `path_open` is set, includes the right to invoke
+    ;;; `path_open` with `fdflag::dsync`.
     $fd_datasync
     ;;; The right to invoke `fd_read` and `sock_recv`.
     ;;
-    ;;; If `RIGHT_FD_SEEK` is set, includes the right to invoke `fd_pread`.
+    ;;; If `rights::fd_seek` is set, includes the right to invoke `fd_pread`.
     $fd_read
-    ;;; The right to invoke `fd_seek`. This flag implies `RIGHT_FD_TELL`.
+    ;;; The right to invoke `fd_seek`. This flag implies `rights::fd_tell`.
     $fd_seek
     ;;; The right to invoke `fd_fdstat_set_flags`.
     $fd_fdstat_set_flags
     ;;; The right to invoke `fd_sync`.
     ;;
-    ;;; If `RIGHT_PATH_OPEN` is set, includes the right to invoke
-    ;;; `path_open` with `FDFLAG_RSYNC` and `FDFLAG_DSYNC`.
+    ;;; If `path_open` is set, includes the right to invoke
+    ;;; `path_open` with `fdflag::rsync` and `fdflag::dsync`.
     $fd_sync
     ;;; The right to invoke `fd_seek` in such a way that the file offset
     ;;; remains unaltered (i.e., `WHENCE_CUR` with offset zero), or to
     ;;; invoke `fd_tell`.
     $fd_tell
     ;;; The right to invoke `fd_write` and `sock_send`.
-    ;;; If `RIGHT_FD_SEEK` is set, includes the right to invoke `fd_pwrite`.
+    ;;; If `rights::fd_seek` is set, includes the right to invoke `fd_pwrite`.
     $fd_write
     ;;; The right to invoke `fd_advise`.
     $fd_advise
@@ -228,7 +228,7 @@
     $fd_allocate
     ;;; The right to invoke `path_create_directory`.
     $path_create_directory
-    ;;; If `RIGHT_PATH_OPEN` is set, the right to invoke `path_open` with `O_CREAT`.
+    ;;; If `path_open` is set, the right to invoke `path_open` with `oflags::creat`.
     $path_create_file
     ;;; The right to invoke `path_link` with the file descriptor as the
     ;;; source directory.
@@ -249,7 +249,7 @@
     ;;; The right to invoke `path_filestat_get`.
     $path_filestat_get
     ;;; The right to change a file's size (there is no `path_filestat_set_size`).
-    ;;; If `RIGHT_PATH_OPEN` is set, includes the right to invoke `path_open` with `O_TRUNC`.
+    ;;; If `path_open` is set, includes the right to invoke `path_open` with `oflags::trunc`.
     $path_filestat_set_size
     ;;; The right to invoke `path_filestat_set_times`.
     $path_filestat_set_times
@@ -265,8 +265,8 @@
     $path_remove_directory
     ;;; The right to invoke `path_unlink_file`.
     $path_unlink_file
-    ;;; If `RIGHT_FD_READ` is set, includes the right to invoke `poll_oneoff` to subscribe to `EVENTTYPE_FD_READ`.
-    ;;; If `RIGHT_FD_WRITE` is set, includes the right to invoke `poll_oneoff` to subscribe to `EVENTTYPE_FD_WRITE`.
+    ;;; If `rights::fd_read` is set, includes the right to invoke `poll_oneoff` to subscribe to `eventtype::fd_read`.
+    ;;; If `rights::fd_write` is set, includes the right to invoke `poll_oneoff` to subscribe to `eventtype::fd_write`.
     $poll_fd_readwrite
     ;;; The right to invoke `sock_shutdown`.
     $sock_shutdown
@@ -413,19 +413,19 @@
 )
 
 ;;; Identifier for a device containing a file system. Can be used in combination
-;;; with `inode_t` to uniquely identify a file or directory in the filesystem.
+;;; with `inode` to uniquely identify a file or directory in the filesystem.
 (typename $device u64)
 
 ;;; Which file time attributes to adjust.
 (typename $fstflags
   (flags u16
-    ;;; Adjust the last data access timestamp to the value stored in `filestat_t::st_atim`.
+    ;;; Adjust the last data access timestamp to the value stored in `filestat::st_atim`.
     $atim
-    ;;; Adjust the last data access timestamp to the time of clock `CLOCK_REALTIME`.
+    ;;; Adjust the last data access timestamp to the time of clock `clock::realtime`.
     $atim_now
-    ;;; Adjust the last data modification timestamp to the value stored in `filestat_t::st_mtim`.
+    ;;; Adjust the last data modification timestamp to the value stored in `filestat::st_mtim`.
     $mtim
-    ;;; Adjust the last data modification timestamp to the time of clock `CLOCK_REALTIME`.
+    ;;; Adjust the last data modification timestamp to the time of clock `clock::realtime`.
     $mtim_now
   )
 )
@@ -484,20 +484,20 @@
 ;;; Type of a subscription to an event or its occurrence.
 (typename $eventtype
   (enum u8
-    ;;; The time value of clock `subscription_t::u.clock.clock_id` has
-    ;;; reached timestamp `subscription_t::u.clock.timeout`.
+    ;;; The time value of clock `subscription::u.clock.clock_id` has
+    ;;; reached timestamp `subscription::u.clock.timeout`.
     $clock
-    ;;; File descriptor `subscription_t::u.fd_readwrite.fd` has data
+    ;;; File descriptor `subscription::u.fd_readwrite.fd` has data
     ;;; available for reading. This event always triggers for regular files.
     $fd_read
-    ;;; File descriptor `subscription_t::u.fd_readwrite.fd` has capacity
+    ;;; File descriptor `subscription::u.fd_readwrite.fd` has capacity
     ;;; available for writing. This event always triggers for regular files.
     $fd_write
   )
 )
 
 ;;; The state of the file descriptor subscribed to with
-;;; `EVENTTYPE_FD_READ` or `EVENTTYPE_FD_WRITE`.
+;;; `eventtype::fd_read` or `eventtype::fd_write`.
 (typename $eventrwflags
   (flags u16
     ;;; The peer of this socket has closed or disconnected.
@@ -505,8 +505,8 @@
   )
 )
 
-;;; The contents of an $event when type is `EVENTTYPE_FD_READ` or
-;;; `EVENTTYPE_FD_WRITE`.
+;;; The contents of an $event when type is `eventtype::fd_read` or
+;;; `eventtype::fd_write`.
 (typename $event_fd_readwrite
   (struct
     ;;; The number of bytes available for reading or writing.
@@ -519,7 +519,7 @@
 ;;; The contents of an $event.
 (typename $event_u
   (union
-    ;;; When type is `EVENTTYPE_FD_READ` or `EVENTTYPE_FD_WRITE`:
+    ;;; When type is `eventtype::fd_read` or `eventtype::fd_write`:
     (field $fd_readwrite $event_fd_readwrite)
   )
 )
@@ -527,7 +527,7 @@
 ;;; An event that occurred.
 (typename $event
   (struct
-    ;;; User-provided value that got attached to `subscription_t::userdata`.
+    ;;; User-provided value that got attached to `subscription::userdata`.
     (field $userdata $userdata)
     ;;; If non-zero, an error that occurred while processing the subscription request.
     (field $error $errno)
@@ -539,19 +539,19 @@
 )
 
 ;;; Flags determining how to interpret the timestamp provided in
-;;; `subscription_t::u.clock.timeout.`
+;;; `subscription::u.clock.timeout.`
 (typename $subclockflags
   (flags u16
     ;;; If set, treat the timestamp provided in
-    ;;; `subscription_t::u.clock.timeout` as an absolute timestamp of clock
-    ;;; `subscription_t::u.clock.clock_id.` If clear, treat the timestamp
-    ;;; provided in `subscription_t::u.clock.timeout` relative to the
-    ;;; current time value of clock `subscription_t::u.clock.clock_id.`
+    ;;; `subscription::u.clock.timeout` as an absolute timestamp of clock
+    ;;; `subscription::u.clock.clock_id.` If clear, treat the timestamp
+    ;;; provided in `subscription::u.clock.timeout` relative to the
+    ;;; current time value of clock `subscription::u.clock.clock_id.`
     $subscription_clock_abstime
   )
 )
 
-;;; The contents of a $subscription when type is `EVENTTYPE_CLOCK`.
+;;; The contents of a $subscription when type is `eventtype::clock`.
 (typename $subscription_clock
   (struct
     ;;; The clock against which to compare the timestamp.
@@ -567,7 +567,7 @@
 )
 
 ;;; The contents of a $subscription when type is type is
-;;; `EVENTTYPE_FD_READ` or `EVENTTYPE_FD_WRITE`.
+;;; `eventtype::fd_read` or `eventtype::fd_write`.
 (typename $subscription_fd_readwrite
   (struct
     ;;; The file descriptor on which to wait for it to become ready for reading or writing.
@@ -578,9 +578,9 @@
 ;;; The contents of a $subscription.
 (typename $subscription_u
   (union
-    ;;; When type is `EVENTTYPE_CLOCK`:
+    ;;; When type is `eventtype::clock`:
     (field $clock $subscription_clock)
-    ;;; When type is `EVENTTYPE_FD_READ` or `EVENTTYPE_FD_WRITE`:
+    ;;; When type is `eventtype::fd_read` or `eventtype::fd_write`:
     (field $fd_readwrite $subscription_fd_readwrite)
   )
 )
@@ -589,7 +589,7 @@
 (typename $subscription
   (struct
     ;;; User-provided value that is attached to the subscription in the
-    ;;; implementation and returned through `event_t::userdata`.
+    ;;; implementation and returned through `event::userdata`.
     (field $userdata $userdata)
     ;;; The type of the event to which to subscribe.
     (field $type $eventtype)
@@ -740,7 +740,7 @@
   )
 )
 
-;;; The contents of a $prestat when type is `PREOPENTYPE_DIR`.
+;;; The contents of a $prestat when type is `preopentype::dir`.
 (typename $prestat_dir
   (struct
     ;;; The length of the directory name for use with `fd_prestat_dir_name`.
@@ -751,7 +751,7 @@
 ;;; The contents of an $prestat.
 (typename $prestat_u
   (union
-    ;;; When type is `PREOPENTYPE_DIR`:
+    ;;; When type is `preopentype::dir`:
     (field $dir $prestat_dir)
   )
 )

--- a/phases/snapshot/witx/typenames.witx
+++ b/phases/snapshot/witx/typenames.witx
@@ -606,97 +606,97 @@
   (enum u8
     ;;; No signal. Note that POSIX has special semantics for `kill(pid, 0)`,
     ;;; so this value is reserved.
-    $signone
+    $none
     ;;; Hangup.
     ;;; Action: Terminates the process.
-    $sighup
+    $hup
     ;;; Terminate interrupt signal.
     ;;; Action: Terminates the process.
-    $sigint
+    $int
     ;;; Terminal quit signal.
     ;;; Action: Terminates the process.
-    $sigquit
+    $quit
     ;;; Illegal instruction.
     ;;; Action: Terminates the process.
-    $sigill
+    $ill
     ;;; Trace/breakpoint trap.
     ;;; Action: Terminates the process.
-    $sigtrap
+    $trap
     ;;; Process abort signal.
     ;;; Action: Terminates the process.
-    $sigabrt
+    $abrt
     ;;; Access to an undefined portion of a memory object.
     ;;; Action: Terminates the process.
-    $sigbus
+    $bus
     ;;; Erroneous arithmetic operation.
     ;;; Action: Terminates the process.
-    $sigfpe
+    $fpe
     ;;; Kill.
     ;;; Action: Terminates the process.
-    $sigkill
+    $kill
     ;;; User-defined signal 1.
     ;;; Action: Terminates the process.
-    $sigusr1
+    $usr1
     ;;; Invalid memory reference.
     ;;; Action: Terminates the process.
-    $sigsegv
+    $segv
     ;;; User-defined signal 2.
     ;;; Action: Terminates the process.
-    $sigusr2
+    $usr2
     ;;; Write on a pipe with no one to read it.
     ;;; Action: Ignored.
-    $sigpipe
+    $pipe
     ;;; Alarm clock.
     ;;; Action: Terminates the process.
-    $sigalrm
+    $alrm
     ;;; Termination signal.
     ;;; Action: Terminates the process.
-    $sigterm
+    $term
     ;;; Child process terminated, stopped, or continued.
     ;;; Action: Ignored.
-    $sigchld
+    $chld
     ;;; Continue executing, if stopped.
     ;;; Action: Continues executing, if stopped.
-    $sigcont
+    $cont
     ;;; Stop executing.
     ;;; Action: Stops executing.
-    $sigstop
+    $stop
     ;;; Terminal stop signal.
     ;;; Action: Stops executing.
-    $sigtstp
+    $tstp
     ;;; Background process attempting read.
     ;;; Action: Stops executing.
-    $sigttin
+    $ttin
     ;;; Background process attempting write.
     ;;; Action: Stops executing.
-    $sigttou
+    $ttou
     ;;; High bandwidth data is available at a socket.
     ;;; Action: Ignored.
-    $sigurg
+    $urg
     ;;; CPU time limit exceeded.
     ;;; Action: Terminates the process.
-    $sigxcpu
+    $xcpu
     ;;; File size limit exceeded.
     ;;; Action: Terminates the process.
-    $sigxfsz
+    $xfsz
     ;;; Virtual timer expired.
     ;;; Action: Terminates the process.
-    $sigvtalrm
+    $vtalrm
     ;;; Profiling timer expired.
     ;;; Action: Terminates the process.
-    $sigprof
+    $prof
     ;;; Window changed.
     ;;; Action: Ignored.
-    $sigwinch
+    $winch
     ;;; I/O possible.
     ;;; Action: Terminates the process.
-    $sigpoll
+    $poll
     ;;; Power failure.
     ;;; Action: Terminates the process.
-    $sigpwr
+    $pwr
     ;;; Bad system call.
     ;;; Action: Terminates the process.
-    $sigsys
+    $sys
   )
 )
 

--- a/phases/snapshot/witx/wasi_snapshot_preview1.witx
+++ b/phases/snapshot/witx/wasi_snapshot_preview1.witx
@@ -17,15 +17,15 @@
   (@interface func (export "args_get")
     (param $argv (@witx pointer (@witx pointer u8)))
     (param $argv_buf (@witx pointer u8))
-    (result $error $errno_t)
+    (result $error $errno)
   )
   ;;; Return command-line argument data sizes.
   (@interface func (export "args_sizes_get")
-    (result $error $errno_t)
+    (result $error $errno)
     ;;; The number of arguments.
-    (result $argc $size_t)
+    (result $argc $size)
     ;;; The size of the argument string data.
-    (result $argv_buf_size $size_t)
+    (result $argv_buf_size $size)
   )
 
   ;;; Read environment variable data.
@@ -33,187 +33,187 @@
   (@interface func (export "environ_get")
     (param $environ (@witx pointer (@witx pointer u8)))
     (param $environ_buf (@witx pointer u8))
-    (result $error $errno_t)
+    (result $error $errno)
   )
   ;;; Return command-line argument data sizes.
   (@interface func (export "environ_sizes_get")
-    (result $error $errno_t)
+    (result $error $errno)
     ;;; The number of arguments.
-    (result $argc $size_t)
+    (result $argc $size)
     ;;; The size of the argument string data.
-    (result $argv_buf_size $size_t)
+    (result $argv_buf_size $size)
   )
 
   ;;; Return the resolution of a clock.
   ;;; Implementations are required to provide a non-zero value for supported clocks. For unsupported clocks, return `WASI_EINVAL`
   ;;; Note: This is similar to `clock_getres` in POSIX.
   (@interface func (export "clock_res_get")
-    (result $error $errno_t)
+    (result $error $errno)
     ;;; The clock for which to return the resolution.
-    (param $clock_id $clockid_t)
+    (param $clock_id $clockid)
     ;;; The resolution of the clock.
-    (result $resolution $timestamp_t)
+    (result $resolution $timestamp)
   )
   ;;; Return the time value of a clock.
   ;;; Note: This is similar to `clock_gettime` in POSIX.
   (@interface func (export "clock_time_get")
     ;;; The clock for which to return the time.
-    (param $clock_id $clockid_t)
+    (param $clock_id $clockid)
     ;;; The maximum lag (exclusive) that the returned time value may have, compared to its actual value.
-    (param $precision $timestamp_t)
-    (result $error $errno_t)
+    (param $precision $timestamp)
+    (result $error $errno)
     ;;; The time value of the clock.
-    (result $time $timestamp_t)
+    (result $time $timestamp)
   )
 
   ;;; Provide file advisory information on a file descriptor.
   ;;; Note: This is similar to `posix_fadvise` in POSIX.
   (@interface func (export "fd_advise")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; The offset within the file to which the advisory applies.
-    (param $offset $filesize_t)
+    (param $offset $filesize)
     ;;; The length of the region to which the advisory applies.
-    (param $len $filesize_t)
+    (param $len $filesize)
     ;;; The advice.
-    (param $advice $advice_t)
-    (result $error $errno_t)
+    (param $advice $advice)
+    (result $error $errno)
   )
 
   ;;; Force the allocation of space in a file.
   ;;; Note: This is similar to `posix_fallocate` in POSIX.
   (@interface func (export "fd_allocate")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; The offset at which to start the allocation.
-    (param $offset $filesize_t)
+    (param $offset $filesize)
     ;;; The length of the area that is allocated.
-    (param $len $filesize_t)
-    (result $error $errno_t)
+    (param $len $filesize)
+    (result $error $errno)
   )
 
   ;;; Close a file descriptor.
   ;;; Note: This is similar to `close` in POSIX.
   (@interface func (export "fd_close")
-    (param $fd $fd_t)
-    (result $error $errno_t)
+    (param $fd $fd)
+    (result $error $errno)
   )
 
   ;;; Synchronize the data of a file to disk.
   ;;; Note: This is similar to `fdatasync` in POSIX.
   (@interface func (export "fd_datasync")
-    (param $fd $fd_t)
-    (result $error $errno_t)
+    (param $fd $fd)
+    (result $error $errno)
   )
 
   ;;; Get the attributes of a file descriptor.
   ;;; Note: This returns similar flags to `fsync(fd, F_GETFL)` in POSIX, as well as additional fields.
   (@interface func (export "fd_fdstat_get")
-    (param $fd $fd_t)
-    (result $error $errno_t)
+    (param $fd $fd)
+    (result $error $errno)
     ;;; The buffer where the file descriptor's attributes are stored.
-    (result $stat $fdstat_t)
+    (result $stat $fdstat)
   )
 
   ;;; Adjust the flags associated with a file descriptor.
   ;;; Note: This is similar to `fcntl(fd, F_SETFL, flags)` in POSIX.
   (@interface func (export "fd_fdstat_set_flags")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; The desired values of the file descriptor flags.
-    (param $flags $fdflags_t)
-    (result $error $errno_t)
+    (param $flags $fdflags)
+    (result $error $errno)
   )
 
   ;;; Adjust the rights associated with a file descriptor.
   ;;; This can only be used to remove rights, and returns `ENOTCAPABLE` if called in a way that would attempt to add rights
   (@interface func (export "fd_fdstat_set_rights")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; The desired rights of the file descriptor.
-    (param $fs_rights_base $rights_t)
-    (param $fs_rights_inheriting $rights_t)
-    (result $error $errno_t)
+    (param $fs_rights_base $rights)
+    (param $fs_rights_inheriting $rights)
+    (result $error $errno)
   )
 
   ;;; Return the attributes of an open file.
   (@interface func (export "fd_filestat_get")
-    (param $fd $fd_t)
-    (result $error $errno_t)
+    (param $fd $fd)
+    (result $error $errno)
     ;;; The buffer where the file's attributes are stored.
-    (result $buf $filestat_t)
+    (result $buf $filestat)
   )
 
   ;;; Adjust the size of an open file. If this increases the file's size, the extra bytes are filled with zeros.
   ;;; Note: This is similar to `ftruncate` in POSIX.
   (@interface func (export "fd_filestat_set_size")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; The desired file size.
-    (param $st_size $filesize_t)
-    (result $error $errno_t)
+    (param $st_size $filesize)
+    (result $error $errno)
   )
 
   ;;; Adjust the timestamps of an open file or directory.
   ;;; Note: This is similar to `futimens` in POSIX.
   (@interface func (export "fd_filestat_set_times")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; The desired values of the data access timestamp.
-    (param $st_atim $timestamp_t)
+    (param $st_atim $timestamp)
     ;;; The desired values of the data modification timestamp.
-    (param $st_mtim $timestamp_t)
+    (param $st_mtim $timestamp)
     ;;; A bitmask indicating which timestamps to adjust.
-    (param $fst_flags $fstflags_t)
-    (result $error $errno_t)
+    (param $fst_flags $fstflags)
+    (result $error $errno)
   )
 
   ;;; Read from a file descriptor, without using and updating the file descriptor's offset.
   ;;; Note: This is similar to `preadv` in POSIX.
   (@interface func (export "fd_pread")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; List of scatter/gather vectors in which to store data.
-    (param $iovs $iovec_t_array)
+    (param $iovs $iovec_array)
     ;;; The offset within the file at which to read.
-    (param $offset $filesize_t)
-    (result $error $errno_t)
+    (param $offset $filesize)
+    (result $error $errno)
     ;;; The number of bytes read.
-    (result $nread $size_t)
+    (result $nread $size)
   )
 
   ;;; Return a description of the given preopened file descriptor.
   (@interface func (export "fd_prestat_get")
-    (param $fd $fd_t)
-    (result $error $errno_t)
+    (param $fd $fd)
+    (result $error $errno)
     ;;; The buffer where the description is stored.
-    (result $buf $prestat_t)
+    (result $buf $prestat)
   )
 
   ;;; Return a description of the given preopened file descriptor.
   (@interface func (export "fd_prestat_dir_name")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; A buffer into which to write the preopened directory name.
     (param $path (@witx pointer u8))
-    (param $path_len $size_t)
-    (result $error $errno_t)
+    (param $path_len $size)
+    (result $error $errno)
   )
 
   ;;; Write to a file descriptor, without using and updating the file descriptor's offset.
   ;;; Note: This is similar to `pwritev` in POSIX.
   (@interface func (export "fd_pwrite")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; List of scatter/gather vectors from which to retrieve data.
-    (param $iovs $ciovec_t_array)
+    (param $iovs $ciovec_array)
     ;;; The offset within the file at which to write.
-    (param $offset $filesize_t)
-    (result $error $errno_t)
+    (param $offset $filesize)
+    (result $error $errno)
     ;;; The number of bytes written.
-    (result $nwritten $size_t)
+    (result $nwritten $size)
   )
 
   ;;; Read from a file descriptor.
   ;;; Note: This is similar to `readv` in POSIX.
   (@interface func (export "fd_read")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; List of scatter/gather vectors to which to store data.
-    (param $iovs $iovec_t_array)
-    (result $error $errno_t)
+    (param $iovs $iovec_array)
+    (result $error $errno)
     ;;; The number of bytes read.
-    (result $nread $size_t)
+    (result $nread $size)
   )
 
   ;;; Read directory entries from a directory.
@@ -227,15 +227,15 @@
   ;;; read buffer size in case it's too small to fit a single large directory
   ;;; entry, or skip the oversized directory entry.
   (@interface func (export "fd_readdir")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; The buffer where directory entries are stored
     (param $buf (@witx pointer u8))
-    (param $buf_len $size_t)
+    (param $buf_len $size)
     ;;; The location within the directory to start reading
-    (param $cookie $dircookie_t)
-    (result $error $errno_t)
+    (param $cookie $dircookie)
+    (result $error $errno)
     ;;; The number of bytes stored in the read buffer. If less than the size of the read buffer, the end of the directory has been reached.
-    (result $bufused $size_t)
+    (result $bufused $size)
   )
 
   ;;; Atomically replace a file descriptor by renumbering another file descriptor.
@@ -249,104 +249,104 @@
   ;;; This function provides a way to atomically renumber file descriptors, which
   ;;; would disappear if `dup2()` were to be removed entirely.
   (@interface func (export "fd_renumber")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; The file descriptor to overwrite.
-    (param $to $fd_t)
-    (result $error $errno_t)
+    (param $to $fd)
+    (result $error $errno)
   )
 
   ;;; Move the offset of a file descriptor.
   ;;; Note: This is similar to `lseek` in POSIX.
   (@interface func (export "fd_seek")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; The number of bytes to move.
-    (param $offset $filedelta_t)
+    (param $offset $filedelta)
     ;;; The base from which the offset is relative.
-    (param $whence $whence_t)
-    (result $error $errno_t)
+    (param $whence $whence)
+    (result $error $errno)
     ;;; The new offset of the file descriptor, relative to the start of the file.
-    (result $newoffset $filesize_t)
+    (result $newoffset $filesize)
   )
 
   ;;; Synchronize the data and metadata of a file to disk.
   ;;; Note: This is similar to `fsync` in POSIX.
   (@interface func (export "fd_sync")
-    (param $fd $fd_t)
-    (result $error $errno_t)
+    (param $fd $fd)
+    (result $error $errno)
   )
 
   ;;; Return the current offset of a file descriptor.
   ;;; Note: This is similar to `lseek(fd, 0, SEEK_CUR)` in POSIX.
   (@interface func (export "fd_tell")
-    (param $fd $fd_t)
-    (result $error $errno_t)
+    (param $fd $fd)
+    (result $error $errno)
     ;;; The current offset of the file descriptor, relative to the start of the file.
-    (result $offset $filesize_t)
+    (result $offset $filesize)
   )
 
   ;;; Write to a file descriptor.
   ;;; Note: This is similar to `writev` in POSIX.
   (@interface func (export "fd_write")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; List of scatter/gather vectors from which to retrieve data.
-    (param $iovs $ciovec_t_array)
-    (result $error $errno_t)
+    (param $iovs $ciovec_array)
+    (result $error $errno)
     ;;; The number of bytes written.
-    (result $nwritten $size_t)
+    (result $nwritten $size)
   )
 
   ;;; Create a directory.
   ;;; Note: This is similar to `mkdirat` in POSIX.
   (@interface func (export "path_create_directory")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; The path at which to create the directory.
     (param $path string)
-    (result $error $errno_t)
+    (result $error $errno)
   )
 
   ;;; Return the attributes of a file or directory.
   ;;; Note: This is similar to `stat` in POSIX.
   (@interface func (export "path_filestat_get")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; Flags determining the method of how the path is resolved.
-    (param $flags $lookupflags_t)
+    (param $flags $lookupflags)
     ;;; The path of the file or directory to inspect.
     (param $path string)
-    (result $error $errno_t)
+    (result $error $errno)
     ;;; The buffer where the file's attributes are stored.
-    (result $buf $filestat_t)
+    (result $buf $filestat)
   )
 
   ;;; Adjust the timestamps of a file or directory.
   ;;; Note: This is similar to `utimensat` in POSIX.
   (@interface func (export "path_filestat_set_times")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; Flags determining the method of how the path is resolved.
-    (param $flags $lookupflags_t)
+    (param $flags $lookupflags)
     ;;; The path of the file or directory to operate on.
     (param $path string)
     ;;; The desired values of the data access timestamp.
-    (param $st_atim $timestamp_t)
+    (param $st_atim $timestamp)
     ;;; The desired values of the data modification timestamp.
-    (param $st_mtim $timestamp_t)
+    (param $st_mtim $timestamp)
     ;;; A bitmask indicating which timestamps to adjust.
-    (param $fst_flags $fstflags_t)
-    (result $error $errno_t)
+    (param $fst_flags $fstflags)
+    (result $error $errno)
   )
 
   ;;; Create a hard link.
   ;;; Note: This is similar to `linkat` in POSIX.
   (@interface func (export "path_link")
-    (param $old_fd $fd_t)
+    (param $old_fd $fd)
     ;;; Flags determining the method of how the path is resolved.
-    (param $old_flags $lookupflags_t)
+    (param $old_flags $lookupflags)
     ;;; The source path from which to link.
     (param $old_path string)
     ;;; The working directory at which the resolution of the new path starts.
-    (param $new_fd $fd_t)
+    (param $new_fd $fd)
     ;;; The destination path at which to create the hard link.
     (param $new_path string)
-    (result $error $errno_t)
+    (result $error $errno)
   )
 
   ;;; Open a file or directory.
@@ -359,14 +359,14 @@
   ;;
   ;;; Note: This is similar to `openat` in POSIX.
   (@interface func (export "path_open")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; Flags determining the method of how the path is resolved.
-    (param $dirflags $lookupflags_t)
+    (param $dirflags $lookupflags)
     ;;; The relative path of the file or directory to open, relative to the
     ;;; `dirfd` directory.
     (param $path string)
     ;;; The method by which to open the file.
-    (param $o_flags $oflags_t)
+    (param $o_flags $oflags)
     ;;; The initial rights of the newly created file descriptor. The
     ;;; implementation is allowed to return a file descriptor with fewer rights
     ;;; than specified, if and only if those rights do not apply to the type of
@@ -375,49 +375,49 @@
     ;;; The *base* rights are rights that will apply to operations using the file
     ;;; descriptor itself, while the *inheriting* rights are rights that apply to
     ;;; file descriptors derived from it.
-    (param $fs_rights_base $rights_t)
-    (param $fs_rights_inherting $rights_t)
-    (param $flags $fdflags_t)
-    (result $error $errno_t)
+    (param $fs_rights_base $rights)
+    (param $fs_rights_inherting $rights)
+    (param $flags $fdflags)
+    (result $error $errno)
     ;;; The file descriptor of the file that has been opened.
-    (result $opened_fd $fd_t)
+    (result $opened_fd $fd)
   )
 
   ;;; Read the contents of a symbolic link.
   ;;; Note: This is similar to `readlinkat` in POSIX.
   (@interface func (export "path_readlink")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; The path of the symbolic link from which to read.
     (param $path string)
     ;;; The buffer to which to write the contents of the symbolic link.
     (param $buf (@witx pointer u8))
-    (param $buf_len $size_t)
-    (result $error $errno_t)
+    (param $buf_len $size)
+    (result $error $errno)
     ;;; The number of bytes placed in the buffer.
-    (result $bufused $size_t)
+    (result $bufused $size)
   )
 
   ;;; Remove a directory.
   ;;; Return `ENOTEMPTY` if the directory is not empty.
   ;;; Note: This is similar to `unlinkat(fd, path, AT_REMOVEDIR)` in POSIX.
   (@interface func (export "path_remove_directory")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; The path to a directory to remove.
     (param $path string)
-    (result $error $errno_t)
+    (result $error $errno)
   )
 
   ;;; Rename a file or directory.
   ;;; Note: This is similar to `renameat` in POSIX.
   (@interface func (export "path_rename")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; The source path of the file or directory to rename.
     (param $old_path string)
     ;;; The working directory at which the resolution of the new path starts.
-    (param $new_fd $fd_t)
+    (param $new_fd $fd)
     ;;; The destination path to which to rename the file or directory.
     (param $new_path string)
-    (result $error $errno_t)
+    (result $error $errno)
   )
 
   ;;; Create a symbolic link.
@@ -425,10 +425,10 @@
   (@interface func (export "path_symlink")
     ;;; The contents of the symbolic link.
     (param $old_path string)
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; The destination path at which to create the symbolic link.
     (param $new_path string)
-    (result $error $errno_t)
+    (result $error $errno)
   )
 
 
@@ -436,23 +436,23 @@
   ;;; Return `EISDIR` if the path refers to a directory.
   ;;; Note: This is similar to `unlinkat(fd, path, 0)` in POSIX.
   (@interface func (export "path_unlink_file")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; The path to a file to unlink.
     (param $path string)
-    (result $error $errno_t)
+    (result $error $errno)
   )
 
   ;;; Concurrently poll for the occurrence of a set of events.
   (@interface func (export "poll_oneoff")
     ;;; The events to which to subscribe.
-    (param $in (@witx const_pointer $subscription_t))
+    (param $in (@witx const_pointer $subscription))
     ;;; The events that have occurred.
-    (param $out (@witx pointer $event_t))
+    (param $out (@witx pointer $event))
     ;;; Both the number of subscriptions and events.
-    (param $nsubscriptions $size_t)
-    (result $error $errno_t)
+    (param $nsubscriptions $size)
+    (result $error $errno)
     ;;; The number of events stored.
-    (result $nevents $size_t)
+    (result $nevents $size)
   )
 
   ;;; Terminate the process normally. An exit code of 0 indicates successful
@@ -460,21 +460,21 @@
   ;;; the environment.
   (@interface func (export "proc_exit")
     ;;; The exit code returned by the process.
-    (param $rval $exitcode_t)
+    (param $rval $exitcode)
   )
 
   ;;; Send a signal to the process of the calling thread.
   ;;; Note: This is similar to `raise` in POSIX.
   (@interface func (export "proc_raise")
     ;;; The signal condition to trigger.
-    (param $sig $signal_t)
-    (result $error $errno_t)
+    (param $sig $signal)
+    (result $error $errno)
   )
 
   ;;; Temporarily yield execution of the calling thread.
   ;;; Note: This is similar to `sched_yield` in POSIX.
   (@interface func (export "sched_yield")
-    (result $error $errno_t)
+    (result $error $errno)
   )
 
   ;;; Write high-quality random data into a buffer.
@@ -486,46 +486,46 @@
   (@interface func (export "random_get")
     ;;; The buffer to fill with random data.
     (param $buf (@witx pointer u8))
-    (param $buf_len $size_t)
-    (result $error $errno_t)
+    (param $buf_len $size)
+    (result $error $errno)
   )
 
   ;;; Receive a message from a socket.
   ;;; Note: This is similar to `recv` in POSIX, though it also supports reading
   ;;; the data into multiple buffers in the manner of `readv`.
   (@interface func (export "sock_recv")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; List of scatter/gather vectors to which to store data.
-    (param $ri_data $iovec_t_array)
+    (param $ri_data $iovec_array)
     ;;; Message flags.
-    (param $ri_flags $riflags_t)
-    (result $error $errno_t)
+    (param $ri_flags $riflags)
+    (result $error $errno)
     ;;; Number of bytes stored in ri_data.
-    (result $ro_datalen $size_t)
+    (result $ro_datalen $size)
     ;;; Message flags.
-    (result $ro_flags $roflags_t)
+    (result $ro_flags $roflags)
   )
 
   ;;; Send a message on a socket.
   ;;; Note: This is similar to `send` in POSIX, though it also supports writing
   ;;; the data from multiple buffers in the manner of `writev`.
   (@interface func (export "sock_send")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; List of scatter/gather vectors to which to retrieve data
-    (param $si_data $ciovec_t_array)
+    (param $si_data $ciovec_array)
     ;;; Message flags.
-    (param $si_flags $siflags_t)
-    (result $error $errno_t)
+    (param $si_flags $siflags)
+    (result $error $errno)
     ;;; Number of bytes transmitted.
-    (result $so_datalen $size_t)
+    (result $so_datalen $size)
   )
 
   ;;; Shut down socket send and receive channels.
   ;;; Note: This is similar to `shutdown` in POSIX.
   (@interface func (export "sock_shutdown")
-    (param $fd $fd_t)
+    (param $fd $fd)
     ;;; Which channels on the socket to shut down.
-    (param $how $sdflags_t)
-    (result $error $errno_t)
+    (param $how $sdflags)
+    (result $error $errno)
   )
 )

--- a/phases/snapshot/witx/wasi_snapshot_preview1.witx
+++ b/phases/snapshot/witx/wasi_snapshot_preview1.witx
@@ -50,7 +50,7 @@
   (@interface func (export "clock_res_get")
     (result $error $errno)
     ;;; The clock for which to return the resolution.
-    (param $clock_id $clockid)
+    (param $id $clockid)
     ;;; The resolution of the clock.
     (result $resolution $timestamp)
   )
@@ -58,7 +58,7 @@
   ;;; Note: This is similar to `clock_gettime` in POSIX.
   (@interface func (export "clock_time_get")
     ;;; The clock for which to return the time.
-    (param $clock_id $clockid)
+    (param $id $clockid)
     ;;; The maximum lag (exclusive) that the returned time value may have, compared to its actual value.
     (param $precision $timestamp)
     (result $error $errno)
@@ -145,7 +145,7 @@
   (@interface func (export "fd_filestat_set_size")
     (param $fd $fd)
     ;;; The desired file size.
-    (param $st_size $filesize)
+    (param $size $filesize)
     (result $error $errno)
   )
 
@@ -154,9 +154,9 @@
   (@interface func (export "fd_filestat_set_times")
     (param $fd $fd)
     ;;; The desired values of the data access timestamp.
-    (param $st_atim $timestamp)
+    (param $atim $timestamp)
     ;;; The desired values of the data modification timestamp.
-    (param $st_mtim $timestamp)
+    (param $mtim $timestamp)
     ;;; A bitmask indicating which timestamps to adjust.
     (param $fst_flags $fstflags)
     (result $error $errno)
@@ -326,9 +326,9 @@
     ;;; The path of the file or directory to operate on.
     (param $path string)
     ;;; The desired values of the data access timestamp.
-    (param $st_atim $timestamp)
+    (param $atim $timestamp)
     ;;; The desired values of the data modification timestamp.
-    (param $st_mtim $timestamp)
+    (param $mtim $timestamp)
     ;;; A bitmask indicating which timestamps to adjust.
     (param $fst_flags $fstflags)
     (result $error $errno)
@@ -366,7 +366,7 @@
     ;;; `dirfd` directory.
     (param $path string)
     ;;; The method by which to open the file.
-    (param $o_flags $oflags)
+    (param $flags $oflags)
     ;;; The initial rights of the newly created file descriptor. The
     ;;; implementation is allowed to return a file descriptor with fewer rights
     ;;; than specified, if and only if those rights do not apply to the type of

--- a/phases/snapshot/witx/wasi_snapshot_preview1.witx
+++ b/phases/snapshot/witx/wasi_snapshot_preview1.witx
@@ -366,7 +366,7 @@
     ;;; `dirfd` directory.
     (param $path string)
     ;;; The method by which to open the file.
-    (param $flags $oflags)
+    (param $oflags $oflags)
     ;;; The initial rights of the newly created file descriptor. The
     ;;; implementation is allowed to return a file descriptor with fewer rights
     ;;; than specified, if and only if those rights do not apply to the type of
@@ -377,7 +377,7 @@
     ;;; file descriptors derived from it.
     (param $fs_rights_base $rights)
     (param $fs_rights_inherting $rights)
-    (param $flags $fdflags)
+    (param $fdflags $fdflags)
     (result $error $errno)
     ;;; The file descriptor of the file that has been opened.
     (result $opened_fd $fd)

--- a/tools/witx/tests/wasi.rs
+++ b/tools/witx/tests/wasi.rs
@@ -25,11 +25,6 @@ fn render_roundtrip() {
 
     let back_to_sexprs = format!("{}", doc);
     println!("{}", back_to_sexprs);
-    let doc2 = witx::parse(&back_to_sexprs)
-        .map_err(|e| e.report_with(&witx::MockFs::new(&[("-", &back_to_sexprs)])))
-        .unwrap();
-
-    let back_to_sexprs = format!("{}", doc);
 
     let doc2 = witx::parse(&back_to_sexprs)
         .map_err(|e| e.report_with(&witx::MockFs::new(&[("-", &back_to_sexprs)])))


### PR DESCRIPTION
Witx files started out encoding the types directly from the wasi/core.h header, including the C rules around identifier capitalization and namespacing.

This PR drops those conventions that are specific to the C language. We do so uniformly in each witx file, meaning we change both the current unstable and the contents of `phases/old`, so that code generators that know about these new conventions can still support all witx files in this repo.

I performed the following changes, mechanically when possible (leaving the sed script in the commit message):
* Drop trailing `_t` from all typenames.
* Change all $SHOUTY_SNAKE_CASE identifiers to $snake_case.
* Remove repeated prefixes from flag and enum variants: e.g. drop right_ prefix on all $rights
    * Most cases of the above was removing the `thistypename_` prefix, with underscore to make it obvious. These were done by sed where possible.
    * Special cases: All `$errno` enum cases had the leading `e` dropped, all `$signal` enum cases had the leading `sig` dropped.
