### PR TITLE
Correct the return type of `fd_filestat_get`.

### DIFF
--- a/phases/ephemeral/witx/wasi_ephemeral_preview.witx
+++ b/phases/ephemeral/witx/wasi_ephemeral_preview.witx
@@ -134,7 +134,7 @@
     (param $fd $fd_t)
     (result $error $errno_t)
     ;; The buffer where the file's attributes are stored.
-    (result $fs_rights_base $rights_t)
+    (result $buf $filestat_t)
   )
 
   ;; Adjust the size of an open file. If this increases the file's size, the extra bytes are filled with zeros.

--- a/phases/old/witx/wasi_unstable.witx
+++ b/phases/old/witx/wasi_unstable.witx
@@ -137,7 +137,7 @@
     (param $fd $fd_t)
     (result $error $errno_t)
     ;; The buffer where the file's attributes are stored.
-    (result $fs_rights_base $rights_t)
+    (result $buf $filestat_t)
   )
 
   ;; Adjust the size of an open file. If this increases the file's size, the extra bytes are filled with zeros.

--- a/phases/unstable/witx/wasi_unstable_preview0.witx
+++ b/phases/unstable/witx/wasi_unstable_preview0.witx
@@ -134,7 +134,7 @@
     (param $fd $fd_t)
     (result $error $errno_t)
     ;; The buffer where the file's attributes are stored.
-    (result $fs_rights_base $rights_t)
+    (result $buf $filestat_t)
   )
 
   ;; Adjust the size of an open file. If this increases the file's size, the extra bytes are filled with zeros.


### PR DESCRIPTION
This fixes the old versions too, as this change reflects current
practice.