### PR TITLE
witx: convert from 0-indexed line and col to 1-indexed

### DIFF
--- a/tools/witx/src/validate.rs
+++ b/tools/witx/src/validate.rs
@@ -143,7 +143,7 @@ impl DocValidationScope<'_> {
         let (line, column) = span.linecol_in(self.text);
         Location {
             line: line + 1,
-            column: column ,
+            column: column,
             path: self.path.to_path_buf(),
         }
     }

--- a/tools/witx/src/validate.rs
+++ b/tools/witx/src/validate.rs
@@ -143,7 +143,7 @@ impl DocValidationScope<'_> {
         let (line, column) = span.linecol_in(self.text);
         Location {
             line: line + 1,
-            column: column,
+            column: column + 1,
             path: self.path.to_path_buf(),
         }
     }

--- a/tools/witx/src/validate.rs
+++ b/tools/witx/src/validate.rs
@@ -139,10 +139,11 @@ impl DocValidation {
 
 impl DocValidationScope<'_> {
     fn location(&self, span: wast::Span) -> Location {
+        // Wast Span gives 0-indexed lines and columns. Location is 1-indexed.
         let (line, column) = span.linecol_in(self.text);
         Location {
-            line,
-            column,
+            line: line + 1,
+            column: column ,
             path: self.path.to_path_buf(),
         }
     }


### PR DESCRIPTION
Currently, validation errors (which use `Location` to render error messages) display the wrong line and column because wast's Span::linecol_in uses 0-indexed lines and columns, but Location uses 1-indexed lines and columns. Trivial fix.