### PR TITLE
Fix old definition of `path_symlink`

### DIFF
--- a/phases/ephemeral/witx/wasi_ephemeral_preview.witx
+++ b/phases/ephemeral/witx/wasi_ephemeral_preview.witx
@@ -420,9 +420,9 @@
   ;; Create a symbolic link.
   ;; Note: This is similar to `symlinkat` in POSIX.
   (@interface func (export "path_symlink")
-    (param $fd $fd_t)
     ;; The contents of the symbolic link.
     (param $old_path string)
+    (param $fd $fd_t)
     ;; The destination path at which to create the symbolic link.
     (param $new_path string)
     (result $error $errno_t)

--- a/phases/old/witx/wasi_unstable.witx
+++ b/phases/old/witx/wasi_unstable.witx
@@ -423,9 +423,9 @@
   ;; Create a symbolic link.
   ;; Note: This is similar to `symlinkat` in POSIX.
   (@interface func (export "path_symlink")
-    (param $fd $fd_t)
     ;; The contents of the symbolic link.
     (param $old_path string)
+    (param $fd $fd_t)
     ;; The destination path at which to create the symbolic link.
     (param $new_path string)
     (result $error $errno_t)

--- a/phases/unstable/witx/wasi_unstable_preview0.witx
+++ b/phases/unstable/witx/wasi_unstable_preview0.witx
@@ -420,9 +420,9 @@
   ;; Create a symbolic link.
   ;; Note: This is similar to `symlinkat` in POSIX.
   (@interface func (export "path_symlink")
-    (param $fd $fd_t)
     ;; The contents of the symbolic link.
     (param $old_path string)
+    (param $fd $fd_t)
     ;; The destination path at which to create the symbolic link.
     (param $new_path string)
     (result $error $errno_t)


### PR DESCRIPTION
This fixes the `*.witx` for the old definition of `path_symlink` to
ensure that the `old_path` argument comes first.