### PR TITLE
Add a .gitignore and add Cargo.toml features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+*.bk
+*.swp
+*.swo
+*.swx
+tags
+target
+Cargo.lock
+.*.rustfmt
+rusty-tags.*
+*~
+\#*\#

--- a/tools/witx/Cargo.toml
+++ b/tools/witx/Cargo.toml
@@ -6,6 +6,7 @@ homepage = "https://github.com/WebAssembly/WASI"
 repository = "https://github.com/WebAssembly/WASI"
 license = "Apache-2.0"
 categories = ["wasm"]
+keywords = ["webassembly", "wasm"]
 authors = ["Pat Hickey <phickey@fastly.com>", "Alex Crichton <alex@alexcrichton.com>"]
 edition = "2018"
 


### PR DESCRIPTION
Add a basic .gitignore for working with Rust code, and add cargo features for witx's Cargo.toml.