### PR TITLE
witx: Depend on wast 3.0.4 to fix build failure with 3.0.1

### DIFF
--- a/tools/witx/Cargo.toml
+++ b/tools/witx/Cargo.toml
@@ -19,5 +19,5 @@ path = "src/main.rs"
 
 [dependencies]
 clap = "2"
-wast = "3.0.1"
+wast = "3.0.4"
 failure = "0.1"


### PR DESCRIPTION
witx depends on wast 3.0.1, but it uses the comment() method of the
Cursor type, which doesn't exist in version 3.0.1. This results in a
build failure if attempting to build witx against wast 3.0.1. That
method exists in the current 3.0.4, so update the wast dependency to
3.0.4.