### PR TITLE
Re-organize witx AST

### DIFF
--- a/tools/witx/src/ast.rs
+++ b/tools/witx/src/ast.rs
@@ -175,7 +175,6 @@ pub enum IntRepr {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EnumDatatype {
-    pub name: Id,
     pub repr: IntRepr,
     pub variants: Vec<EnumVariant>,
 }
@@ -188,7 +187,6 @@ pub struct EnumVariant {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FlagsDatatype {
-    pub name: Id,
     pub repr: IntRepr,
     pub flags: Vec<FlagsMember>,
 }
@@ -201,7 +199,6 @@ pub struct FlagsMember {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StructDatatype {
-    pub name: Id,
     pub members: Vec<StructMember>,
 }
 
@@ -214,7 +211,6 @@ pub struct StructMember {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UnionDatatype {
-    pub name: Id,
     pub variants: Vec<UnionVariant>,
 }
 
@@ -227,7 +223,6 @@ pub struct UnionVariant {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HandleDatatype {
-    pub name: Id,
     pub supertypes: Vec<DatatypeRef>,
 }
 

--- a/tools/witx/src/ast.rs
+++ b/tools/witx/src/ast.rs
@@ -107,6 +107,8 @@ impl PartialEq for Entry {
     }
 }
 
+pub type DatatypeIdent = Rc<Datatype>;
+/*
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DatatypeIdent {
     Builtin(BuiltinType),
@@ -115,10 +117,11 @@ pub enum DatatypeIdent {
     ConstPointer(Box<DatatypeIdent>),
     Ident(Rc<Datatype>),
 }
+*/
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Datatype {
-    pub name: Id,
+    pub name: Option<Id>,
     pub variant: DatatypeVariant,
     pub docs: String,
 }
@@ -131,6 +134,10 @@ pub enum DatatypeVariant {
     Struct(StructDatatype),
     Union(UnionDatatype),
     Handle(HandleDatatype),
+    Array(Rc<Datatype>),
+    Pointer(Rc<Datatype>),
+    ConstPointer(Rc<Datatype>),
+    Builtin(BuiltinType),
 }
 
 impl DatatypeVariant {
@@ -143,6 +150,10 @@ impl DatatypeVariant {
             Struct(_) => "struct",
             Union(_) => "union",
             Handle(_) => "handle",
+            Builtin(_) => "builtin",
+            Array(_) => "array",
+            Pointer(_) => "pointer",
+            ConstPointer(_) => "constpointer",
         }
     }
 }

--- a/tools/witx/src/ast.rs
+++ b/tools/witx/src/ast.rs
@@ -114,9 +114,9 @@ pub enum DatatypeRef {
 }
 
 impl DatatypeRef {
-    pub fn deref(&self) -> Rc<Datatype> {
+    pub fn datatype(&self) -> Rc<Datatype> {
         match self {
-            DatatypeRef::Name(named) => named.dt.deref(),
+            DatatypeRef::Name(named) => named.datatype(),
             DatatypeRef::Value(ref v) => v.clone(),
         }
     }
@@ -127,6 +127,12 @@ pub struct NamedDatatype {
     pub name: Id,
     pub dt: DatatypeRef,
     pub docs: String,
+}
+
+impl NamedDatatype {
+    pub fn datatype(&self) -> Rc<Datatype> {
+        self.dt.datatype()
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/tools/witx/src/coretypes.rs
+++ b/tools/witx/src/coretypes.rs
@@ -103,7 +103,7 @@ impl InterfaceFuncParam {
     /// Gives the WebAssembly type that corresponds to passing this interface func parameter by value.
     /// Not all types can be passed by value: those which cannot return None
     pub fn pass_by_value(&self) -> Option<CoreParamType> {
-        match self.type_.deref().passed_by() {
+        match self.type_.datatype().passed_by() {
             DatatypePassedBy::Value(atom) => Some(CoreParamType {
                 signifies: CoreParamSignifies::Value(atom),
                 param: self.clone(),
@@ -116,7 +116,7 @@ impl InterfaceFuncParam {
     /// by reference. Some types are passed by reference using a single pointer, others
     /// require both a pointer and length.
     pub fn pass_by_reference(&self) -> Vec<CoreParamType> {
-        match self.type_.deref().passed_by() {
+        match self.type_.datatype().passed_by() {
             DatatypePassedBy::Value(_) | DatatypePassedBy::Pointer => vec![CoreParamType {
                 signifies: CoreParamSignifies::PointerTo,
                 param: self.clone(),

--- a/tools/witx/src/coretypes.rs
+++ b/tools/witx/src/coretypes.rs
@@ -1,6 +1,4 @@
-use crate::{
-    BuiltinType, DatatypeIdent, DatatypeVariant, IntRepr, InterfaceFunc, InterfaceFuncParam,
-};
+use crate::{BuiltinType, Datatype, DatatypeVariant, IntRepr, InterfaceFunc, InterfaceFuncParam};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 /// Enumerates the types permitted for function arguments in the WebAssembly spec
@@ -31,12 +29,12 @@ pub enum DatatypePassedBy {
     PointerLengthPair,
 }
 
-impl DatatypeIdent {
+impl Datatype {
     /// Determine the simplest strategy by which a type may be passed. Value always preferred over
     /// Pointer.
     pub fn passed_by(&self) -> DatatypePassedBy {
-        match &self {
-            DatatypeIdent::Builtin(b) => match b {
+        match &self.variant {
+            DatatypeVariant::Builtin(b) => match b {
                 BuiltinType::String => DatatypePassedBy::PointerLengthPair,
                 BuiltinType::U8
                 | BuiltinType::U16
@@ -48,19 +46,17 @@ impl DatatypeIdent {
                 BuiltinType::F32 => DatatypePassedBy::Value(AtomType::F32),
                 BuiltinType::F64 => DatatypePassedBy::Value(AtomType::F64),
             },
-            DatatypeIdent::Array { .. } => DatatypePassedBy::PointerLengthPair,
-            DatatypeIdent::Pointer { .. } | DatatypeIdent::ConstPointer { .. } => {
+            DatatypeVariant::Array { .. } => DatatypePassedBy::PointerLengthPair,
+            DatatypeVariant::Pointer { .. } | DatatypeVariant::ConstPointer { .. } => {
                 DatatypePassedBy::Value(AtomType::I32)
             }
-            DatatypeIdent::Ident(i) => match &i.variant {
-                DatatypeVariant::Alias(a) => a.to.passed_by(),
-                DatatypeVariant::Enum(e) => DatatypePassedBy::Value(e.repr.into()),
-                DatatypeVariant::Flags(f) => DatatypePassedBy::Value(f.repr.into()),
-                DatatypeVariant::Struct { .. } | DatatypeVariant::Union { .. } => {
-                    DatatypePassedBy::Pointer
-                }
-                DatatypeVariant::Handle { .. } => DatatypePassedBy::Value(AtomType::I32),
-            },
+            DatatypeVariant::Alias(a) => a.to.passed_by(),
+            DatatypeVariant::Enum(e) => DatatypePassedBy::Value(e.repr.into()),
+            DatatypeVariant::Flags(f) => DatatypePassedBy::Value(f.repr.into()),
+            DatatypeVariant::Struct { .. } | DatatypeVariant::Union { .. } => {
+                DatatypePassedBy::Pointer
+            }
+            DatatypeVariant::Handle { .. } => DatatypePassedBy::Value(AtomType::I32),
         }
     }
 }

--- a/tools/witx/src/docs.rs
+++ b/tools/witx/src/docs.rs
@@ -37,63 +37,48 @@ impl BuiltinType {
     }
 }
 
+impl Documentation for NamedDatatype {
+    fn to_md(&self) -> String {
+        let body = match &self.dt {
+            DatatypeRef::Value(v) => v.to_md(),
+            DatatypeRef::Name(n) => format!("Alias to {}", n.name.as_str()),
+        };
+        format!("## `{}`\n{}\n{}\n", self.name.as_str(), self.docs, body,)
+    }
+}
+
+impl DatatypeRef {
+    fn type_name(&self) -> String {
+        match self {
+            DatatypeRef::Name(n) => n.name.as_str().to_string(),
+            DatatypeRef::Value(ref v) => match &**v {
+                Datatype::Array(a) => format!("Array<{}>", a.type_name()),
+                Datatype::Pointer(p) => format!("Pointer<{}>", p.type_name()),
+                Datatype::ConstPointer(p) => format!("ConstPointer<{}>", p.type_name()),
+                Datatype::Builtin(b) => b.type_name().to_string(),
+                Datatype::Enum { .. }
+                | Datatype::Flags { .. }
+                | Datatype::Struct { .. }
+                | Datatype::Union { .. }
+                | Datatype::Handle { .. } => unimplemented!("type_name of anonymous datatypes"),
+            },
+        }
+    }
+}
+
 impl Documentation for Datatype {
     fn to_md(&self) -> String {
-        if let Some(name) = &self.name {
-            format!(
-                "## `{}`\n{}\n{}\n",
-                name.as_str(),
-                self.docs,
-                self.variant.to_md()
-            )
-        } else {
-            unreachable!("should only produce Documentation for named datatypes")
-        }
-    }
-}
-
-impl Datatype {
-    fn type_name(&self) -> String {
-        self.name
-            .clone()
-            .map(|n| n.as_str().to_string())
-            .unwrap_or_else(|| match &self.variant {
-                DatatypeVariant::Array(a) => format!("Array<{}>", a.type_name()),
-                DatatypeVariant::Pointer(p) => format!("Pointer<{}>", p.type_name()),
-                DatatypeVariant::ConstPointer(p) => format!("ConstPointer<{}>", p.type_name()),
-                DatatypeVariant::Builtin(b) => b.type_name().to_string(),
-                DatatypeVariant::Alias { .. }
-                | DatatypeVariant::Enum { .. }
-                | DatatypeVariant::Flags { .. }
-                | DatatypeVariant::Struct { .. }
-                | DatatypeVariant::Union { .. }
-                | DatatypeVariant::Handle { .. } => {
-                    unreachable!("these variants should always be named")
-                }
-            })
-    }
-}
-
-impl Documentation for DatatypeVariant {
-    fn to_md(&self) -> String {
         match self {
-            DatatypeVariant::Alias(a) => a.to_md(),
-            DatatypeVariant::Enum(a) => a.to_md(),
-            DatatypeVariant::Flags(a) => a.to_md(),
-            DatatypeVariant::Struct(a) => a.to_md(),
-            DatatypeVariant::Union(a) => a.to_md(),
-            DatatypeVariant::Handle(a) => a.to_md(),
-            DatatypeVariant::Array{..} |
-            DatatypeVariant::Pointer{..} |
-            DatatypeVariant::ConstPointer{..} |
-            DatatypeVariant::Builtin{..} => unreachable!("should only produce Documentation for other variants"),
+            Datatype::Enum(a) => a.to_md(),
+            Datatype::Flags(a) => a.to_md(),
+            Datatype::Struct(a) => a.to_md(),
+            Datatype::Union(a) => a.to_md(),
+            Datatype::Handle(a) => a.to_md(),
+            Datatype::Array { .. }
+            | Datatype::Pointer { .. }
+            | Datatype::ConstPointer { .. }
+            | Datatype::Builtin { .. } => unimplemented!(),
         }
-    }
-}
-
-impl Documentation for AliasDatatype {
-    fn to_md(&self) -> String {
-        format!("Alias to `{}`", self.to.type_name())
     }
 }
 

--- a/tools/witx/src/docs.rs
+++ b/tools/witx/src/docs.rs
@@ -7,7 +7,7 @@ pub trait Documentation {
 impl Documentation for Document {
     fn to_md(&self) -> String {
         let mut ret = "# Types\n".to_string();
-        for d in self.datatypes() {
+        for d in self.typenames() {
             ret += &d.to_md();
         }
 
@@ -37,47 +37,47 @@ impl BuiltinType {
     }
 }
 
-impl Documentation for NamedDatatype {
+impl Documentation for NamedType {
     fn to_md(&self) -> String {
         let body = match &self.dt {
-            DatatypeRef::Value(v) => v.to_md(),
-            DatatypeRef::Name(n) => format!("Alias to {}", n.name.as_str()),
+            TypeRef::Value(v) => v.to_md(),
+            TypeRef::Name(n) => format!("Alias to {}", n.name.as_str()),
         };
         format!("## `{}`\n{}\n{}\n", self.name.as_str(), self.docs, body,)
     }
 }
 
-impl DatatypeRef {
+impl TypeRef {
     fn type_name(&self) -> String {
         match self {
-            DatatypeRef::Name(n) => n.name.as_str().to_string(),
-            DatatypeRef::Value(ref v) => match &**v {
-                Datatype::Array(a) => format!("Array<{}>", a.type_name()),
-                Datatype::Pointer(p) => format!("Pointer<{}>", p.type_name()),
-                Datatype::ConstPointer(p) => format!("ConstPointer<{}>", p.type_name()),
-                Datatype::Builtin(b) => b.type_name().to_string(),
-                Datatype::Enum { .. }
-                | Datatype::Flags { .. }
-                | Datatype::Struct { .. }
-                | Datatype::Union { .. }
-                | Datatype::Handle { .. } => unimplemented!("type_name of anonymous datatypes"),
+            TypeRef::Name(n) => n.name.as_str().to_string(),
+            TypeRef::Value(ref v) => match &**v {
+                Type::Array(a) => format!("Array<{}>", a.type_name()),
+                Type::Pointer(p) => format!("Pointer<{}>", p.type_name()),
+                Type::ConstPointer(p) => format!("ConstPointer<{}>", p.type_name()),
+                Type::Builtin(b) => b.type_name().to_string(),
+                Type::Enum { .. }
+                | Type::Flags { .. }
+                | Type::Struct { .. }
+                | Type::Union { .. }
+                | Type::Handle { .. } => unimplemented!("type_name of anonymous datatypes"),
             },
         }
     }
 }
 
-impl Documentation for Datatype {
+impl Documentation for Type {
     fn to_md(&self) -> String {
         match self {
-            Datatype::Enum(a) => a.to_md(),
-            Datatype::Flags(a) => a.to_md(),
-            Datatype::Struct(a) => a.to_md(),
-            Datatype::Union(a) => a.to_md(),
-            Datatype::Handle(a) => a.to_md(),
-            Datatype::Array { .. }
-            | Datatype::Pointer { .. }
-            | Datatype::ConstPointer { .. }
-            | Datatype::Builtin { .. } => unimplemented!(),
+            Type::Enum(a) => a.to_md(),
+            Type::Flags(a) => a.to_md(),
+            Type::Struct(a) => a.to_md(),
+            Type::Union(a) => a.to_md(),
+            Type::Handle(a) => a.to_md(),
+            Type::Array { .. }
+            | Type::Pointer { .. }
+            | Type::ConstPointer { .. }
+            | Type::Builtin { .. } => unimplemented!(),
         }
     }
 }
@@ -123,7 +123,7 @@ impl Documentation for StructDatatype {
                 format!(
                     "#### `{}`\nMember type: `{}`\n{}",
                     m.name.as_str(),
-                    m.type_.type_name(),
+                    m.tref.type_name(),
                     m.docs,
                 )
             })
@@ -142,7 +142,7 @@ impl Documentation for UnionDatatype {
                 format!(
                     "#### `{}`\nVariant type: `{}`\n{}",
                     v.name.as_str(),
-                    v.type_.type_name(),
+                    v.tref.type_name(),
                     v.docs,
                 )
             })
@@ -212,7 +212,7 @@ impl Documentation for InterfaceFunc {
                 format!(
                     "##### `{name}`\n`{name}` has type `{type_}`\n{docs}",
                     name = f.name.as_str(),
-                    type_ = f.type_.type_name(),
+                    type_ = f.tref.type_name(),
                     docs = f.docs
                 )
             })
@@ -225,7 +225,7 @@ impl Documentation for InterfaceFunc {
                 format!(
                     "##### `{name}`\n`{name}` has type `{type_}`\n{docs}",
                     name = f.name.as_str(),
-                    type_ = f.type_.type_name(),
+                    type_ = f.tref.type_name(),
                     docs = f.docs
                 )
             })

--- a/tools/witx/src/docs.rs
+++ b/tools/witx/src/docs.rs
@@ -40,7 +40,17 @@ impl BuiltinType {
 impl Documentation for NamedType {
     fn to_md(&self) -> String {
         let body = match &self.dt {
-            TypeRef::Value(v) => v.to_md(),
+            TypeRef::Value(v) => match &**v {
+                Type::Enum(a) => a.to_md(),
+                Type::Flags(a) => a.to_md(),
+                Type::Struct(a) => a.to_md(),
+                Type::Union(a) => a.to_md(),
+                Type::Handle(a) => a.to_md(),
+                Type::Array(a) => format!("Array of {}", a.type_name()),
+                Type::Pointer(a) => format!("Pointer to {}", a.type_name()),
+                Type::ConstPointer(a) => format!("Constant Pointer to {}", a.type_name()),
+                Type::Builtin(a) => format!("Builtin type {}", a.type_name()),
+            },
             TypeRef::Name(n) => format!("Alias to {}", n.name.as_str()),
         };
         format!("## `{}`\n{}\n{}\n", self.name.as_str(), self.docs, body,)
@@ -60,24 +70,10 @@ impl TypeRef {
                 | Type::Flags { .. }
                 | Type::Struct { .. }
                 | Type::Union { .. }
-                | Type::Handle { .. } => unimplemented!("type_name of anonymous datatypes"),
+                | Type::Handle { .. } => {
+                    unimplemented!("type_name of anonymous compound datatypes")
+                }
             },
-        }
-    }
-}
-
-impl Documentation for Type {
-    fn to_md(&self) -> String {
-        match self {
-            Type::Enum(a) => a.to_md(),
-            Type::Flags(a) => a.to_md(),
-            Type::Struct(a) => a.to_md(),
-            Type::Union(a) => a.to_md(),
-            Type::Handle(a) => a.to_md(),
-            Type::Array { .. }
-            | Type::Pointer { .. }
-            | Type::ConstPointer { .. }
-            | Type::Builtin { .. } => unimplemented!(),
         }
     }
 }

--- a/tools/witx/src/lib.rs
+++ b/tools/witx/src/lib.rs
@@ -16,11 +16,10 @@ mod toplevel;
 mod validate;
 
 pub use ast::{
-    AliasDatatype, BuiltinType, Datatype, DatatypeIdent, DatatypeVariant, Definition, Document,
-    Entry, EnumDatatype, EnumVariant, FlagsDatatype, FlagsMember, HandleDatatype, Id, IntRepr,
-    InterfaceFunc, InterfaceFuncParam, InterfaceFuncParamPosition, Module, ModuleDefinition,
-    ModuleEntry, ModuleImport, ModuleImportVariant, StructDatatype, StructMember, UnionDatatype,
-    UnionVariant,
+    BuiltinType, Datatype, DatatypeRef, Definition, Document, Entry, EnumDatatype, EnumVariant,
+    FlagsDatatype, FlagsMember, HandleDatatype, Id, IntRepr, InterfaceFunc, InterfaceFuncParam,
+    InterfaceFuncParamPosition, Module, ModuleDefinition, ModuleEntry, ModuleImport,
+    ModuleImportVariant, NamedDatatype, StructDatatype, StructMember, UnionDatatype, UnionVariant,
 };
 pub use coretypes::{AtomType, CoreFuncType, CoreParamSignifies, CoreParamType, DatatypePassedBy};
 pub use docs::Documentation;

--- a/tools/witx/src/lib.rs
+++ b/tools/witx/src/lib.rs
@@ -16,12 +16,13 @@ mod toplevel;
 mod validate;
 
 pub use ast::{
-    BuiltinType, Datatype, DatatypeRef, Definition, Document, Entry, EnumDatatype, EnumVariant,
-    FlagsDatatype, FlagsMember, HandleDatatype, Id, IntRepr, InterfaceFunc, InterfaceFuncParam,
+    BuiltinType, Definition, Document, Entry, EnumDatatype, EnumVariant, FlagsDatatype,
+    FlagsMember, HandleDatatype, Id, IntRepr, InterfaceFunc, InterfaceFuncParam,
     InterfaceFuncParamPosition, Module, ModuleDefinition, ModuleEntry, ModuleImport,
-    ModuleImportVariant, NamedDatatype, StructDatatype, StructMember, UnionDatatype, UnionVariant,
+    ModuleImportVariant, NamedType, StructDatatype, StructMember, Type, TypeRef, UnionDatatype,
+    UnionVariant,
 };
-pub use coretypes::{AtomType, CoreFuncType, CoreParamSignifies, CoreParamType, DatatypePassedBy};
+pub use coretypes::{AtomType, CoreFuncType, CoreParamSignifies, CoreParamType, TypePassedBy};
 pub use docs::Documentation;
 pub use io::{Filesystem, MockFs, WitxIo};
 pub use parser::DeclSyntax;

--- a/tools/witx/src/lib.rs
+++ b/tools/witx/src/lib.rs
@@ -26,7 +26,7 @@ pub use coretypes::{AtomType, CoreFuncType, CoreParamSignifies, CoreParamType, D
 pub use docs::Documentation;
 pub use io::{Filesystem, MockFs, WitxIo};
 pub use parser::DeclSyntax;
-pub use render::{Render, SExpr as RenderSExpr};
+pub use render::SExpr;
 pub use validate::ValidationError;
 
 use failure::Fail;

--- a/tools/witx/src/parser.rs
+++ b/tools/witx/src/parser.rs
@@ -345,6 +345,7 @@ impl<'a> Parse<'a> for TypedefSyntax<'a> {
                 } else if l.peek::<kw::handle>() {
                     Ok(TypedefSyntax::Handle(parser.parse()?))
                 } else if l.peek::<kw::array>() {
+                    parser.parse::<kw::array>()?;
                     Ok(TypedefSyntax::Array(Box::new(parser.parse()?)))
                 } else if l.peek::<AtWitx>() {
                     parser.parse::<AtWitx>()?;
@@ -425,7 +426,7 @@ impl<'a> Parse<'a> for StructSyntax<'a> {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FieldSyntax<'a> {
     pub name: wast::Id<'a>,
-    pub type_: wast::Id<'a>,
+    pub type_: TypedefSyntax<'a>,
 }
 
 impl<'a> Parse<'a> for FieldSyntax<'a> {

--- a/tools/witx/src/render.rs
+++ b/tools/witx/src/render.rs
@@ -92,57 +92,48 @@ impl BuiltinType {
     }
 }
 
-impl Datatype {
+impl NamedDatatype {
     fn definition_sexpr(&self) -> SExpr {
-        let name = self
-            .name
-            .as_ref()
-            .expect("definition of named datatype")
-            .to_sexpr();
-        let body = self.variant.to_sexpr();
+        let body = self.dt.to_sexpr();
         SExpr::docs(
             &self.docs,
-            SExpr::Vec(vec![SExpr::word("typename"), name, body]),
+            SExpr::Vec(vec![SExpr::word("typename"), self.name.to_sexpr(), body]),
         )
     }
-    fn identifier_sexpr(&self) -> SExpr {
-        match &self.name {
-            Some(n) => n.to_sexpr(),
-            None => self.variant.to_sexpr(),
-        }
-    }
 }
 
-impl DatatypeVariant {
+impl DatatypeRef {
     fn to_sexpr(&self) -> SExpr {
         match self {
-            DatatypeVariant::Alias(a) => a.to_sexpr(),
-            DatatypeVariant::Enum(a) => a.to_sexpr(),
-            DatatypeVariant::Flags(a) => a.to_sexpr(),
-            DatatypeVariant::Struct(a) => a.to_sexpr(),
-            DatatypeVariant::Union(a) => a.to_sexpr(),
-            DatatypeVariant::Handle(a) => a.to_sexpr(),
-            DatatypeVariant::Array(a) => {
-                SExpr::Vec(vec![SExpr::word("array"), a.identifier_sexpr()])
-            }
-            DatatypeVariant::Pointer(p) => SExpr::Vec(vec![
-                SExpr::annot("witx"),
-                SExpr::word("pointer"),
-                p.identifier_sexpr(),
-            ]),
-            DatatypeVariant::ConstPointer(p) => SExpr::Vec(vec![
-                SExpr::annot("witx"),
-                SExpr::word("const_pointer"),
-                p.identifier_sexpr(),
-            ]),
-            DatatypeVariant::Builtin(b) => b.to_sexpr(),
+            DatatypeRef::Name(n) => n.name.to_sexpr(),
+            DatatypeRef::Value(v) => v.to_sexpr(),
         }
     }
 }
 
-impl AliasDatatype {
+impl Datatype {
     fn to_sexpr(&self) -> SExpr {
-        self.to.identifier_sexpr()
+        match self {
+            Datatype::Enum(a) => a.to_sexpr(),
+            Datatype::Flags(a) => a.to_sexpr(),
+            Datatype::Struct(a) => a.to_sexpr(),
+            Datatype::Union(a) => a.to_sexpr(),
+            Datatype::Handle(a) => a.to_sexpr(),
+            Datatype::Array(a) => {
+                SExpr::Vec(vec![SExpr::word("array"), a.to_sexpr()])
+            }
+            Datatype::Pointer(p) => SExpr::Vec(vec![
+                SExpr::annot("witx"),
+                SExpr::word("pointer"),
+                p.to_sexpr(),
+            ]),
+            Datatype::ConstPointer(p) => SExpr::Vec(vec![
+                SExpr::annot("witx"),
+                SExpr::word("const_pointer"),
+                p.to_sexpr(),
+            ]),
+            Datatype::Builtin(b) => b.to_sexpr(),
+        }
     }
 }
 
@@ -182,7 +173,7 @@ impl StructDatatype {
                     SExpr::Vec(vec![
                         SExpr::word("field"),
                         m.name.to_sexpr(),
-                        m.type_.identifier_sexpr(),
+                        m.type_.to_sexpr(),
                     ]),
                 )
             })
@@ -203,7 +194,7 @@ impl UnionDatatype {
                     SExpr::Vec(vec![
                         SExpr::word("field"),
                         v.name.to_sexpr(),
-                        v.type_.identifier_sexpr(),
+                        v.type_.to_sexpr(),
                     ]),
                 )
             })
@@ -218,7 +209,7 @@ impl HandleDatatype {
         let supertypes = self
             .supertypes
             .iter()
-            .map(|s| s.identifier_sexpr())
+            .map(|s| s.to_sexpr())
             .collect::<Vec<SExpr>>();
         SExpr::Vec([header, supertypes].concat())
     }
@@ -281,7 +272,7 @@ impl InterfaceFunc {
                     SExpr::Vec(vec![
                         SExpr::word("param"),
                         f.name.to_sexpr(),
-                        f.type_.identifier_sexpr(),
+                        f.type_.to_sexpr(),
                     ]),
                 )
             })
@@ -295,7 +286,7 @@ impl InterfaceFunc {
                     SExpr::Vec(vec![
                         SExpr::word("result"),
                         f.name.to_sexpr(),
-                        f.type_.identifier_sexpr(),
+                        f.type_.to_sexpr(),
                     ]),
                 )
             })

--- a/tools/witx/src/render.rs
+++ b/tools/witx/src/render.rs
@@ -3,7 +3,7 @@ use std::fmt;
 
 impl fmt::Display for Document {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        for d in self.datatypes() {
+        for d in self.typenames() {
             write!(f, "{}\n", d.definition_sexpr())?;
         }
         for m in self.modules() {
@@ -92,7 +92,7 @@ impl BuiltinType {
     }
 }
 
-impl NamedDatatype {
+impl NamedType {
     fn definition_sexpr(&self) -> SExpr {
         let body = self.dt.to_sexpr();
         SExpr::docs(
@@ -102,37 +102,35 @@ impl NamedDatatype {
     }
 }
 
-impl DatatypeRef {
+impl TypeRef {
     fn to_sexpr(&self) -> SExpr {
         match self {
-            DatatypeRef::Name(n) => n.name.to_sexpr(),
-            DatatypeRef::Value(v) => v.to_sexpr(),
+            TypeRef::Name(n) => n.name.to_sexpr(),
+            TypeRef::Value(v) => v.to_sexpr(),
         }
     }
 }
 
-impl Datatype {
+impl Type {
     fn to_sexpr(&self) -> SExpr {
         match self {
-            Datatype::Enum(a) => a.to_sexpr(),
-            Datatype::Flags(a) => a.to_sexpr(),
-            Datatype::Struct(a) => a.to_sexpr(),
-            Datatype::Union(a) => a.to_sexpr(),
-            Datatype::Handle(a) => a.to_sexpr(),
-            Datatype::Array(a) => {
-                SExpr::Vec(vec![SExpr::word("array"), a.to_sexpr()])
-            }
-            Datatype::Pointer(p) => SExpr::Vec(vec![
+            Type::Enum(a) => a.to_sexpr(),
+            Type::Flags(a) => a.to_sexpr(),
+            Type::Struct(a) => a.to_sexpr(),
+            Type::Union(a) => a.to_sexpr(),
+            Type::Handle(a) => a.to_sexpr(),
+            Type::Array(a) => SExpr::Vec(vec![SExpr::word("array"), a.to_sexpr()]),
+            Type::Pointer(p) => SExpr::Vec(vec![
                 SExpr::annot("witx"),
                 SExpr::word("pointer"),
                 p.to_sexpr(),
             ]),
-            Datatype::ConstPointer(p) => SExpr::Vec(vec![
+            Type::ConstPointer(p) => SExpr::Vec(vec![
                 SExpr::annot("witx"),
                 SExpr::word("const_pointer"),
                 p.to_sexpr(),
             ]),
-            Datatype::Builtin(b) => b.to_sexpr(),
+            Type::Builtin(b) => b.to_sexpr(),
         }
     }
 }
@@ -173,7 +171,7 @@ impl StructDatatype {
                     SExpr::Vec(vec![
                         SExpr::word("field"),
                         m.name.to_sexpr(),
-                        m.type_.to_sexpr(),
+                        m.tref.to_sexpr(),
                     ]),
                 )
             })
@@ -194,7 +192,7 @@ impl UnionDatatype {
                     SExpr::Vec(vec![
                         SExpr::word("field"),
                         v.name.to_sexpr(),
-                        v.type_.to_sexpr(),
+                        v.tref.to_sexpr(),
                     ]),
                 )
             })
@@ -272,7 +270,7 @@ impl InterfaceFunc {
                     SExpr::Vec(vec![
                         SExpr::word("param"),
                         f.name.to_sexpr(),
-                        f.type_.to_sexpr(),
+                        f.tref.to_sexpr(),
                     ]),
                 )
             })
@@ -286,7 +284,7 @@ impl InterfaceFunc {
                     SExpr::Vec(vec![
                         SExpr::word("result"),
                         f.name.to_sexpr(),
-                        f.type_.to_sexpr(),
+                        f.tref.to_sexpr(),
                     ]),
                 )
             })

--- a/tools/witx/src/toplevel.rs
+++ b/tools/witx/src/toplevel.rs
@@ -110,7 +110,7 @@ mod test {
         match &doc.datatype(&Id::new("b_float")).unwrap().variant {
             DatatypeVariant::Alias(a) => {
                 assert_eq!(a.name.as_str(), "b_float");
-                assert_eq!(a.to, DatatypeIdent::Builtin(BuiltinType::F64));
+                assert_eq!(a.to.variant, DatatypeVariant::Builtin(BuiltinType::F64));
             }
             other => panic!("expected alias, got {:?}", other),
         }
@@ -118,7 +118,7 @@ mod test {
         match &doc.datatype(&Id::new("c_int")).unwrap().variant {
             DatatypeVariant::Alias(a) => {
                 assert_eq!(a.name.as_str(), "c_int");
-                assert_eq!(a.to, DatatypeIdent::Builtin(BuiltinType::U32));
+                assert_eq!(a.to.variant, DatatypeVariant::Builtin(BuiltinType::U32));
             }
             other => panic!("expected alias, got {:?}", other),
         }
@@ -140,7 +140,7 @@ mod test {
         match &doc.datatype(&Id::new("d_char")).unwrap().variant {
             DatatypeVariant::Alias(a) => {
                 assert_eq!(a.name.as_str(), "d_char");
-                assert_eq!(a.to, DatatypeIdent::Builtin(BuiltinType::U8));
+                assert_eq!(a.to.variant, DatatypeVariant::Builtin(BuiltinType::U8));
             }
             other => panic!("expected alias, got {:?}", other),
         }

--- a/tools/witx/src/toplevel.rs
+++ b/tools/witx/src/toplevel.rs
@@ -107,11 +107,11 @@ mod test {
         )
         .expect("parse");
 
-        let b_float = doc.datatype(&Id::new("b_float")).unwrap();
-        assert_eq!(*b_float.datatype(), Datatype::Builtin(BuiltinType::F64));
+        let b_float = doc.typename(&Id::new("b_float")).unwrap();
+        assert_eq!(*b_float.type_(), Type::Builtin(BuiltinType::F64));
 
-        let c_int = doc.datatype(&Id::new("c_int")).unwrap();
-        assert_eq!(*c_int.datatype(), Datatype::Builtin(BuiltinType::U32));
+        let c_int = doc.typename(&Id::new("c_int")).unwrap();
+        assert_eq!(*c_int.type_(), Type::Builtin(BuiltinType::U32));
     }
 
     #[test]
@@ -127,8 +127,8 @@ mod test {
         )
         .expect("parse");
 
-        let d_char = doc.datatype(&Id::new("d_char")).unwrap();
-        assert_eq!(*d_char.datatype(), Datatype::Builtin(BuiltinType::U8));
+        let d_char = doc.typename(&Id::new("d_char")).unwrap();
+        assert_eq!(*d_char.type_(), Type::Builtin(BuiltinType::U8));
     }
 
     #[test]

--- a/tools/witx/src/toplevel.rs
+++ b/tools/witx/src/toplevel.rs
@@ -107,21 +107,11 @@ mod test {
         )
         .expect("parse");
 
-        match &doc.datatype(&Id::new("b_float")).unwrap().variant {
-            DatatypeVariant::Alias(a) => {
-                assert_eq!(a.name.as_str(), "b_float");
-                assert_eq!(a.to.variant, DatatypeVariant::Builtin(BuiltinType::F64));
-            }
-            other => panic!("expected alias, got {:?}", other),
-        }
+        let b_float = doc.datatype(&Id::new("b_float")).unwrap();
+        assert_eq!(*b_float.datatype(), Datatype::Builtin(BuiltinType::F64));
 
-        match &doc.datatype(&Id::new("c_int")).unwrap().variant {
-            DatatypeVariant::Alias(a) => {
-                assert_eq!(a.name.as_str(), "c_int");
-                assert_eq!(a.to.variant, DatatypeVariant::Builtin(BuiltinType::U32));
-            }
-            other => panic!("expected alias, got {:?}", other),
-        }
+        let c_int = doc.datatype(&Id::new("c_int")).unwrap();
+        assert_eq!(*c_int.datatype(), Datatype::Builtin(BuiltinType::U32));
     }
 
     #[test]
@@ -137,13 +127,8 @@ mod test {
         )
         .expect("parse");
 
-        match &doc.datatype(&Id::new("d_char")).unwrap().variant {
-            DatatypeVariant::Alias(a) => {
-                assert_eq!(a.name.as_str(), "d_char");
-                assert_eq!(a.to.variant, DatatypeVariant::Builtin(BuiltinType::U8));
-            }
-            other => panic!("expected alias, got {:?}", other),
-        }
+        let d_char = doc.datatype(&Id::new("d_char")).unwrap();
+        assert_eq!(*d_char.datatype(), Datatype::Builtin(BuiltinType::U8));
     }
 
     #[test]

--- a/tools/witx/src/validate.rs
+++ b/tools/witx/src/validate.rs
@@ -375,7 +375,7 @@ impl DocValidationScope<'_> {
                 match self.doc.entries.get(&id) {
                     Some(Entry::Datatype(weak_ref)) => {
                         let named_dt = weak_ref.upgrade().expect("weak backref to defined type");
-                        match &*named_dt.dt.deref() {
+                        match &*named_dt.datatype() {
                             Datatype::Handle { .. } => Ok(DatatypeRef::Name(named_dt)),
                             other => Err(ValidationError::WrongKindName {
                                 name: id_syntax.name().to_string(),
@@ -495,7 +495,7 @@ impl<'a> ModuleValidation<'a> {
                     .map(|(ix, f)| {
                         let type_ = self.doc.validate_datatype_ident(&f.item.type_)?;
                         if ix == 0 {
-                            match type_.deref().passed_by() {
+                            match type_.datatype().passed_by() {
                                 DatatypePassedBy::Value(_) => {}
                                 _ => Err(ValidationError::InvalidFirstResultType {
                                     location: self.doc.location(f.item.name.span()),

--- a/tools/witx/tests/multimodule.rs
+++ b/tools/witx/tests/multimodule.rs
@@ -1,4 +1,4 @@
-use witx::{load, BuiltinType, Datatype, DatatypeRef, Id};
+use witx::{load, BuiltinType, Id, Type, TypeRef};
 
 #[test]
 fn validate_multimodule() {
@@ -12,26 +12,32 @@ fn validate_multimodule() {
     //println!("{}", doc);
 
     // Check that the `a` both modules use is what we expect:
-    let type_a = doc.datatype(&Id::new("a")).expect("type a exists");
-    assert_eq!(*type_a.datatype(), Datatype::Builtin(BuiltinType::U32));
+    let type_a = doc.typename(&Id::new("a")).expect("type a exists");
+    assert_eq!(*type_a.type_(), Type::Builtin(BuiltinType::U32));
 
     // `b` is a struct with a single member of type `a`
-    let type_b = doc.datatype(&Id::new("b")).expect("type b exists");
-    match &*type_b.datatype() {
-        Datatype::Struct(struct_) => {
+    let type_b = doc.typename(&Id::new("b")).expect("type b exists");
+    match &*type_b.type_() {
+        Type::Struct(struct_) => {
             assert_eq!(struct_.members.len(), 1);
-            assert_eq!(struct_.members.get(0).unwrap().type_, DatatypeRef::Name(type_a.clone()));
+            assert_eq!(
+                struct_.members.get(0).unwrap().tref,
+                TypeRef::Name(type_a.clone())
+            );
         }
         _ => panic!("b is a struct"),
     }
 
     // `c` is a struct with a two members of type `a`
-    let type_c = doc.datatype(&Id::new("c")).expect("type c exists");
-    match &*type_c.datatype() {
-        Datatype::Struct(struct_) => {
+    let type_c = doc.typename(&Id::new("c")).expect("type c exists");
+    match &*type_c.type_() {
+        Type::Struct(struct_) => {
             assert_eq!(struct_.members.len(), 2);
-            assert_eq!(struct_.members.get(0).unwrap().type_, DatatypeRef::Name(type_a.clone()));
-            assert_eq!(struct_.members.get(1).unwrap().type_, DatatypeRef::Name(type_a));
+            assert_eq!(
+                struct_.members.get(0).unwrap().tref,
+                TypeRef::Name(type_a.clone())
+            );
+            assert_eq!(struct_.members.get(1).unwrap().tref, TypeRef::Name(type_a));
         }
         _ => panic!("c is a struct"),
     }

--- a/tools/witx/tests/multimodule.rs
+++ b/tools/witx/tests/multimodule.rs
@@ -1,4 +1,4 @@
-use witx::{load, BuiltinType, DatatypeVariant, Id};
+use witx::{load, BuiltinType, Datatype, DatatypeRef, Id};
 
 #[test]
 fn validate_multimodule() {
@@ -13,31 +13,25 @@ fn validate_multimodule() {
 
     // Check that the `a` both modules use is what we expect:
     let type_a = doc.datatype(&Id::new("a")).expect("type a exists");
-    match &type_a.variant {
-        DatatypeVariant::Alias(alias) => match alias.to.variant {
-            DatatypeVariant::Builtin(b) => assert_eq!(b, BuiltinType::U32),
-            _ => panic!("a is an alias u32"),
-        },
-        _ => panic!("a is an alias to u32"),
-    }
+    assert_eq!(*type_a.datatype(), Datatype::Builtin(BuiltinType::U32));
 
     // `b` is a struct with a single member of type `a`
     let type_b = doc.datatype(&Id::new("b")).expect("type b exists");
-    match &type_b.variant {
-        DatatypeVariant::Struct(struct_) => {
+    match &*type_b.datatype() {
+        Datatype::Struct(struct_) => {
             assert_eq!(struct_.members.len(), 1);
-            assert_eq!(struct_.members.get(0).unwrap().type_, type_a);
+            assert_eq!(struct_.members.get(0).unwrap().type_, DatatypeRef::Name(type_a.clone()));
         }
         _ => panic!("b is a struct"),
     }
 
     // `c` is a struct with a two members of type `a`
     let type_c = doc.datatype(&Id::new("c")).expect("type c exists");
-    match &type_c.variant {
-        DatatypeVariant::Struct(struct_) => {
+    match &*type_c.datatype() {
+        Datatype::Struct(struct_) => {
             assert_eq!(struct_.members.len(), 2);
-            assert_eq!(struct_.members.get(0).unwrap().type_, type_a);
-            assert_eq!(struct_.members.get(1).unwrap().type_, type_a);
+            assert_eq!(struct_.members.get(0).unwrap().type_, DatatypeRef::Name(type_a.clone()));
+            assert_eq!(struct_.members.get(1).unwrap().type_, DatatypeRef::Name(type_a));
         }
         _ => panic!("c is a struct"),
     }

--- a/tools/witx/tests/multimodule.rs
+++ b/tools/witx/tests/multimodule.rs
@@ -1,4 +1,4 @@
-use witx::{load, BuiltinType, DatatypeIdent, DatatypeVariant, Id};
+use witx::{load, BuiltinType, DatatypeVariant, Id};
 
 #[test]
 fn validate_multimodule() {
@@ -9,13 +9,13 @@ fn validate_multimodule() {
     ])
     .unwrap_or_else(|e| panic!("failed to validate: {}", e));
 
-    println!("{}", doc);
+    //println!("{}", doc);
 
     // Check that the `a` both modules use is what we expect:
     let type_a = doc.datatype(&Id::new("a")).expect("type a exists");
     match &type_a.variant {
-        DatatypeVariant::Alias(alias) => match alias.to {
-            DatatypeIdent::Builtin(b) => assert_eq!(b, BuiltinType::U32),
+        DatatypeVariant::Alias(alias) => match alias.to.variant {
+            DatatypeVariant::Builtin(b) => assert_eq!(b, BuiltinType::U32),
             _ => panic!("a is an alias u32"),
         },
         _ => panic!("a is an alias to u32"),
@@ -26,10 +26,7 @@ fn validate_multimodule() {
     match &type_b.variant {
         DatatypeVariant::Struct(struct_) => {
             assert_eq!(struct_.members.len(), 1);
-            match &struct_.members.get(0).unwrap().type_ {
-                DatatypeIdent::Ident(member_a) => assert_eq!(*member_a, type_a),
-                _ => panic!("b.0 has type a"),
-            }
+            assert_eq!(struct_.members.get(0).unwrap().type_, type_a);
         }
         _ => panic!("b is a struct"),
     }
@@ -39,14 +36,8 @@ fn validate_multimodule() {
     match &type_c.variant {
         DatatypeVariant::Struct(struct_) => {
             assert_eq!(struct_.members.len(), 2);
-            match &struct_.members.get(0).unwrap().type_ {
-                DatatypeIdent::Ident(member_a) => assert_eq!(*member_a, type_a),
-                _ => panic!("c.0 has type a"),
-            }
-            match &struct_.members.get(1).unwrap().type_ {
-                DatatypeIdent::Ident(member_a) => assert_eq!(*member_a, type_a),
-                _ => panic!("c.1 has type a"),
-            }
+            assert_eq!(struct_.members.get(0).unwrap().type_, type_a);
+            assert_eq!(struct_.members.get(1).unwrap().type_, type_a);
         }
         _ => panic!("c is a struct"),
     }

--- a/tools/witx/tests/wasi.rs
+++ b/tools/witx/tests/wasi.rs
@@ -35,7 +35,7 @@ fn render_roundtrip() {
     if doc != doc2 {
         for type_ in doc.datatypes() {
             let type2 = doc2
-                .datatype(&type_.name.as_ref().expect("iterator gives named datatypes"))
+                .datatype(&type_.name)
                 .expect("doc2 missing datatype");
             assert_eq!(type_, type2);
         }

--- a/tools/witx/tests/wasi.rs
+++ b/tools/witx/tests/wasi.rs
@@ -33,9 +33,9 @@ fn render_roundtrip() {
     // I'd just assert_eq, but when it fails the debug print is thousands of lines long and impossible
     // to figure out where they are unequal.
     if doc != doc2 {
-        for type_ in doc.datatypes() {
+        for type_ in doc.typenames() {
             let type2 = doc2
-                .datatype(&type_.name)
+                .typename(&type_.name)
                 .expect("doc2 missing datatype");
             assert_eq!(type_, type2);
         }

--- a/tools/witx/tests/wasi.rs
+++ b/tools/witx/tests/wasi.rs
@@ -34,7 +34,9 @@ fn render_roundtrip() {
     // to figure out where they are unequal.
     if doc != doc2 {
         for type_ in doc.datatypes() {
-            let type2 = doc2.datatype(&type_.name).expect("doc2 missing datatype");
+            let type2 = doc2
+                .datatype(&type_.name.as_ref().expect("iterator gives named datatypes"))
+                .expect("doc2 missing datatype");
             assert_eq!(type_, type2);
         }
         for mod_ in doc.modules() {

--- a/tools/witx/tests/wasi.rs
+++ b/tools/witx/tests/wasi.rs
@@ -34,9 +34,7 @@ fn render_roundtrip() {
     // to figure out where they are unequal.
     if doc != doc2 {
         for type_ in doc.typenames() {
-            let type2 = doc2
-                .typename(&type_.name)
-                .expect("doc2 missing datatype");
+            let type2 = doc2.typename(&type_.name).expect("doc2 missing datatype");
             assert_eq!(type_, type2);
         }
         for mod_ in doc.modules() {
@@ -53,4 +51,15 @@ fn render_roundtrip() {
     }
     // This should be equivelant to the above, but just in case some code changes where it isnt:
     assert_eq!(doc, doc2);
+}
+
+#[test]
+fn document_wasi_snapshot() {
+    use witx::Documentation;
+    println!(
+        "{}",
+        witx::load(&["../../phases/snapshot/witx/wasi_snapshot_preview1.witx"])
+            .unwrap_or_else(|e| panic!("failed to parse: {}", e))
+            .to_md()
+    );
 }


### PR DESCRIPTION
The `witx::ast` types had some confusing choices that I blame on building the first draft of the tool in a hurry. This redesigns the AST a bit:
* I used `Datatype`/`datatype` in a number of places where witx syntax and wasm just call things `type`s. The data-prefix has been dropped in many places. `StructDatatype`, `UnionDatatype` and friends still retain the "data" part of the name, but that seems less problematic.
* instead of two enumerations (`DatatypeIdent` and `DatatypeVariant`) holding different variations (arrays and pointers and builtins falling under Ident, everything else in variant) there is now just one enum `Type` that has each possible variation in a datatype
* `Type`s can either be anonymous (e.g. an `(array u8)` in a function argument) or named (by `(typename ...)`. An  `enum TypeRef` gives a type either by `Value(Type)` or `Name(NamedType)`.
* Only `NamedType`s have docs.
* Instead of considering Aliases as a variation of a datatype, they are now encoded using TypeRef: `(typename $a u32)` is a `NamedType { name: "a", dt: TypeRef::Value(Type::Builtin(BuiltinType::U32)) }`.

I was able to change the `wasi-headers` tool over in `wasi-libc` to consume the new witx ast pretty quickly, and it even managed to fix a minor bug involving aliasing. I'll send a PR there and also to the other `witx`-using crate in `https://github.com/bytecodealliance/wasi` shortly.