### PR TITLE
Switch `witx` crate from using `failure` to `thiserror`, bump to 0.6.0

### DIFF
--- a/tools/witx/Cargo.toml
+++ b/tools/witx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "witx"
-version = "0.5.0"
+version = "0.6.0"
 description = "Parse and validate witx file format"
 homepage = "https://github.com/WebAssembly/WASI"
 repository = "https://github.com/WebAssembly/WASI"

--- a/tools/witx/Cargo.toml
+++ b/tools/witx/Cargo.toml
@@ -20,4 +20,4 @@ path = "src/main.rs"
 [dependencies]
 clap = "2"
 wast = "3.0.4"
-failure = "0.1"
+thiserror = "1.0"

--- a/tools/witx/src/lib.rs
+++ b/tools/witx/src/lib.rs
@@ -29,8 +29,8 @@ pub use parser::DeclSyntax;
 pub use render::SExpr;
 pub use validate::ValidationError;
 
-use failure::Fail;
 use std::path::{Path, PathBuf};
+use thiserror::Error;
 
 /// Load a witx document from the filesystem
 pub fn load<P: AsRef<Path>>(paths: &[P]) -> Result<Document, WitxError> {
@@ -51,14 +51,14 @@ pub struct Location {
     pub column: usize,
 }
 
-#[derive(Debug, Fail)]
+#[derive(Debug, Error)]
 pub enum WitxError {
-    #[fail(display = "with file {:?}: {}", _0, _1)]
-    Io(PathBuf, #[cause] ::std::io::Error),
-    #[fail(display = "{}", _0)]
-    Parse(#[cause] wast::Error),
-    #[fail(display = "{}", _0)]
-    Validation(#[cause] ValidationError),
+    #[error("IO error with file {0:?}")]
+    Io(PathBuf, #[source] ::std::io::Error),
+    #[error("Parse error")]
+    Parse(#[from] wast::Error),
+    #[error("Validation error")]
+    Validation(#[from] ValidationError),
 }
 
 impl WitxError {

--- a/tools/witx/src/validate.rs
+++ b/tools/witx/src/validate.rs
@@ -9,39 +9,36 @@ use crate::{
     Location, Module, ModuleDefinition, ModuleEntry, ModuleImport, ModuleImportVariant, NamedType,
     StructDatatype, StructMember, Type, TypePassedBy, TypeRef, UnionDatatype, UnionVariant,
 };
-use failure::Fail;
 use std::collections::HashMap;
 use std::path::Path;
 use std::rc::Rc;
+use thiserror::Error;
 
-#[derive(Debug, Fail)]
+#[derive(Debug, Error)]
 pub enum ValidationError {
-    #[fail(display = "Unknown name `{}`", name)]
+    #[error("Unknown name `{name}`")]
     UnknownName { name: String, location: Location },
-    #[fail(display = "Redefinition of name `{}`", name)]
+    #[error("Redefinition of name `{name}`")]
     NameAlreadyExists {
         name: String,
         at_location: Location,
         previous_location: Location,
     },
-    #[fail(
-        display = "Wrong kind of name `{}`: expected {}, got {}",
-        name, expected, got
-    )]
+    #[error("Wrong kind of name `{name}`: expected {expected}, got {got}")]
     WrongKindName {
         name: String,
         location: Location,
         expected: &'static str,
         got: &'static str,
     },
-    #[fail(display = "Recursive definition of name `{}`", name)]
+    #[error("Recursive definition of name `{name}`")]
     Recursive { name: String, location: Location },
-    #[fail(display = "Invalid representation `{:?}`", repr)]
+    #[error("Invalid representation `{repr:?}`")]
     InvalidRepr {
         repr: BuiltinType,
         location: Location,
     },
-    #[fail(display = "First result type must be pass-by-value")]
+    #[error("First result type must be pass-by-value")]
     InvalidFirstResultType { location: Location },
 }
 


### PR DESCRIPTION
Straightforward upgrade of the error deriving crate. I'll publish this as 0.6.0 once merged.