### PR TITLE
Add a `usize` type to indicate types which will change size on wasm64.

### DIFF
--- a/phases/ephemeral/witx/typenames.witx
+++ b/phases/ephemeral/witx/typenames.witx
@@ -5,7 +5,7 @@
 ;; This is a `witx` file. See [here](https://github.com/WebAssembly/WASI/tree/master/docs/witx.md)
 ;; for an explanation of what that means.
 
-(typename $size u32)
+(typename $size (@witx usize))
 
 ;;; Non-negative file size or length of a region within a file.
 (typename $filesize u64)

--- a/tools/witx/src/ast.rs
+++ b/tools/witx/src/ast.rs
@@ -149,6 +149,7 @@ pub enum Type {
     Array(TypeRef),
     Pointer(TypeRef),
     ConstPointer(TypeRef),
+    USize,
     Builtin(BuiltinType),
 }
 
@@ -164,6 +165,7 @@ impl Type {
             Array(_) => "array",
             Pointer(_) => "pointer",
             ConstPointer(_) => "constpointer",
+            USize => "usize",
             Builtin(_) => "builtin",
         }
     }

--- a/tools/witx/src/coretypes.rs
+++ b/tools/witx/src/coretypes.rs
@@ -47,7 +47,9 @@ impl Type {
                 BuiltinType::F64 => TypePassedBy::Value(AtomType::F64),
             },
             Type::Array { .. } => TypePassedBy::PointerLengthPair,
-            Type::Pointer { .. } | Type::ConstPointer { .. } => TypePassedBy::Value(AtomType::I32),
+            Type::Pointer { .. } | Type::ConstPointer { .. } | Type::USize => {
+                TypePassedBy::Value(AtomType::I32)
+            }
             Type::Enum(e) => TypePassedBy::Value(e.repr.into()),
             Type::Flags(f) => TypePassedBy::Value(f.repr.into()),
             Type::Struct { .. } | Type::Union { .. } => TypePassedBy::Pointer,

--- a/tools/witx/src/docs.rs
+++ b/tools/witx/src/docs.rs
@@ -51,6 +51,7 @@ impl Documentation for NamedType {
                 Type::Array(a) => format!("Array of {}", a.type_name()),
                 Type::Pointer(a) => format!("Pointer to {}", a.type_name()),
                 Type::ConstPointer(a) => format!("Constant Pointer to {}", a.type_name()),
+                Type::USize => format!("USize"),
                 Type::Builtin(a) => format!("Builtin type {}", a.type_name()),
             },
             TypeRef::Name(n) => format!("Alias to {}", n.name.as_str()),
@@ -67,6 +68,7 @@ impl TypeRef {
                 Type::Array(a) => format!("Array<{}>", a.type_name()),
                 Type::Pointer(p) => format!("Pointer<{}>", p.type_name()),
                 Type::ConstPointer(p) => format!("ConstPointer<{}>", p.type_name()),
+                Type::USize => format!("USize"),
                 Type::Builtin(b) => b.type_name().to_string(),
                 Type::Enum { .. }
                 | Type::Flags { .. }

--- a/tools/witx/src/layout.rs
+++ b/tools/witx/src/layout.rs
@@ -29,7 +29,9 @@ impl TypeRef {
             Type::Union(u) => u.layout(cache),
             Type::Handle(h) => h.mem_size_align(),
             Type::Array { .. } => BuiltinType::String.mem_size_align(),
-            Type::Pointer { .. } | Type::ConstPointer { .. } => BuiltinType::U32.mem_size_align(),
+            Type::Pointer { .. } | Type::ConstPointer { .. } | Type::USize => {
+                BuiltinType::U32.mem_size_align()
+            }
             Type::Builtin(b) => b.mem_size_align(),
         };
         cache.insert(self.clone(), layout);

--- a/tools/witx/src/parser.rs
+++ b/tools/witx/src/parser.rs
@@ -40,6 +40,7 @@ mod kw {
     wast::custom_keyword!(u32);
     wast::custom_keyword!(u64);
     wast::custom_keyword!(u8);
+    wast::custom_keyword!(usize);
 }
 
 impl Parse<'_> for BuiltinType {
@@ -306,6 +307,7 @@ pub enum TypedefSyntax<'a> {
     Array(Box<TypedefSyntax<'a>>),
     Pointer(Box<TypedefSyntax<'a>>),
     ConstPointer(Box<TypedefSyntax<'a>>),
+    USize,
     Builtin(BuiltinType),
     Ident(wast::Id<'a>),
 }
@@ -342,6 +344,9 @@ impl<'a> Parse<'a> for TypedefSyntax<'a> {
                     } else if l.peek::<kw::pointer>() {
                         parser.parse::<kw::pointer>()?;
                         Ok(TypedefSyntax::Pointer(Box::new(parser.parse()?)))
+                    } else if l.peek::<kw::usize>() {
+                        parser.parse::<kw::usize>()?;
+                        Ok(TypedefSyntax::USize)
                     } else {
                         Err(l.error())
                     }

--- a/tools/witx/src/render.rs
+++ b/tools/witx/src/render.rs
@@ -130,6 +130,7 @@ impl Type {
                 SExpr::word("const_pointer"),
                 p.to_sexpr(),
             ]),
+            Type::USize => SExpr::Vec(vec![SExpr::annot("witx"), SExpr::word("usize")]),
             Type::Builtin(b) => b.to_sexpr(),
         }
     }

--- a/tools/witx/src/validate.rs
+++ b/tools/witx/src/validate.rs
@@ -236,6 +236,7 @@ impl DocValidationScope<'_> {
                 TypedefSyntax::ConstPointer(syntax) => {
                     Type::ConstPointer(self.validate_datatype(syntax, span)?)
                 }
+                TypedefSyntax::USize => Type::USize,
                 TypedefSyntax::Builtin(builtin) => Type::Builtin(*builtin),
                 TypedefSyntax::Ident { .. } => unreachable!(),
             }))),


### PR DESCRIPTION
This will allow code generators to know which types are sensitive to
wasm32 vs wasm64 without special-casing the `size` type.