### PR TITLE
Add a noreturn keyword to annotate functions expected to not return.

### DIFF
--- a/phases/ephemeral/witx/wasi_ephemeral_proc.witx
+++ b/phases/ephemeral/witx/wasi_ephemeral_proc.witx
@@ -14,5 +14,6 @@
   (@interface func (export "exit")
     ;;; The exit code returned by the process.
     (param $rval $exitcode)
+    (@witx noreturn)
   )
 )

--- a/tools/witx/src/ast.rs
+++ b/tools/witx/src/ast.rs
@@ -361,6 +361,7 @@ pub struct InterfaceFunc {
     pub name: Id,
     pub params: Vec<InterfaceFuncParam>,
     pub results: Vec<InterfaceFuncParam>,
+    pub noreturn: bool,
     pub docs: String,
 }
 

--- a/tools/witx/src/render.rs
+++ b/tools/witx/src/render.rs
@@ -289,6 +289,14 @@ impl InterfaceFunc {
                 )
             })
             .collect();
-        SExpr::docs(&self.docs, SExpr::Vec([header, params, results].concat()))
+        let attrs = if self.noreturn {
+            vec![SExpr::annot("witx"), SExpr::word("noreturn")]
+        } else {
+            vec![]
+        };
+        SExpr::docs(
+            &self.docs,
+            SExpr::Vec([header, params, results, attrs].concat()),
+        )
     }
 }

--- a/tools/witx/src/validate.rs
+++ b/tools/witx/src/validate.rs
@@ -466,11 +466,13 @@ impl<'a> ModuleValidation<'a> {
                         })
                     })
                     .collect::<Result<Vec<_>, _>>()?;
+                let noreturn = syntax.noreturn;
 
                 let rc_func = Rc::new(InterfaceFunc {
                     name: name.clone(),
                     params,
                     results,
+                    noreturn,
                     docs: decl.comments.docs(),
                 });
                 self.entries


### PR DESCRIPTION
This will allow us to automatically add `_Noreturn` to `proc_exit` in C,
and `-> !` in Rust, rather than special-casing it.