### PR TITLE
Add a char8 type to represent data which is expected to be valid UTF-8.

### DIFF
--- a/phases/ephemeral/witx/wasi_ephemeral_args.witx
+++ b/phases/ephemeral/witx/wasi_ephemeral_args.witx
@@ -12,8 +12,8 @@
   ;;; Read command-line argument data.
   ;;; The size of the array should match that returned by `sizes_get`
   (@interface func (export "get")
-    (param $argv (@witx pointer (@witx pointer u8)))
-    (param $argv_buf (@witx pointer u8))
+    (param $argv (@witx pointer (@witx pointer char8)))
+    (param $argv_buf (@witx pointer char8))
     (result $error $errno)
   )
 

--- a/phases/ephemeral/witx/wasi_ephemeral_environ.witx
+++ b/phases/ephemeral/witx/wasi_ephemeral_environ.witx
@@ -12,8 +12,8 @@
   ;;; Read environment variable data.
   ;;; The sizes of the buffers should match that returned by `sizes_get`.
   (@interface func (export "get")
-    (param $environ (@witx pointer (@witx pointer u8)))
-    (param $environ_buf (@witx pointer u8))
+    (param $environ (@witx pointer (@witx pointer char8)))
+    (param $environ_buf (@witx pointer char8))
     (result $error $errno)
   )
 

--- a/phases/ephemeral/witx/wasi_ephemeral_fd.witx
+++ b/phases/ephemeral/witx/wasi_ephemeral_fd.witx
@@ -132,7 +132,7 @@
   (@interface func (export "prestat_dir_name")
     (param $fd $fd)
     ;;; A buffer into which to write the preopened directory name.
-    (param $path (@witx pointer u8))
+    (param $path (@witx pointer char8))
     (param $path_len $size)
     (result $error $errno)
   )

--- a/phases/ephemeral/witx/wasi_ephemeral_path.witx
+++ b/phases/ephemeral/witx/wasi_ephemeral_path.witx
@@ -106,7 +106,7 @@
     ;;; The path of the symbolic link from which to read.
     (param $path string)
     ;;; The buffer to which to write the contents of the symbolic link.
-    (param $buf (@witx pointer u8))
+    (param $buf (@witx pointer char8))
     (param $buf_len $size)
     (result $error $errno)
     ;;; The number of bytes placed in the buffer.

--- a/phases/ephemeral/witx/wasi_ephemeral_random.witx
+++ b/phases/ephemeral/witx/wasi_ephemeral_random.witx
@@ -19,7 +19,7 @@
   ;;; number generator, rather than to provide the random data directly.
   (@interface func (export "get")
     ;;; The buffer to fill with random data.
-    (param $buf (@witx pointer u8))
+    (param $buf (@witx pointer char8))
     (param $buf_len $size)
     (result $error $errno)
   )

--- a/tools/witx/src/ast.rs
+++ b/tools/witx/src/ast.rs
@@ -172,6 +172,7 @@ impl Type {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum BuiltinType {
     String,
+    Char8,
     U8,
     U16,
     U32,

--- a/tools/witx/src/coretypes.rs
+++ b/tools/witx/src/coretypes.rs
@@ -41,7 +41,8 @@ impl Type {
                 | BuiltinType::U32
                 | BuiltinType::S8
                 | BuiltinType::S16
-                | BuiltinType::S32 => TypePassedBy::Value(AtomType::I32),
+                | BuiltinType::S32
+                | BuiltinType::Char8 => TypePassedBy::Value(AtomType::I32),
                 BuiltinType::U64 | BuiltinType::S64 => TypePassedBy::Value(AtomType::I64),
                 BuiltinType::F32 => TypePassedBy::Value(AtomType::F32),
                 BuiltinType::F64 => TypePassedBy::Value(AtomType::F64),

--- a/tools/witx/src/docs.rs
+++ b/tools/witx/src/docs.rs
@@ -25,6 +25,7 @@ impl BuiltinType {
     pub fn type_name(&self) -> &'static str {
         match self {
             BuiltinType::String => "string",
+            BuiltinType::Char8 => "char8",
             BuiltinType::U8 => "u8",
             BuiltinType::U16 => "u16",
             BuiltinType::U32 => "u32",

--- a/tools/witx/src/layout.rs
+++ b/tools/witx/src/layout.rs
@@ -170,7 +170,9 @@ impl Layout for BuiltinType {
     fn mem_size_align(&self) -> SizeAlign {
         match self {
             BuiltinType::String => SizeAlign { size: 8, align: 4 }, // Pointer and Length
-            BuiltinType::U8 | BuiltinType::S8 => SizeAlign { size: 1, align: 1 },
+            BuiltinType::U8 | BuiltinType::S8 | BuiltinType::Char8 => {
+                SizeAlign { size: 1, align: 1 }
+            }
             BuiltinType::U16 | BuiltinType::S16 => SizeAlign { size: 2, align: 2 },
             BuiltinType::U32 | BuiltinType::S32 | BuiltinType::F32 => {
                 SizeAlign { size: 4, align: 4 }

--- a/tools/witx/src/parser.rs
+++ b/tools/witx/src/parser.rs
@@ -19,6 +19,7 @@ mod kw {
     pub use wast::kw::{export, func, import, memory, module, param, result};
 
     wast::custom_keyword!(array);
+    wast::custom_keyword!(char8);
     wast::custom_keyword!(const_pointer);
     wast::custom_keyword!(f32);
     wast::custom_keyword!(f64);
@@ -48,6 +49,9 @@ impl Parse<'_> for BuiltinType {
         if l.peek::<kw::string>() {
             parser.parse::<kw::string>()?;
             Ok(BuiltinType::String)
+        } else if l.peek::<kw::char8>() {
+            parser.parse::<kw::char8>()?;
+            Ok(BuiltinType::Char8)
         } else if l.peek::<kw::u8>() {
             parser.parse::<kw::u8>()?;
             Ok(BuiltinType::U8)
@@ -87,6 +91,7 @@ impl Parse<'_> for BuiltinType {
 impl wast::parser::Peek for BuiltinType {
     fn peek(cursor: wast::parser::Cursor<'_>) -> bool {
         <kw::string as Peek>::peek(cursor)
+            || <kw::char8 as Peek>::peek(cursor)
             || <kw::u8 as Peek>::peek(cursor)
             || <kw::u16 as Peek>::peek(cursor)
             || <kw::u32 as Peek>::peek(cursor)

--- a/tools/witx/src/render.rs
+++ b/tools/witx/src/render.rs
@@ -78,6 +78,7 @@ impl BuiltinType {
     pub fn to_sexpr(&self) -> SExpr {
         match self {
             BuiltinType::String => SExpr::word("string"),
+            BuiltinType::Char8 => SExpr::word("char8"),
             BuiltinType::U8 => SExpr::word("u8"),
             BuiltinType::U16 => SExpr::word("u16"),
             BuiltinType::U32 => SExpr::word("u32"),


### PR DESCRIPTION
This will allow the generated C header file to use [char8_t].

[char8_t]: https://en.cppreference.com/w/cpp/keyword/char8_t

Fixes #6.