### PR TITLE
Compute layout of datatypes according to C ABI

### DIFF
--- a/tools/witx/src/layout.rs
+++ b/tools/witx/src/layout.rs
@@ -3,8 +3,8 @@ use std::collections::HashMap;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SizeAlign {
-    size: usize,
-    align: usize,
+    pub size: usize,
+    pub align: usize,
 }
 
 pub trait Layout {

--- a/tools/witx/src/layout.rs
+++ b/tools/witx/src/layout.rs
@@ -148,6 +148,7 @@ impl UnionDatatype {
             .map(|sa| sa.align)
             .max()
             .expect("nonzero variants");
+        let size = align_to(size, align);
         SizeAlign { size, align }
     }
 }

--- a/tools/witx/src/layout.rs
+++ b/tools/witx/src/layout.rs
@@ -27,7 +27,7 @@ impl TypeRef {
             Type::Flags(f) => f.repr.mem_size_align(),
             Type::Struct(s) => s.layout(cache),
             Type::Union(u) => u.layout(cache),
-            Type::Handle { .. } => BuiltinType::U32.mem_size_align(),
+            Type::Handle(h) => h.mem_size_align(),
             Type::Array { .. } => BuiltinType::String.mem_size_align(),
             Type::Pointer { .. } | Type::ConstPointer { .. } => BuiltinType::U32.mem_size_align(),
             Type::Builtin(b) => b.mem_size_align(),
@@ -156,6 +156,12 @@ impl Layout for UnionDatatype {
     fn mem_size_align(&self) -> SizeAlign {
         let mut cache = HashMap::new();
         self.layout(&mut cache)
+    }
+}
+
+impl Layout for HandleDatatype {
+    fn mem_size_align(&self) -> SizeAlign {
+        BuiltinType::U32.mem_size_align()
     }
 }
 

--- a/tools/witx/src/layout.rs
+++ b/tools/witx/src/layout.rs
@@ -125,7 +125,22 @@ mod test {
 
 impl UnionDatatype {
     pub fn layout(&self, cache: &mut HashMap<TypeRef, SizeAlign>) -> SizeAlign {
-        unimplemented!()
+        let sas = self
+            .variants
+            .iter()
+            .map(|v| v.tref.layout(cache))
+            .collect::<Vec<SizeAlign>>();
+        let size = sas
+            .iter()
+            .map(|sa| sa.size)
+            .max()
+            .expect("nonzero variants");
+        let align = sas
+            .iter()
+            .map(|sa| sa.align)
+            .max()
+            .expect("nonzero variants");
+        SizeAlign { size, align }
     }
 }
 

--- a/tools/witx/src/lib.rs
+++ b/tools/witx/src/lib.rs
@@ -7,7 +7,7 @@ mod docs;
 /// Interface for filesystem or mock IO
 mod io;
 /// Calculate memory layout of types
-pub mod layout;
+mod layout;
 /// Witx syntax parsing from SExprs
 mod parser;
 /// Calculate required polyfill between interfaces
@@ -31,6 +31,7 @@ pub use ast::{
 pub use coretypes::{AtomType, CoreFuncType, CoreParamSignifies, CoreParamType, TypePassedBy};
 pub use docs::Documentation;
 pub use io::{Filesystem, MockFs, WitxIo};
+pub use layout::{Layout, SizeAlign, StructMemberLayout};
 pub use parser::DeclSyntax;
 pub use render::SExpr;
 pub use representation::{RepEquality, Representable};

--- a/tools/witx/src/render.rs
+++ b/tools/witx/src/render.rs
@@ -47,19 +47,19 @@ impl fmt::Display for SExpr {
 }
 
 impl SExpr {
-    fn word(s: &str) -> SExpr {
+    pub fn word(s: &str) -> SExpr {
         SExpr::Word(s.to_string())
     }
-    fn ident(s: &str) -> SExpr {
+    pub fn ident(s: &str) -> SExpr {
         SExpr::Ident(s.to_string())
     }
-    fn quote(s: &str) -> SExpr {
+    pub fn quote(s: &str) -> SExpr {
         SExpr::Quote(s.to_string())
     }
-    fn annot(s: &str) -> SExpr {
+    pub fn annot(s: &str) -> SExpr {
         SExpr::Annot(s.to_string())
     }
-    fn docs(d: &str, s: SExpr) -> SExpr {
+    pub fn docs(d: &str, s: SExpr) -> SExpr {
         if d.is_empty() {
             s
         } else {


### PR DESCRIPTION
Based on #164 

This is useful for validating pointers, enums, and flags in host code.