### PR TITLE
witx: exclude structs, unions, enums, flags, and handles from being declared anonymously

### DIFF
--- a/tools/witx/src/validate.rs
+++ b/tools/witx/src/validate.rs
@@ -40,6 +40,8 @@ pub enum ValidationError {
     },
     #[error("First result type must be pass-by-value")]
     InvalidFirstResultType { location: Location },
+    #[error("Anonymous structured types (struct, union, enum, flags, handle) are not permitted")]
+    AnonymousStructure { location: Location },
 }
 
 impl ValidationError {
@@ -50,7 +52,8 @@ impl ValidationError {
             | WrongKindName { location, .. }
             | Recursive { location, .. }
             | InvalidRepr { location, .. }
-            | InvalidFirstResultType { location, .. } => {
+            | InvalidFirstResultType { location, .. }
+            | AnonymousStructure { location, .. } => {
                 format!("{}\n{}", location.highlight_source_with(witxio), &self)
             }
             NameAlreadyExists {
@@ -164,7 +167,7 @@ impl DocValidationScope<'_> {
             DeclSyntax::Typename(decl) => {
                 let name = self.introduce(&decl.ident)?;
                 let docs = comments.docs();
-                let tref = self.validate_datatype(&decl.def, decl.ident.span())?;
+                let tref = self.validate_datatype(&decl.def, true, decl.ident.span())?;
 
                 let rc_datatype = Rc::new(NamedType {
                     name: name.clone(),
@@ -202,6 +205,7 @@ impl DocValidationScope<'_> {
     fn validate_datatype(
         &self,
         syntax: &TypedefSyntax,
+        named: bool,
         span: wast::Span,
     ) -> Result<TypeRef, ValidationError> {
         match syntax {
@@ -223,18 +227,31 @@ impl DocValidationScope<'_> {
                     }),
                 }
             }
+            TypedefSyntax::Enum { .. }
+            | TypedefSyntax::Flags { .. }
+            | TypedefSyntax::Struct { .. }
+            | TypedefSyntax::Union { .. }
+            | TypedefSyntax::Handle { .. }
+                if !named =>
+            {
+                Err(ValidationError::AnonymousStructure {
+                    location: self.location(span),
+                })
+            }
             other => Ok(TypeRef::Value(Rc::new(match other {
                 TypedefSyntax::Enum(syntax) => Type::Enum(self.validate_enum(&syntax, span)?),
                 TypedefSyntax::Flags(syntax) => Type::Flags(self.validate_flags(&syntax, span)?),
                 TypedefSyntax::Struct(syntax) => Type::Struct(self.validate_struct(&syntax, span)?),
                 TypedefSyntax::Union(syntax) => Type::Union(self.validate_union(&syntax, span)?),
                 TypedefSyntax::Handle(syntax) => Type::Handle(self.validate_handle(syntax, span)?),
-                TypedefSyntax::Array(syntax) => Type::Array(self.validate_datatype(syntax, span)?),
+                TypedefSyntax::Array(syntax) => {
+                    Type::Array(self.validate_datatype(syntax, false, span)?)
+                }
                 TypedefSyntax::Pointer(syntax) => {
-                    Type::Pointer(self.validate_datatype(syntax, span)?)
+                    Type::Pointer(self.validate_datatype(syntax, false, span)?)
                 }
                 TypedefSyntax::ConstPointer(syntax) => {
-                    Type::ConstPointer(self.validate_datatype(syntax, span)?)
+                    Type::ConstPointer(self.validate_datatype(syntax, false, span)?)
                 }
                 TypedefSyntax::Builtin(builtin) => Type::Builtin(*builtin),
                 TypedefSyntax::Ident { .. } => unreachable!(),
@@ -294,7 +311,7 @@ impl DocValidationScope<'_> {
             .map(|f| {
                 let name = member_scope
                     .introduce(f.item.name.name(), self.location(f.item.name.span()))?;
-                let tref = self.validate_datatype(&f.item.type_, f.item.name.span())?;
+                let tref = self.validate_datatype(&f.item.type_, false, f.item.name.span())?;
                 let docs = f.comments.docs();
                 Ok(StructMember { name, tref, docs })
             })
@@ -315,7 +332,7 @@ impl DocValidationScope<'_> {
             .map(|f| {
                 let name = variant_scope
                     .introduce(f.item.name.name(), self.location(f.item.name.span()))?;
-                let tref = self.validate_datatype(&f.item.type_, f.item.name.span())?;
+                let tref = self.validate_datatype(&f.item.type_, false, f.item.name.span())?;
                 let docs = f.comments.docs();
                 Ok(UnionVariant { name, tref, docs })
             })
@@ -431,9 +448,11 @@ impl<'a> ModuleValidation<'a> {
                                 f.item.name.name(),
                                 self.doc.location(f.item.name.span()),
                             )?,
-                            tref: self
-                                .doc
-                                .validate_datatype(&f.item.type_, f.item.name.span())?,
+                            tref: self.doc.validate_datatype(
+                                &f.item.type_,
+                                false,
+                                f.item.name.span(),
+                            )?,
                             position: InterfaceFuncParamPosition::Param(ix),
                             docs: f.comments.docs(),
                         })
@@ -444,9 +463,9 @@ impl<'a> ModuleValidation<'a> {
                     .iter()
                     .enumerate()
                     .map(|(ix, f)| {
-                        let tref = self
-                            .doc
-                            .validate_datatype(&f.item.type_, f.item.name.span())?;
+                        let tref =
+                            self.doc
+                                .validate_datatype(&f.item.type_, false, f.item.name.span())?;
                         if ix == 0 {
                             match tref.type_().passed_by() {
                                 TypePassedBy::Value(_) => {}

--- a/tools/witx/tests/anonymous.rs
+++ b/tools/witx/tests/anonymous.rs
@@ -1,0 +1,41 @@
+use witx;
+
+fn is_anonymous_struct_err(r: Result<witx::Document, witx::WitxError>) -> bool {
+    match r {
+        Err(witx::WitxError::Validation(witx::ValidationError::AnonymousStructure { .. })) => true,
+        _ => false,
+    }
+}
+
+#[test]
+fn anonymous_types() {
+    let pointer_to_struct = witx::parse("(typename $a (@witx pointer (struct (field $b u8))))");
+    assert!(is_anonymous_struct_err(pointer_to_struct));
+
+    let pointer_to_union = witx::parse("(typename $a (@witx pointer (union (field $b u8))))");
+    assert!(is_anonymous_struct_err(pointer_to_union));
+
+    let pointer_to_enum = witx::parse("(typename $a (@witx pointer (enum u32 $b)))");
+    assert!(is_anonymous_struct_err(pointer_to_enum));
+
+    let pointer_to_flags = witx::parse("(typename $a (@witx pointer (flags u32 $b)))");
+    assert!(is_anonymous_struct_err(pointer_to_flags));
+
+    let pointer_to_handle = witx::parse("(typename $a (@witx pointer (handle)))");
+    assert!(is_anonymous_struct_err(pointer_to_handle));
+
+    let pointer_to_builtin = witx::parse("(typename $a (@witx pointer u8))");
+    assert!(pointer_to_builtin.is_ok());
+
+    let pointer_to_pointer = witx::parse("(typename $a (@witx pointer (@witx const_pointer u8)))");
+    assert!(pointer_to_pointer.is_ok());
+
+    let struct_in_struct = witx::parse("(typename $a (struct (field $b (struct (field $c u8)))))");
+    assert!(is_anonymous_struct_err(struct_in_struct));
+
+    let union_in_struct = witx::parse("(typename $a (struct (field $b (union (field $c u8)))))");
+    assert!(is_anonymous_struct_err(union_in_struct));
+
+    let pointer_in_struct = witx::parse("(typename $a (struct (field $b (@witx pointer u8))))");
+    assert!(pointer_in_struct.is_ok())
+}


### PR DESCRIPTION
If you need to use a witx struct, union, enum, flags, or handle, you should please give it a name. This is an artificial restriction to make it easier to write backends for witx.

This doesn't actually happen in our current witx specs of wasi, but its accepted by the validator as part of #154.

Adds a set of tests of which sorts of types can and can't be used anonymously.

