### PR TITLE
witx: make USize a BuiltinType

### DIFF
--- a/tools/witx/src/ast.rs
+++ b/tools/witx/src/ast.rs
@@ -150,7 +150,6 @@ pub enum Type {
     Array(TypeRef),
     Pointer(TypeRef),
     ConstPointer(TypeRef),
-    USize,
     Builtin(BuiltinType),
 }
 
@@ -167,7 +166,6 @@ impl Type {
             Array(_) => "array",
             Pointer(_) => "pointer",
             ConstPointer(_) => "constpointer",
-            USize => "usize",
             Builtin(_) => "builtin",
         }
     }
@@ -177,6 +175,7 @@ impl Type {
 pub enum BuiltinType {
     String,
     Char8,
+    USize,
     U8,
     U16,
     U32,

--- a/tools/witx/src/coretypes.rs
+++ b/tools/witx/src/coretypes.rs
@@ -42,15 +42,14 @@ impl Type {
                 | BuiltinType::S8
                 | BuiltinType::S16
                 | BuiltinType::S32
-                | BuiltinType::Char8 => TypePassedBy::Value(AtomType::I32),
+                | BuiltinType::Char8
+                | BuiltinType::USize => TypePassedBy::Value(AtomType::I32),
                 BuiltinType::U64 | BuiltinType::S64 => TypePassedBy::Value(AtomType::I64),
                 BuiltinType::F32 => TypePassedBy::Value(AtomType::F32),
                 BuiltinType::F64 => TypePassedBy::Value(AtomType::F64),
             },
             Type::Array { .. } => TypePassedBy::PointerLengthPair,
-            Type::Pointer { .. } | Type::ConstPointer { .. } | Type::USize => {
-                TypePassedBy::Value(AtomType::I32)
-            }
+            Type::Pointer { .. } | Type::ConstPointer { .. } => TypePassedBy::Value(AtomType::I32),
             Type::Enum(e) => TypePassedBy::Value(e.repr.into()),
             Type::Int(i) => TypePassedBy::Value(i.repr.into()),
             Type::Flags(f) => TypePassedBy::Value(f.repr.into()),

--- a/tools/witx/src/docs.rs
+++ b/tools/witx/src/docs.rs
@@ -26,6 +26,7 @@ impl BuiltinType {
         match self {
             BuiltinType::String => "string",
             BuiltinType::Char8 => "char8",
+            BuiltinType::USize => "usize",
             BuiltinType::U8 => "u8",
             BuiltinType::U16 => "u16",
             BuiltinType::U32 => "u32",
@@ -53,7 +54,6 @@ impl Documentation for NamedType {
                 Type::Array(a) => format!("Array of {}", a.type_name()),
                 Type::Pointer(a) => format!("Pointer to {}", a.type_name()),
                 Type::ConstPointer(a) => format!("Constant Pointer to {}", a.type_name()),
-                Type::USize => format!("USize"),
                 Type::Builtin(a) => format!("Builtin type {}", a.type_name()),
             },
             TypeRef::Name(n) => format!("Alias to {}", n.name.as_str()),
@@ -70,7 +70,6 @@ impl TypeRef {
                 Type::Array(a) => format!("Array<{}>", a.type_name()),
                 Type::Pointer(p) => format!("Pointer<{}>", p.type_name()),
                 Type::ConstPointer(p) => format!("ConstPointer<{}>", p.type_name()),
-                Type::USize => format!("USize"),
                 Type::Builtin(b) => b.type_name().to_string(),
                 Type::Enum { .. }
                 | Type::Int { .. }

--- a/tools/witx/src/layout.rs
+++ b/tools/witx/src/layout.rs
@@ -30,9 +30,7 @@ impl TypeRef {
             Type::Union(u) => u.layout(cache),
             Type::Handle(h) => h.mem_size_align(),
             Type::Array { .. } => BuiltinType::String.mem_size_align(),
-            Type::Pointer { .. } | Type::ConstPointer { .. } | Type::USize => {
-                BuiltinType::U32.mem_size_align()
-            }
+            Type::Pointer { .. } | Type::ConstPointer { .. } => BuiltinType::U32.mem_size_align(),
             Type::Builtin(b) => b.mem_size_align(),
         };
         cache.insert(self.clone(), layout);
@@ -177,7 +175,7 @@ impl Layout for BuiltinType {
                 SizeAlign { size: 1, align: 1 }
             }
             BuiltinType::U16 | BuiltinType::S16 => SizeAlign { size: 2, align: 2 },
-            BuiltinType::U32 | BuiltinType::S32 | BuiltinType::F32 => {
+            BuiltinType::USize | BuiltinType::U32 | BuiltinType::S32 | BuiltinType::F32 => {
                 SizeAlign { size: 4, align: 4 }
             }
             BuiltinType::U64 | BuiltinType::S64 | BuiltinType::F64 => {

--- a/tools/witx/src/parser.rs
+++ b/tools/witx/src/parser.rs
@@ -316,7 +316,6 @@ pub enum TypedefSyntax<'a> {
     Array(Box<TypedefSyntax<'a>>),
     Pointer(Box<TypedefSyntax<'a>>),
     ConstPointer(Box<TypedefSyntax<'a>>),
-    USize,
     Builtin(BuiltinType),
     Ident(wast::Id<'a>),
 }
@@ -357,7 +356,7 @@ impl<'a> Parse<'a> for TypedefSyntax<'a> {
                         Ok(TypedefSyntax::Pointer(Box::new(parser.parse()?)))
                     } else if l.peek::<kw::usize>() {
                         parser.parse::<kw::usize>()?;
-                        Ok(TypedefSyntax::USize)
+                        Ok(TypedefSyntax::Builtin(BuiltinType::USize))
                     } else {
                         Err(l.error())
                     }

--- a/tools/witx/src/render.rs
+++ b/tools/witx/src/render.rs
@@ -79,6 +79,7 @@ impl BuiltinType {
         match self {
             BuiltinType::String => SExpr::word("string"),
             BuiltinType::Char8 => SExpr::word("char8"),
+            BuiltinType::USize => SExpr::Vec(vec![SExpr::annot("witx"), SExpr::word("usize")]),
             BuiltinType::U8 => SExpr::word("u8"),
             BuiltinType::U16 => SExpr::word("u16"),
             BuiltinType::U32 => SExpr::word("u32"),
@@ -132,7 +133,6 @@ impl Type {
                 SExpr::word("const_pointer"),
                 p.to_sexpr(),
             ]),
-            Type::USize => SExpr::Vec(vec![SExpr::annot("witx"), SExpr::word("usize")]),
             Type::Builtin(b) => b.to_sexpr(),
         }
     }

--- a/tools/witx/src/validate.rs
+++ b/tools/witx/src/validate.rs
@@ -255,7 +255,6 @@ impl DocValidationScope<'_> {
                 TypedefSyntax::ConstPointer(syntax) => {
                     Type::ConstPointer(self.validate_datatype(syntax, false, span)?)
                 }
-                TypedefSyntax::USize => Type::USize,
                 TypedefSyntax::Builtin(builtin) => Type::Builtin(*builtin),
                 TypedefSyntax::Ident { .. } => unreachable!(),
             }))),


### PR DESCRIPTION
Minor change to move `USize` from being a variant of `Type` to a variant of `BuiltinType`. The syntax `(@witx usize)` is different from the ordinary BuiltinType syntax `u32`, but otherwise its the same sort of thing as a BuiltinType. The `String` BuiltinTypes also will have a different representation for wasm64 targets.

This is more of a code review on #175, but unfortunately I missed that PR when it went up.