### PR TITLE
wasi_unstable_preview1.md: fix deleted field, reported in #188

### DIFF
--- a/phases/snapshot/docs/wasi_unstable_preview1.md
+++ b/phases/snapshot/docs/wasi_unstable_preview1.md
@@ -2286,7 +2286,7 @@ Members:
 
     - <a href="#subscription.u.clock" name="subscription.u.clock"></a>**`u.clock`**
 
-        - <a href="#subscription.u.clock.clock_id" name="subscription.u.clock.clock_id"></a><code>[\_\_wasi\_clockid\_t](#clockid) <strong>clock\_id</strong></code>
+        - <a href="#subscription.u.clock.clock_id" name="subscription.u.clock.clock_id"></a><code>[\_\_wasi\_clockid\_t](#clockid) <strong>id</strong></code>
 
             The clock against which to compare the timestamp.
 
@@ -2344,4 +2344,3 @@ Possible values:
 - <a href="#whence.end" name="whence.end"></a>**`__WASI_WHENCE_END`**
 
     Seek relative to end-of-file.
-

--- a/phases/snapshot/docs/wasi_unstable_preview1.md
+++ b/phases/snapshot/docs/wasi_unstable_preview1.md
@@ -2286,10 +2286,6 @@ Members:
 
     - <a href="#subscription.u.clock" name="subscription.u.clock"></a>**`u.clock`**
 
-        - <a href="#subscription.u.clock.identifier" name="subscription.u.clock.identifier"></a><code>[\_\_wasi\_userdata\_t](#userdata) <strong>identifier</strong></code>
-
-            The user-defined unique identifier of the clock.
-
         - <a href="#subscription.u.clock.clock_id" name="subscription.u.clock.clock_id"></a><code>[\_\_wasi\_clockid\_t](#clockid) <strong>clock\_id</strong></code>
 
             The clock against which to compare the timestamp.


### PR DESCRIPTION
I'm sure this isn't the only place the markdown has diverged from the spec, but it was simple enough to correct.

Closes #188 