### PR TITLE
Make poll return errno::inval if there are no subscriptions.

### DIFF
--- a/phases/ephemeral/witx/wasi_ephemeral_poll.witx
+++ b/phases/ephemeral/witx/wasi_ephemeral_poll.witx
@@ -12,6 +12,8 @@
   (import "memory" (memory))
 
   ;;; Concurrently poll for the occurrence of a set of events.
+  ;;;
+  ;;; If `nsubscriptions` is 0, returns `errno::inval`.
   (@interface func (export "oneoff")
     ;;; The events to which to subscribe.
     (param $in (@witx const_pointer $subscription))


### PR DESCRIPTION
`poll` with no subscriptions is effectively an infinite hang. Since wasm
has no signals, use cases which involve waking up a libc `pause` call, which
is implemented in terms of a poll with no subscriptions, aren't applicable.
So all `pause` can do is suspend the program until the host environment
terminates it.

One situation where that's useful is in debugging, as it's sometimes useful
to be able to suspend a process in place so that it can be inspected by a
debugger. However, that doesn't require a fully infinite suspend; a suspend
with a long timeout is adequate.

Making the no-subscriptions case an error can help catch cases where
applications unintentionally enter infinite loops.