### PR TITLE
Remove the cputime clocks.

### DIFF
--- a/phases/ephemeral/docs.md
+++ b/phases/ephemeral/docs.md
@@ -21,12 +21,6 @@ real time, whose value cannot be adjusted and which cannot have negative
 clock jumps. The epoch of this clock is undefined. The absolute time
 value of this clock therefore has no meaning.
 
-- <a href="#clockid.process_cputime_id" name="clockid.process_cputime_id"></a> `process_cputime_id`
-The CPU-time clock associated with the current process.
-
-- <a href="#clockid.thread_cputime_id" name="clockid.thread_cputime_id"></a> `thread_cputime_id`
-The CPU-time clock associated with the current thread.
-
 ## <a href="#errno" name="errno"></a> `errno`: Enum(`u16`)
 Error codes returned by functions.
 Not all of these error codes are returned by the functions provided by this

--- a/phases/ephemeral/witx/typenames.witx
+++ b/phases/ephemeral/witx/typenames.witx
@@ -24,10 +24,6 @@
     ;;; clock jumps. The epoch of this clock is undefined. The absolute time
     ;;; value of this clock therefore has no meaning.
     $monotonic
-    ;;; The CPU-time clock associated with the current process.
-    $process_cputime_id
-    ;;; The CPU-time clock associated with the current thread.
-    $thread_cputime_id
   )
 )
 


### PR DESCRIPTION
Remove $process_cputime_id and $thread_cputime_id.

Some implementations will not have one wasm nanoprocess per OS process,
or one wasm thread per OS thread, making it difficult to implement
$process_cputime_id meaningfully. Also, the concept of "cputime"
available in most host environments isn't easy to directly connect to
what we might expect "cputime" to mean for wasm code.

These correspond to `CLOCK_PROCESS_CPUTIME_ID` and `CLOCK_THREAD_CPUTIME_ID`
in POSIX, which are optional:

https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/time.h.html