### PR TITLE
Change `random`'s buffer back to `u8`.

### DIFF
--- a/phases/ephemeral/witx/wasi_ephemeral_random.witx
+++ b/phases/ephemeral/witx/wasi_ephemeral_random.witx
@@ -19,7 +19,7 @@
   ;;; number generator, rather than to provide the random data directly.
   (@interface func (export "get")
     ;;; The buffer to fill with random data.
-    (param $buf (@witx pointer char8))
+    (param $buf (@witx pointer u8))
     (param $buf_len $size)
     (result $error $errno)
   )


### PR DESCRIPTION
The buffer contains arbitrary bytes, not UTF-8-encoded bytes, so use
`u8` rather than `char8`.

Fixes #184.