### PR TITLE
Rename $subscription_fd_readwrite's $fd member to $fd.

### DIFF
--- a/phases/ephemeral/witx/typenames.witx
+++ b/phases/ephemeral/witx/typenames.witx
@@ -613,7 +613,7 @@
 (typename $subscription_fd_readwrite
   (struct
     ;;; The file descriptor on which to wait for it to become ready for reading or writing.
-    (field $file_descriptor $fd)
+    (field $fd $fd)
   )
 )
 


### PR DESCRIPTION
This makes it more consistent with naming through the rest of the witx
specs.