### PR TITLE
witx validator: reject anonymous int type declarations

### DIFF
--- a/tools/witx/src/validate.rs
+++ b/tools/witx/src/validate.rs
@@ -229,6 +229,7 @@ impl DocValidationScope<'_> {
                 }
             }
             TypedefSyntax::Enum { .. }
+            | TypedefSyntax::Int { .. }
             | TypedefSyntax::Flags { .. }
             | TypedefSyntax::Struct { .. }
             | TypedefSyntax::Union { .. }


### PR DESCRIPTION
ints are like enums or flags - they only really make sense to have a name.

Lets merge this before #201 