### PR TITLE
Fix some links in the docs

### DIFF
--- a/phases/snapshot/witx/typenames.witx
+++ b/phases/snapshot/witx/typenames.witx
@@ -200,7 +200,7 @@
     ;;; The right to invoke `fd_datasync`.
     ;;
     ;;; If `path_open` is set, includes the right to invoke
-    ;;; `path_open` with `fdflag::dsync`.
+    ;;; `path_open` with `fdflags::dsync`.
     $fd_datasync
     ;;; The right to invoke `fd_read` and `sock_recv`.
     ;;
@@ -213,10 +213,10 @@
     ;;; The right to invoke `fd_sync`.
     ;;
     ;;; If `path_open` is set, includes the right to invoke
-    ;;; `path_open` with `fdflag::rsync` and `fdflag::dsync`.
+    ;;; `path_open` with `fdflags::rsync` and `fdflags::dsync`.
     $fd_sync
     ;;; The right to invoke `fd_seek` in such a way that the file offset
-    ;;; remains unaltered (i.e., `WHENCE_CUR` with offset zero), or to
+    ;;; remains unaltered (i.e., `whence::cur` with offset zero), or to
     ;;; invoke `fd_tell`.
     $fd_tell
     ;;; The right to invoke `fd_write` and `sock_send`.
@@ -419,13 +419,13 @@
 ;;; Which file time attributes to adjust.
 (typename $fstflags
   (flags u16
-    ;;; Adjust the last data access timestamp to the value stored in `filestat::st_atim`.
+    ;;; Adjust the last data access timestamp to the value stored in `filestat::atim`.
     $atim
-    ;;; Adjust the last data access timestamp to the time of clock `clock::realtime`.
+    ;;; Adjust the last data access timestamp to the time of clock `clockid::realtime`.
     $atim_now
-    ;;; Adjust the last data modification timestamp to the value stored in `filestat::st_mtim`.
+    ;;; Adjust the last data modification timestamp to the value stored in `filestat::mtim`.
     $mtim
-    ;;; Adjust the last data modification timestamp to the time of clock `clock::realtime`.
+    ;;; Adjust the last data modification timestamp to the time of clock `clockid::realtime`.
     $mtim_now
   )
 )
@@ -484,13 +484,13 @@
 ;;; Type of a subscription to an event or its occurrence.
 (typename $eventtype
   (enum u8
-    ;;; The time value of clock `subscription::u.clock.clock_id` has
-    ;;; reached timestamp `subscription::u.clock.timeout`.
+    ;;; The time value of clock `subscription_clock::id` has
+    ;;; reached timestamp `subscription_clock::timeout`.
     $clock
-    ;;; File descriptor `subscription::u.fd_readwrite.fd` has data
+    ;;; File descriptor `subscription_fd_readwrite::file_descriptor` has data
     ;;; available for reading. This event always triggers for regular files.
     $fd_read
-    ;;; File descriptor `subscription::u.fd_readwrite.fd` has capacity
+    ;;; File descriptor `subscription_fd_readwrite::file_descriptor` has capacity
     ;;; available for writing. This event always triggers for regular files.
     $fd_write
   )
@@ -539,14 +539,14 @@
 )
 
 ;;; Flags determining how to interpret the timestamp provided in
-;;; `subscription::u.clock.timeout.`
+;;; `subscription_clock::timeout`.
 (typename $subclockflags
   (flags u16
     ;;; If set, treat the timestamp provided in
-    ;;; `subscription::u.clock.timeout` as an absolute timestamp of clock
-    ;;; `subscription::u.clock.clock_id.` If clear, treat the timestamp
-    ;;; provided in `subscription::u.clock.timeout` relative to the
-    ;;; current time value of clock `subscription::u.clock.clock_id.`
+    ;;; `subscription_clock::timeout` as an absolute timestamp of clock
+    ;;; `subscription_clock::id`. If clear, treat the timestamp
+    ;;; provided in `subscription_clock::timeout` relative to the
+    ;;; current time value of clock `subscription_clock::id`.
     $subscription_clock_abstime
   )
 )

--- a/phases/snapshot/witx/wasi_snapshot_preview1.witx
+++ b/phases/snapshot/witx/wasi_snapshot_preview1.witx
@@ -13,7 +13,7 @@
   (import "memory" (memory))
 
   ;;; Read command-line argument data.
-  ;;; The size of the array should match that returned by `wasi_args_sizes_get()`
+  ;;; The size of the array should match that returned by `args_sizes_get`
   (@interface func (export "args_get")
     (param $argv (@witx pointer (@witx pointer u8)))
     (param $argv_buf (@witx pointer u8))
@@ -29,7 +29,7 @@
   )
 
   ;;; Read environment variable data.
-  ;;; The sizes of the buffers should match that returned by `environ.sizes_get()`.
+  ;;; The sizes of the buffers should match that returned by `environ_sizes_get`.
   (@interface func (export "environ_get")
     (param $environ (@witx pointer (@witx pointer u8)))
     (param $environ_buf (@witx pointer u8))
@@ -45,7 +45,8 @@
   )
 
   ;;; Return the resolution of a clock.
-  ;;; Implementations are required to provide a non-zero value for supported clocks. For unsupported clocks, return `WASI_EINVAL`
+  ;;; Implementations are required to provide a non-zero value for supported clocks. For unsupported clocks,
+  ;;; return `errno::inval`.
   ;;; Note: This is similar to `clock_getres` in POSIX.
   (@interface func (export "clock_res_get")
     (result $error $errno)
@@ -123,7 +124,7 @@
   )
 
   ;;; Adjust the rights associated with a file descriptor.
-  ;;; This can only be used to remove rights, and returns `ENOTCAPABLE` if called in a way that would attempt to add rights
+  ;;; This can only be used to remove rights, and returns `errno::notcapable` if called in a way that would attempt to add rights
   (@interface func (export "fd_fdstat_set_rights")
     (param $fd $fd)
     ;;; The desired rights of the file descriptor.
@@ -363,7 +364,7 @@
     ;;; Flags determining the method of how the path is resolved.
     (param $dirflags $lookupflags)
     ;;; The relative path of the file or directory to open, relative to the
-    ;;; `dirfd` directory.
+    ;;; `path_open::fd` directory.
     (param $path string)
     ;;; The method by which to open the file.
     (param $oflags $oflags)
@@ -398,7 +399,7 @@
   )
 
   ;;; Remove a directory.
-  ;;; Return `ENOTEMPTY` if the directory is not empty.
+  ;;; Return `errno::notempty` if the directory is not empty.
   ;;; Note: This is similar to `unlinkat(fd, path, AT_REMOVEDIR)` in POSIX.
   (@interface func (export "path_remove_directory")
     (param $fd $fd)
@@ -433,7 +434,7 @@
 
 
   ;;; Unlink a file.
-  ;;; Return `EISDIR` if the path refers to a directory.
+  ;;; Return `errno::isdir` if the path refers to a directory.
   ;;; Note: This is similar to `unlinkat(fd, path, 0)` in POSIX.
   (@interface func (export "path_unlink_file")
     (param $fd $fd)


### PR DESCRIPTION
This commit fixes some links in different places in the docs
sections in `snapshot1` `*.witx` files so that they are consistent
with type naming throughout the document. This will aid correct
Markdown link generation by the `witx` tool directly from `*.witx`
files.

Note that thanks to this fix, the links are now correctly generated by `witx`
tool with the new docs generator introduced in #194.