### PR TITLE
Replace clap with structopt

### DIFF
--- a/tools/witx/Cargo.toml
+++ b/tools/witx/Cargo.toml
@@ -18,7 +18,7 @@ name = "witx"
 path = "src/main.rs"
 
 [dependencies]
-clap = "2"
+structopt = "0.3"
 wast = "3.0.4"
 thiserror = "1.0"
 log = "0.4"

--- a/tools/witx/src/main.rs
+++ b/tools/witx/src/main.rs
@@ -1,127 +1,146 @@
-use clap::{App, Arg, ArgMatches, SubCommand};
-use std::collections::HashMap;
+use anyhow::{anyhow, bail, Result};
 use std::fs::File;
 use std::io::Write;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process;
+use structopt::{clap::AppSettings, StructOpt};
 use witx::{load, phases, Document, Documentation};
 
-pub fn main() {
-    let app = App::new("witx")
-        .version(env!("CARGO_PKG_VERSION"))
-        .about("Validate and process witx files")
-        .arg(
-            Arg::with_name("verbose")
-                .short("v")
-                .long("verbose")
-                .takes_value(false)
-                .required(false),
-        )
-        .subcommand(
-            SubCommand::with_name("docs")
-                .about("Output documentation")
-                .arg(
-                    Arg::with_name("input")
-                        .required(true)
-                        .multiple(true)
-                        .help("path to root of witx document"),
-                )
-                .arg(
-                    Arg::with_name("output")
-                        .short("o")
-                        .long("output")
-                        .takes_value(true)
-                        .required(false),
-                ),
-        )
-        .subcommand(
-            SubCommand::with_name("polyfill")
-                .about("Examine differences between interfaces")
-                .arg(
-                    Arg::with_name("input")
-                        .required(true)
-                        .multiple(true)
-                        .help("path to root of witx document"),
-                )
-                .arg(
-                    Arg::with_name("older_interface")
-                        .required(true)
-                        .multiple(true)
-                        .help("path to root of witx document describing interface to polyfill"),
-                )
-                .arg(
-                    Arg::with_name("module_mapping")
-                        .short("m")
-                        .long("module_mapping")
-                        .required(false)
-                        .takes_value(true)
-                        .multiple(true)
-                        .help("module to examine. Use newname=oldname syntax if name is different between new and old interfaces"),
-                ),
-        )
-        .subcommand(
-            SubCommand::with_name("repo-docs")
-                .about("Update documentation in WASI repository to reflect witx specs")
-        )
-        .get_matches();
+/// Validate and process witx files
+#[derive(StructOpt, Debug)]
+#[structopt(
+    name = "witx",
+    version = env!("CARGO_PKG_VERSION"),
+    global_settings = &[
+        AppSettings::VersionlessSubcommands,
+        AppSettings::ColoredHelp
+    ]
+)]
+struct Args {
+    #[structopt(short = "v", long = "verbose")]
+    verbose: bool,
 
-    let load_witx = {
-        |args: &ArgMatches, field: &str| -> Document {
-            let inputs = args
-                .values_of(field)
-                .expect(&format!("required argument: {}", field))
-                .collect::<Vec<_>>();
-            match load(&inputs) {
-                Ok(doc) => {
-                    if app.is_present("verbose") {
-                        println!("{}: {:?}", field, doc)
-                    }
-                    doc
-                }
-                Err(e) => {
-                    println!("{}", e.report());
-                    if app.is_present("verbose") {
-                        println!("{:?}", e);
-                    }
-                    process::exit(1)
-                }
+    #[structopt(subcommand)]
+    cmd: Command,
+}
+
+#[derive(StructOpt, Debug)]
+enum Command {
+    /// Output documentation
+    Docs {
+        /// Path to root of witx document
+        #[structopt(number_of_values = 1, value_name = "INPUT", parse(from_os_str))]
+        input: Vec<PathBuf>,
+        /// Path to generated documentation in Markdown format
+        #[structopt(
+            short = "o",
+            long = "output",
+            value_name = "OUTPUT",
+            parse(from_os_str)
+        )]
+        output: Option<PathBuf>,
+    },
+    /// Update documentation in WASI repository to reflect witx specs
+    RepoDocs,
+    /// Examine differences between interfaces
+    Polyfill {
+        /// Path to root of witx document
+        #[structopt(
+            required = true,
+            number_of_values = 1,
+            value_name = "INPUT",
+            parse(from_os_str)
+        )]
+        input: Vec<PathBuf>,
+        /// Path to root of witx document describing interface to polyfill
+        #[structopt(
+            required = true,
+            number_of_values = 1,
+            value_name = "OLDER_INTERFACE",
+            parse(from_os_str)
+        )]
+        older_interface: Vec<PathBuf>,
+        /// Module to examine (use newname=oldname syntax if name is different
+        /// between new and old interfaces)
+        #[structopt(
+            short = "m",
+            long = "module_mapping",
+            required = true,
+            number_of_values = 1,
+            value_name = "NEWNAME=OLDNAME",
+            parse(try_from_str = parse_module_mapping)
+        )]
+        module_mapping: Vec<(String, String)>,
+    },
+}
+
+pub fn main() {
+    let args = Args::from_args();
+    pretty_env_logger::init();
+    let verbose = args.verbose;
+
+    match args.cmd {
+        Command::Docs { input, output } => {
+            let doc = load_witx(&input, "input", verbose);
+            if let Some(output) = output {
+                write_docs(&doc, output)
+            } else {
+                println!("{}", doc.to_md())
             }
         }
-    };
-
-    pretty_env_logger::init();
-
-    if let Some(docs_args) = app.subcommand_matches("docs") {
-        let doc = load_witx(&docs_args, "input");
-        if let Some(output) = docs_args.value_of("output") {
-            write_docs(&doc, output)
-        } else {
-            println!("{}", doc.to_md())
+        Command::RepoDocs => {
+            for phase in &[
+                phases::snapshot().unwrap(),
+                phases::ephemeral().unwrap(),
+                phases::old::snapshot_0().unwrap(),
+            ] {
+                let doc = load(&phase).expect("parse phase");
+                write_docs(&doc, phases::docs_path(&phase));
+            }
         }
-    } else if let Some(polyfill_args) = app.subcommand_matches("polyfill") {
-        let doc = load_witx(&polyfill_args, "input");
-        let older_doc = load_witx(&polyfill_args, "older_interface");
+        Command::Polyfill {
+            input,
+            older_interface,
+            module_mapping,
+        } => {
+            use std::{collections::HashMap, iter::FromIterator};
+            use witx::polyfill::Polyfill;
 
-        let module_mapping_args = polyfill_args
-            .values_of("module_mapping")
-            .expect("at least one module_mapping argument required")
-            .collect::<Vec<&str>>();
-        let module_mapping = parse_module_mapping(&module_mapping_args);
-
-        let polyfill = witx::polyfill::Polyfill::new(&doc, &older_doc, &module_mapping)
-            .expect("calculate polyfill");
-        println!("{}", polyfill.to_md());
-        if app.is_present("verbose") {
-            println!("{:?}", polyfill);
+            let doc = load_witx(&input, "input", verbose);
+            let older_doc = load_witx(&older_interface, "older_interface", verbose);
+            let module_mapping = HashMap::from_iter(module_mapping.into_iter());
+            let polyfill = match Polyfill::new(&doc, &older_doc, &module_mapping) {
+                Ok(polyfill) => polyfill,
+                Err(e) => {
+                    eprintln!("couldn't calculate polyfill");
+                    if verbose {
+                        println!("{:?}", e);
+                    }
+                    process::exit(1);
+                }
+            };
+            println!("{}", polyfill.to_md());
+            if verbose {
+                println!("{:?}", polyfill);
+            }
         }
-    } else if app.subcommand_matches("repo-docs").is_some() {
-        for phase in &[
-            phases::snapshot().unwrap(),
-            phases::ephemeral().unwrap(),
-            phases::old::snapshot_0().unwrap(),
-        ] {
-            let doc = load(&phase).expect("parse phase");
-            write_docs(&doc, phases::docs_path(&phase));
+    }
+}
+
+fn load_witx(input: &[PathBuf], field_name: &str, verbose: bool) -> Document {
+    match load(input) {
+        Ok(doc) => {
+            if verbose {
+                println!("{}: {:?}", field_name, doc);
+            }
+            doc
+        }
+        Err(e) => {
+            eprintln!("{}", e.report());
+            if verbose {
+                println!("{:?}", e);
+            }
+            process::exit(1)
         }
     }
 }
@@ -132,20 +151,26 @@ fn write_docs<P: AsRef<Path>>(document: &Document, path: P) {
         .expect("write output file");
 }
 
-fn parse_module_mapping(ms: &[&str]) -> HashMap<String, String> {
-    let mut o = HashMap::new();
-    for m in ms {
-        let s = m.split('=').collect::<Vec<&str>>();
-        if s.len() == 1 {
-            let mname = s.get(0).unwrap();
-            o.insert(mname.to_string(), mname.to_string());
-        } else if s.len() == 2 {
-            let newname = s.get(0).unwrap();
-            let oldname = s.get(1).unwrap();
-            o.insert(newname.to_string(), oldname.to_string());
-        } else {
-            panic!("invalid module mapping: '{}'", m)
+fn parse_module_mapping(m: &str) -> Result<(String, String)> {
+    let s: Vec<_> = m.split('=').collect();
+    let (n, o) = match s.len() {
+        1 => {
+            let mname = s
+                .get(0)
+                .ok_or(anyhow!("module name cannot be an empty string"))?;
+            (mname, mname)
         }
-    }
-    o
+        2 => {
+            let newname = s
+                .get(0)
+                .ok_or(anyhow!("new module name cannot be an empty string"))?;
+            let oldname = s
+                .get(1)
+                .ok_or(anyhow!("old module name cannot be an empty string"))?;
+            (newname, oldname)
+        }
+        _ => bail!("invalid module mapping: '{}'", m),
+    };
+    Ok((n.to_string(), o.to_string()))
 }
+

--- a/tools/witx/src/main.rs
+++ b/tools/witx/src/main.rs
@@ -173,4 +173,3 @@ fn parse_module_mapping(m: &str) -> Result<(String, String)> {
     };
     Ok((n.to_string(), o.to_string()))
 }
-


### PR DESCRIPTION
IMHO, `structopt` generally makes things somewhat cleaner and is worth
moving `witx` to `structopt` from `clap` for added readability and
extendability of the tool in the future.