### PR TITLE
Reorder results of fd_permissions_set in ephemeral

### DIFF
--- a/phases/ephemeral/witx/wasi_ephemeral_fd.witx
+++ b/phases/ephemeral/witx/wasi_ephemeral_fd.witx
@@ -121,9 +121,9 @@
   ;;; umask to determine which of the user/group/other flags to modify.
   (@interface func (export "permissions_set")
     (param $fd $fd)
+    (result $error $errno)
     ;;; The permissions associated with the file.
     (result $permissions $permissions)
-    (result $error $errno)
   )
 
   ;;; Read from a file descriptor, without using and updating the file descriptor's offset.


### PR DESCRIPTION
I tried to feed the current ephemeral witx files to the `generate-raw` tool and noticed a minor inconsistency. Unlike other interface functions, `permissions_set` in `wasi_ephemeral_fd.witx` returns `error` as the second result, which is not supported by the tool:
https://github.com/bytecodealliance/wasi/blob/master/crates/generate-raw/src/lib.rs#L280

Might it make sense to change the order to be consistent with the other part of the proposal?