### PR TITLE
Clarify "type" is $pr_type in $prestat_u::dir and $prestat_dir

### DIFF
--- a/phases/ephemeral/docs.md
+++ b/phases/ephemeral/docs.md
@@ -809,7 +809,7 @@ Identifiers for preopened capabilities.
 A pre-opened directory.
 
 ## <a href="#prestat_dir" name="prestat_dir"></a> `prestat_dir`: Struct
-The contents of a $prestat when type is [`preopentype::dir`](#preopentype.dir).
+The contents of a $prestat when its $pr\_type is [`preopentype::dir`](#preopentype.dir).
 
 ### Struct members
 - <a href="#prestat_dir.pr_name_len" name="prestat_dir.pr_name_len"></a> `pr_name_len`: [`size`](#size)
@@ -820,7 +820,7 @@ The contents of an $prestat.
 
 ### Union variants
 - <a href="#prestat_u.dir" name="prestat_u.dir"></a> `dir`: [`prestat_dir`](#prestat_dir)
-When type is [`preopentype::dir`](#preopentype.dir):
+When $pr\_type of the $prestat is [`preopentype::dir`](#preopentype.dir):
 
 ## <a href="#prestat" name="prestat"></a> `prestat`: Struct
 Information about a pre-opened capability.

--- a/phases/ephemeral/docs.md
+++ b/phases/ephemeral/docs.md
@@ -809,7 +809,7 @@ Identifiers for preopened capabilities.
 A pre-opened directory.
 
 ## <a href="#prestat_dir" name="prestat_dir"></a> `prestat_dir`: Struct
-The contents of a $prestat when its $pr\_type is [`preopentype::dir`](#preopentype.dir).
+The contents of a $prestat when its $pr_type is [`preopentype::dir`](#preopentype.dir).
 
 ### Struct members
 - <a href="#prestat_dir.pr_name_len" name="prestat_dir.pr_name_len"></a> `pr_name_len`: [`size`](#size)
@@ -820,7 +820,7 @@ The contents of an $prestat.
 
 ### Union variants
 - <a href="#prestat_u.dir" name="prestat_u.dir"></a> `dir`: [`prestat_dir`](#prestat_dir)
-When $pr\_type of the $prestat is [`preopentype::dir`](#preopentype.dir):
+When $pr_type of the $prestat is [`preopentype::dir`](#preopentype.dir):
 
 ## <a href="#prestat" name="prestat"></a> `prestat`: Struct
 Information about a pre-opened capability.

--- a/phases/ephemeral/witx/typenames.witx
+++ b/phases/ephemeral/witx/typenames.witx
@@ -683,7 +683,7 @@
   )
 )
 
-;;; The contents of a $prestat when type is `preopentype::dir`.
+;;; The contents of a $prestat when its $pr_type is `preopentype::dir`.
 (typename $prestat_dir
   (struct
     ;;; The length of the directory name for use with `fd_prestat_dir_name`.
@@ -694,7 +694,7 @@
 ;;; The contents of an $prestat.
 (typename $prestat_u
   (union
-    ;;; When type is `preopentype::dir`:
+    ;;; When $pr_type of the $prestat is `preopentype::dir`:
     (field $dir $prestat_dir)
   )
 )


### PR DESCRIPTION
The word "type" in the descriptions of `$prestat_u::dir` and `$prestat_dir` should be clarified as `$pr_type`.
We can actually easily infer from the context, but I felt confused a little at first.

Fix: https://github.com/WebAssembly/WASI/issues/221