### PR TITLE
Fix const description in ephemeral

### DIFF
--- a/phases/ephemeral/docs.md
+++ b/phases/ephemeral/docs.md
@@ -423,6 +423,7 @@ A reference to the offset of a directory entry.
 
 ### Consts
 - <a href="#dircookie.start" name="dircookie.start"></a> `start`
+In an `fd_readdir` call, this value signifies the start of the directory.
 
 ## <a href="#dirnamlen" name="dirnamlen"></a> `dirnamlen`: `u32`
 The type for the $d_namlen field of $dirent.

--- a/phases/ephemeral/witx/typenames.witx
+++ b/phases/ephemeral/witx/typenames.witx
@@ -321,7 +321,7 @@
 ;;; A reference to the offset of a directory entry.
 (typename $dircookie
   (int u64
-    ;; In an `fd_readdir` call, this value signifies the start of the directory.
+    ;;; In an `fd_readdir` call, this value signifies the start of the directory.
     (const $start 0)
   )
 )


### PR DESCRIPTION
This commit fixes a `dircookie` comment string of its only const
member `start`. Effectively, due to the fact that one semicolon
was missing, the docs were not properly generated.