### PR TITLE
Fix wording and return args in environ_sizes_get syscall

### DIFF
--- a/phases/ephemeral/docs.md
+++ b/phases/ephemeral/docs.md
@@ -916,17 +916,17 @@ The sizes of the buffers should match that returned by [`sizes_get`](#sizes_get)
 ---
 
 #### <a href="#sizes_get" name="sizes_get"></a> `sizes_get() -> (errno, size, size)`
-Return command-line argument data sizes.
+Return environment variable data sizes.
 
 ##### Params
 ##### Results
 - <a href="#sizes_get.error" name="sizes_get.error"></a> `error`: [`errno`](#errno)
 
-- <a href="#sizes_get.argc" name="sizes_get.argc"></a> `argc`: [`size`](#size)
-The number of arguments.
+- <a href="#sizes_get.environc" name="sizes_get.environc"></a> `environc`: [`size`](#size)
+The number of environment variable arguments.
 
-- <a href="#sizes_get.argv_buf_size" name="sizes_get.argv_buf_size"></a> `argv_buf_size`: [`size`](#size)
-The size of the argument string data.
+- <a href="#sizes_get.environ_buf_size" name="sizes_get.environ_buf_size"></a> `environ_buf_size`: [`size`](#size)
+The size of the environment variable data.
 
 ## <a href="#wasi_ephemeral_fd" name="wasi_ephemeral_fd"></a> wasi_ephemeral_fd
 ### Imports

--- a/phases/ephemeral/witx/wasi_ephemeral_environ.witx
+++ b/phases/ephemeral/witx/wasi_ephemeral_environ.witx
@@ -17,12 +17,12 @@
     (result $error $errno)
   )
 
-  ;;; Return command-line argument data sizes.
+  ;;; Return environment variable data sizes.
   (@interface func (export "sizes_get")
     (result $error $errno)
-    ;;; The number of arguments.
-    (result $argc $size)
-    ;;; The size of the argument string data.
-    (result $argv_buf_size $size)
+    ;;; The number of environment variable arguments.
+    (result $environc $size)
+    ;;; The size of the environment variable data.
+    (result $environ_buf_size $size)
   )
 )

--- a/phases/old/snapshot_0/docs.md
+++ b/phases/old/snapshot_0/docs.md
@@ -952,17 +952,17 @@ The sizes of the buffers should match that returned by [`environ_sizes_get`](#en
 ---
 
 #### <a href="#environ_sizes_get" name="environ_sizes_get"></a> `environ_sizes_get() -> (errno, size, size)`
-Return command-line argument data sizes.
+Return environment variable data sizes.
 
 ##### Params
 ##### Results
 - <a href="#environ_sizes_get.error" name="environ_sizes_get.error"></a> `error`: [`errno`](#errno)
 
-- <a href="#environ_sizes_get.argc" name="environ_sizes_get.argc"></a> `argc`: [`size`](#size)
-The number of arguments.
+- <a href="#environ_sizes_get.environc" name="environ_sizes_get.environc"></a> `environc`: [`size`](#size)
+The number of environment variable arguments.
 
-- <a href="#environ_sizes_get.argv_buf_size" name="environ_sizes_get.argv_buf_size"></a> `argv_buf_size`: [`size`](#size)
-The size of the argument string data.
+- <a href="#environ_sizes_get.environ_buf_size" name="environ_sizes_get.environ_buf_size"></a> `environ_buf_size`: [`size`](#size)
+The size of the environment variable data.
 
 
 ---

--- a/phases/old/snapshot_0/witx/wasi_unstable.witx
+++ b/phases/old/snapshot_0/witx/wasi_unstable.witx
@@ -38,13 +38,13 @@
     (param $environ_buf (@witx pointer u8))
     (result $error $errno)
   )
-  ;;; Return command-line argument data sizes.
+  ;;; Return environment variable data sizes.
   (@interface func (export "environ_sizes_get")
     (result $error $errno)
-    ;;; The number of arguments.
-    (result $argc $size)
-    ;;; The size of the argument string data.
-    (result $argv_buf_size $size)
+    ;;; The number of environment variable arguments.
+    (result $environc $size)
+    ;;; The size of the environment variable data.
+    (result $environ_buf_size $size)
   )
 
   ;;; Return the resolution of a clock.

--- a/phases/snapshot/docs.md
+++ b/phases/snapshot/docs.md
@@ -951,17 +951,17 @@ The sizes of the buffers should match that returned by [`environ_sizes_get`](#en
 ---
 
 #### <a href="#environ_sizes_get" name="environ_sizes_get"></a> `environ_sizes_get() -> (errno, size, size)`
-Return command-line argument data sizes.
+Return environment variable data sizes.
 
 ##### Params
 ##### Results
 - <a href="#environ_sizes_get.error" name="environ_sizes_get.error"></a> `error`: [`errno`](#errno)
 
-- <a href="#environ_sizes_get.argc" name="environ_sizes_get.argc"></a> `argc`: [`size`](#size)
-The number of arguments.
+- <a href="#environ_sizes_get.environc" name="environ_sizes_get.environc"></a> `environc`: [`size`](#size)
+The number of environment variable arguments.
 
-- <a href="#environ_sizes_get.argv_buf_size" name="environ_sizes_get.argv_buf_size"></a> `argv_buf_size`: [`size`](#size)
-The size of the argument string data.
+- <a href="#environ_sizes_get.environ_buf_size" name="environ_sizes_get.environ_buf_size"></a> `environ_buf_size`: [`size`](#size)
+The size of the environment variable data.
 
 
 ---

--- a/phases/snapshot/witx/wasi_snapshot_preview1.witx
+++ b/phases/snapshot/witx/wasi_snapshot_preview1.witx
@@ -35,13 +35,13 @@
     (param $environ_buf (@witx pointer u8))
     (result $error $errno)
   )
-  ;;; Return command-line argument data sizes.
+  ;;; Return environment variable data sizes.
   (@interface func (export "environ_sizes_get")
     (result $error $errno)
-    ;;; The number of arguments.
-    (result $argc $size)
-    ;;; The size of the argument string data.
-    (result $argv_buf_size $size)
+    ;;; The number of environment variable arguments.
+    (result $environc $size)
+    ;;; The size of the environment variable data.
+    (result $environ_buf_size $size)
   )
 
   ;;; Return the resolution of a clock.


### PR DESCRIPTION
This commit fixes wording and return args naming in `environ_sizes_get`
syscalls across all snapshots. It seems that the wording for `args_sizes_get`
was copied over to `environ_sizes_get` but without adjusting the wording
and naming.