### PR TITLE
Started the Framebuffer API - Am I doing things right so far?

### DIFF
--- a/phases/ephemeral/witx/wasi_ephemeral_framebuffer.witx
+++ b/phases/ephemeral/witx/wasi_ephemeral_framebuffer.witx
@@ -1,0 +1,21 @@
+;; WASI Environment Variables.
+;;
+;; This is a `witx` file. See [here](https://github.com/WebAssembly/WASI/tree/master/docs/witx.md)
+;; for an explanation of what that means.
+
+(use "typenames.witx")
+
+(module $wasi_ephemeral_framebuffer
+ ;;; Linear memory to be accessed by WASI functions that need it.
+ (import "memory" (memory))
+
+ ;;; Function to output rgba array to the framebuffer
+ (@interface func (export "draw")
+  ;; Pointer to the buffer
+  (param $frame_buf (@witx pointer u8))
+  ;; Length of the buffer
+  (param $buf_length u64)
+  ;; The error code of the operation
+  (result $error $errno)
+ )
+)

--- a/phases/ephemeral/witx/wasi_ephemeral_framebuffer.witx
+++ b/phases/ephemeral/witx/wasi_ephemeral_framebuffer.witx
@@ -14,7 +14,7 @@
   ;; Pointer to the buffer
   (param $frame_buf (@witx pointer u8))
   ;; Length of the buffer
-  (param $buf_length u64)
+  (param $buf_length $size)
   ;; The error code of the operation
   (result $error $errno)
  )


### PR DESCRIPTION
relates to #174 

cc @sunfishcode 

# What is this PR?

This starts a simple draw syscall for a possible framebuffer API. **This is a draft PR where I am more just asking if I seem to be on the right track so far with my implementation on how i can contribute this API.**

This (so far) creates: `phases/ephemeral/witx/wasi_ephemeral_framebuffer.witx` which will be the home for all of the syscalls used by the framebuffer API. And this was tested on my fork of [wasmtime on my framebuffer branch](https://github.com/torch2424/wasmtime/commit/b0b69f14603c15257f99d41c2c019f91cc6e140c). 

# What is the proposed Framebuffer API?

Please see #174 for more context. But to me, it will eventually become the equivalent of [writing directly to something like a linux framebuffer](http://seenaburns.com/2018/04/04/writing-to-the-framebuffer/) but standardized in WASI.

# How did I get this up and running to start contributing?

[Josh Triplett's, Extending WASI and wasmtime from WasmSF](https://www.youtube.com/watch?v=9py3lqYoihc) was a great starting point for me! The technical "how-to contribute" is already out of date. But I still think it is great for the context, and still is somewhat true for what you need to do (covered in my how-to below). 

(Per @sunfishcode request) Here's how I was able to import my own WASi syscall to my wasm program, and then run it on my forked wasm runtime:

1. Fork the [WASI](https://github.com/WebAssembly/WASI) repo.
2. Clone your WASI fork.
3. Fork the [wasmtime]() repo (Using wasmtime as it was the one used in Josh Triplett's talk).
4. Clone your wasmtime fork using the build instructions on [wasmtime.dev](https://wasmtime.dev/).
5. In your WASi fork, implement your syscall in a `.witx` file in : `phases/ephemeral/witx` (For example, [here is my initial draw syscall](https://github.com/torch2424/WASI/commit/9512fa34ee06ced3765aa6e2926e94635c8859d9)).
6. In your wasmtime fork, that you correctly made sure to get the submodules for when you cloned it, implement this same syscall in the latest snapshot. In my case it was in: `crates/wig/WASI/phases/snapshot/witx/wasi_snapshot_preview1.witx`. **NOTE:** We are implementing this in the latest snapshot so there is less you have to do to have wasmtime allow it.
7. In your wasmtime fork, implement the actual function that does the logic of your syscall in: `crates/wasi-common/src/hostcalls_impl/misc.rs`. (For example, here is my "println does it work?" [draw syscall implementation](https://github.com/torch2424/wasmtime/commit/b0b69f14603c15257f99d41c2c019f91cc6e140c))
8. Build your wasmtime fork using the instructions in [wasmtime.dev](https://wasmtime.dev/) (NOTE: I had to use Rust nightly).
9. Write a wasm module that calls your WASI syscall (For example, here is my [draw.wat compiled with wat2wasm](https://github.com/torch2424/wasi-syscall-playground/blob/fb1e6511d7f97d7a71306f1e01ec0690a8789da7/draw.wat))
10. Run your compiled wasm module with your compiled wasmtime fork (wasmtime executable should be in `target/release/wasmtime`). For Example: `./target/release/wasmtime ../wasi-syscall-playground/draw.wasm`.
11. Your syscall should be run! :smile: 

# Results

![Screenshot from 2020-02-24 01-50-32](https://user-images.githubusercontent.com/1448289/75136029-f568c500-56a8-11ea-8283-87760a64ce90.png)

EDIT: Meant to make a draft PR, but I clicked the wrong button, [and there is no way to go back](https://github.community/t5/How-to-use-Git-and-GitHub/Feature-Request-Switch-from-ready-to-draft-in-pull-requests/td-p/19107/page/5). Closing for now, and I'll keep working on it until it is actually ready and re-open? 