### PR TITLE
Update the wast crate in the witx tool

### DIFF
--- a/tools/witx/Cargo.toml
+++ b/tools/witx/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 
 [dependencies]
 structopt = "0.3"
-wast = "8.0.0"
+wast = { version = "9.0.0", default-features = false }
 thiserror = "1.0"
 log = "0.4"
 pretty_env_logger = "0.3"


### PR DESCRIPTION
This updates the necessary glue to parse annotations, since the `wast`
crate now has more official support for annotations.