### PR TITLE
Reorder params/results in clock_res_get syscall

### DIFF
--- a/phases/ephemeral/witx/wasi_ephemeral_clock.witx
+++ b/phases/ephemeral/witx/wasi_ephemeral_clock.witx
@@ -16,9 +16,9 @@
   ;;; return `errno::inval`.
   ;;; Note: This is similar to `clock_getres` in POSIX.
   (@interface func (export "res_get")
-    (result $error $errno)
     ;;; The clock for which to return the resolution.
     (param $id $clockid)
+    (result $error $errno)
     ;;; The resolution of the clock.
     (result $resolution $timestamp)
   )

--- a/phases/old/snapshot_0/witx/wasi_unstable.witx
+++ b/phases/old/snapshot_0/witx/wasi_unstable.witx
@@ -52,9 +52,9 @@
   ;;; `errno::inval`.
   ;;; Note: This is similar to `clock_getres` in POSIX.
   (@interface func (export "clock_res_get")
-    (result $error $errno)
     ;;; The clock for which to return the resolution.
     (param $id $clockid)
+    (result $error $errno)
     ;;; The resolution of the clock.
     (result $resolution $timestamp)
   )

--- a/phases/snapshot/witx/wasi_snapshot_preview1.witx
+++ b/phases/snapshot/witx/wasi_snapshot_preview1.witx
@@ -49,9 +49,9 @@
   ;;; return `errno::inval`.
   ;;; Note: This is similar to `clock_getres` in POSIX.
   (@interface func (export "clock_res_get")
-    (result $error $errno)
     ;;; The clock for which to return the resolution.
     (param $id $clockid)
+    (result $error $errno)
     ;;; The resolution of the clock.
     (result $resolution $timestamp)
   )


### PR DESCRIPTION
This is merely a stylistic nit which strives to maintain consistency
across all WASI syscalls in that `param`s *always* precede `result`s
in `*.witx` specs.