### PR TITLE
Add a documentation comment for the `$size` type.

### DIFF
--- a/phases/ephemeral/docs.md
+++ b/phases/ephemeral/docs.md
@@ -1,5 +1,8 @@
 # Types
 ## <a href="#size" name="size"></a> `size`: `usize`
+An array size.
+
+Note: This is similar to `size_t` in POSIX.
 
 ## <a href="#filesize" name="filesize"></a> `filesize`: `u64`
 Non-negative file size or length of a region within a file.

--- a/phases/ephemeral/witx/typenames.witx
+++ b/phases/ephemeral/witx/typenames.witx
@@ -5,6 +5,9 @@
 ;; This is a `witx` file. See [here](https://github.com/WebAssembly/WASI/tree/master/docs/witx.md)
 ;; for an explanation of what that means.
 
+;;; An array size.
+;;;
+;;; Note: This is similar to `size_t` in POSIX.
 (typename $size (@witx usize))
 
 ;;; Non-negative file size or length of a region within a file.


### PR DESCRIPTION
Add a simple documentation comment for the `$size` type.