### PR TITLE
Backport fd as handle to past and current snapshots

### DIFF
--- a/phases/old/snapshot_0/docs.md
+++ b/phases/old/snapshot_0/docs.md
@@ -368,9 +368,10 @@ If [`rights::fd_write`](#rights.fd_write) is set, includes the right to invoke [
 - <a href="#rights.sock_shutdown" name="rights.sock_shutdown"></a> `sock_shutdown`
 The right to invoke [`sock_shutdown`](#sock_shutdown).
 
-## <a href="#fd" name="fd"></a> `fd`: `u32`
-A file descriptor index.
+## <a href="#fd" name="fd"></a> `fd`
+A file descriptor handle.
 
+### Supertypes
 ## <a href="#iovec" name="iovec"></a> `iovec`: Struct
 A region of memory for scatter/gather reads.
 

--- a/phases/old/snapshot_0/witx/typenames.witx
+++ b/phases/old/snapshot_0/witx/typenames.witx
@@ -273,8 +273,8 @@
   )
 )
 
-;;; A file descriptor index.
-(typename $fd u32)
+;;; A file descriptor handle.
+(typename $fd (handle))
 
 ;;; A region of memory for scatter/gather reads.
 (typename $iovec

--- a/phases/snapshot/docs.md
+++ b/phases/snapshot/docs.md
@@ -368,9 +368,10 @@ If [`rights::fd_write`](#rights.fd_write) is set, includes the right to invoke [
 - <a href="#rights.sock_shutdown" name="rights.sock_shutdown"></a> `sock_shutdown`
 The right to invoke [`sock_shutdown`](#sock_shutdown).
 
-## <a href="#fd" name="fd"></a> `fd`: `u32`
-A file descriptor index.
+## <a href="#fd" name="fd"></a> `fd`
+A file descriptor handle.
 
+### Supertypes
 ## <a href="#iovec" name="iovec"></a> `iovec`: Struct
 A region of memory for scatter/gather reads.
 

--- a/phases/snapshot/witx/typenames.witx
+++ b/phases/snapshot/witx/typenames.witx
@@ -273,8 +273,8 @@
   )
 )
 
-;;; A file descriptor index.
-(typename $fd u32)
+;;; A file descriptor handle.
+(typename $fd (handle))
 
 ;;; A region of memory for scatter/gather reads.
 (typename $iovec


### PR DESCRIPTION
This commit backports fd as handle to past and current snapshots. I'm hoping this could prove useful in situations where currently in the implementor's code, any syscall that deals with `fd`s has to be marked as potentially "unsafe", whereas with `fd` as a handle this would be shifted to the fact that `fd` *is* a handle rather than an alias to an int type.

To put it more into context. Currently, in `wasmtime`, whenever we deal with a WASI fd type in a syscall, we tag the function as `unsafe` which makes perfect sense. The question here then is: could we assume it is safe if the fd was a handle rather than an alias to an int type?

Either way, even if this won't really help with this question, @pchickey and myself still think it's useful to have handles backported to all historic snapshots as well, especially since adding support to the majority of implementors shouldn't be too difficult.

Thoughts and comments are most welcome here!