### PR TITLE
fix error message when docs out of date

### DIFF
--- a/tools/witx/tests/wasi.rs
+++ b/tools/witx/tests/wasi.rs
@@ -155,7 +155,9 @@ fn diff_against_filesystem(expected: &str, path: &Path) {
     }
 
     eprintln!();
-    eprintln!("To regenerate the files, run `cd tools/witx && cargo run -- repo-docs`.");
+    eprintln!(
+        "To regenerate the files, run `cd tools/witx && cargo run --example witx repo-docs`."
+    );
     eprintln!();
     panic!();
 }


### PR DESCRIPTION
The invocation for the docs generator changed with #243 .  Remembered this right after I merged.