### PR TITLE
Describe a primitive reactor ABI.

### DIFF
--- a/design/application-abi.md
+++ b/design/application-abi.md
@@ -20,7 +20,7 @@ There are two kinds of modules:
    is considered terminated and no further use of any of its exports should be
    permitted.
 
- - A *reactor* exports a function named `_activate`, with no arguments and no
+ - A *reactor* exports a function named `_initialize`, with no arguments and no
    return values. Environments shall call this function once, after instantiating
    the module and all of its dependencies. After this function exits, the instance
    remains live, and its exports may be accessed.

--- a/design/application-abi.md
+++ b/design/application-abi.md
@@ -12,20 +12,25 @@ include.
 Current Unstable ABI
 --------------------
 
-The current WASI unstable ABI specifies only two exports from a WASI
-application:
+There are two kinds of modules:
 
-- `_start` - the program entry point
-- `memory` - linear memory used by the program
+ - A *command* exports a function named `_start`, with no arguments and no return
+   values. Environments shall call this function once, after instantiating the
+   module and all of its dependencies. After this function exits, the instance
+   is considered terminated and no further use of any of its exports should be
+   permitted.
 
-The `_start` export must be WebAssembly function and will be used as the program
-entry point.  This is the default name used by `lld` when linking WebAssembly
-modules.  The embedder is expected to call this function once the module is
-instantiated.
+ - A *reactor* exports a function named `_activate`, with no arguments and no
+   return values. Environments shall call this function once, after instantiating
+   the module and all of its dependencies. After this function exits, the instance
+   remains live, and its exports may be accessed.
 
-Many of the current WASI unstable APIs require sharing of linear memory between
-the application and the embedder.  In order to use any such APIs the WASI module
-is expected to export its linear memory under the name `memory`.
+Regardless of the kind, all programs accessing WASI APIs also export a linear
+memory with the name `memory`. Pointers in WASI API calls are relative to this
+memory's index space.
+
+In the future, as the underlying WebAssembly platform offers more features, we
+we hope to eliminate the requirement to export all of linear memory.
 
 Planned Stable ABI
 ------------------

--- a/design/application-abi.md
+++ b/design/application-abi.md
@@ -25,6 +25,10 @@ There are two kinds of modules:
    the module and all of its dependencies. After this function exits, the instance
    remains live, and its exports may be accessed.
 
+These kinds are mutually exclusive; implementations should report an error if
+asked to instantiate a module containing exports which declare it to be of
+multiple kinds.
+
 Regardless of the kind, all programs accessing WASI APIs also export a linear
 memory with the name `memory`. Pointers in WASI API calls are relative to this
 memory's index space.


### PR DESCRIPTION
This adds a new reactor ABI, indicated by exporting the function
"_activate". For now, a reactor is just a module which doesn't have
a lifetime scoped by a "_start" or "main" function, though it may
evolve to include other semantics in the future.