### PR TITLE
Document atomicity of `write` and `pwrite`, and technical fix about POSIX

### DIFF
--- a/phases/ephemeral/docs.md
+++ b/phases/ephemeral/docs.md
@@ -1466,10 +1466,9 @@ A buffer into which to write the preopened directory name.
 Write to a file descriptor, without using and updating the file descriptor's offset.
 Note: This is similar to `pwritev` in Linux (and other Unix-es).
 
-Like Linux (and other Unix-es), [`pwrite`](#pwrite) should write all data in the `$fd` is
-for a regular file or a symbolic link to a regular file: Any calls of [`pwrite`](#pwrite)
-(and other functions to read or write on the file) by other threads in the WASI
-process should not be interleaved while [`pwrite`](#pwrite) is executed.
+Like Linux (and other Unix-es), Any calls of [`pwrite`](#pwrite) (and other
+functions to read or write) for a regular file by other threads in the
+WASI process should not be interleaved while [`pwrite`](#pwrite) is executed.
 
 ##### Params
 - <a href="#pwrite.fd" name="pwrite.fd"></a> `fd`: [`fd`](#fd)
@@ -1616,10 +1615,9 @@ The current offset of the file descriptor, relative to the start of the file.
 Write to a file descriptor.
 Note: This is similar to `writev` in POSIX.
 
-Like POSIX, [`write`](#write) should write all data in `$iovs` atomically if the `$fd` is
-for a regular file or a symbolic link to a regular file: Any calls of [`write`](#write)
-(and other functions to read or write on the file) by other threads in the WASI
-process should not be interleaved while [`write`](#write) is executed.
+Like POSIX, Any calls of [`write`](#write) (and other functions to read or write)
+for a regular file by other threads in the WASI process should not be
+interleaved while [`write`](#write) is executed.
 
 ##### Params
 - <a href="#write.fd" name="write.fd"></a> `fd`: [`fd`](#fd)

--- a/phases/ephemeral/docs.md
+++ b/phases/ephemeral/docs.md
@@ -1410,7 +1410,7 @@ The permissions associated with the file.
 
 #### <a href="#pread" name="pread"></a> `pread(fd: fd, iovs: iovec_array, offset: filesize) -> (errno, size)`
 Read from a file descriptor, without using and updating the file descriptor's offset.
-Note: This is similar to `preadv` in POSIX.
+Note: This is similar to `preadv` in Linux (and other Unix-es).
 
 ##### Params
 - <a href="#pread.fd" name="pread.fd"></a> `fd`: [`fd`](#fd)
@@ -1464,7 +1464,12 @@ A buffer into which to write the preopened directory name.
 
 #### <a href="#pwrite" name="pwrite"></a> `pwrite(fd: fd, iovs: ciovec_array, offset: filesize) -> (errno, size)`
 Write to a file descriptor, without using and updating the file descriptor's offset.
-Note: This is similar to `pwritev` in POSIX.
+Note: This is similar to `pwritev` in Linux (and other Unix-es).
+
+Like Linux (and other Unix-es), [`pwrite`](#pwrite) should write all data in `$iovs`
+atomically: Any concurrent calls of [`pwrite`](#pwrite) (and other functions to read or write
+on the file) by other threads in the WASI process should see the data in `$iovs`
+either written all or not written at all.
 
 ##### Params
 - <a href="#pwrite.fd" name="pwrite.fd"></a> `fd`: [`fd`](#fd)
@@ -1610,6 +1615,11 @@ The current offset of the file descriptor, relative to the start of the file.
 #### <a href="#write" name="write"></a> `write(fd: fd, iovs: ciovec_array) -> (errno, size)`
 Write to a file descriptor.
 Note: This is similar to `writev` in POSIX.
+
+Like POSIX, [`write`](#write) should write all data in `$iovs`
+atomically: Any concurrent calls of [`write`](#write) (and other functions to read or write
+on the file) by other threads in the WASI process should see the data in `$iovs`
+either written all or not written at all.
 
 ##### Params
 - <a href="#write.fd" name="write.fd"></a> `fd`: [`fd`](#fd)

--- a/phases/ephemeral/docs.md
+++ b/phases/ephemeral/docs.md
@@ -1466,10 +1466,10 @@ A buffer into which to write the preopened directory name.
 Write to a file descriptor, without using and updating the file descriptor's offset.
 Note: This is similar to `pwritev` in Linux (and other Unix-es).
 
-Like Linux (and other Unix-es), [`pwrite`](#pwrite) should write all data in `$iovs`
-atomically: Any concurrent calls of [`pwrite`](#pwrite) (and other functions to read or write
-on the file) by other threads in the WASI process should see the data in `$iovs`
-either written all or not written at all.
+Like Linux (and other Unix-es), [`pwrite`](#pwrite) should write all data in the `$fd` is
+for a regular file or a symbolic link to a regular file: Any calls of [`pwrite`](#pwrite)
+(and other functions to read or write on the file) by other threads in the WASI
+process should not be interleaved while [`pwrite`](#pwrite) is executed.
 
 ##### Params
 - <a href="#pwrite.fd" name="pwrite.fd"></a> `fd`: [`fd`](#fd)
@@ -1616,10 +1616,10 @@ The current offset of the file descriptor, relative to the start of the file.
 Write to a file descriptor.
 Note: This is similar to `writev` in POSIX.
 
-Like POSIX, [`write`](#write) should write all data in `$iovs`
-atomically: Any concurrent calls of [`write`](#write) (and other functions to read or write
-on the file) by other threads in the WASI process should see the data in `$iovs`
-either written all or not written at all.
+Like POSIX, [`write`](#write) should write all data in `$iovs` atomically if the `$fd` is
+for a regular file or a symbolic link to a regular file: Any calls of [`write`](#write)
+(and other functions to read or write on the file) by other threads in the WASI
+process should not be interleaved while [`write`](#write) is executed.
 
 ##### Params
 - <a href="#write.fd" name="write.fd"></a> `fd`: [`fd`](#fd)

--- a/phases/ephemeral/docs.md
+++ b/phases/ephemeral/docs.md
@@ -1466,7 +1466,7 @@ A buffer into which to write the preopened directory name.
 Write to a file descriptor, without using and updating the file descriptor's offset.
 Note: This is similar to `pwritev` in Linux (and other Unix-es).
 
-Like Linux (and other Unix-es), Any calls of [`pwrite`](#pwrite) (and other
+Like Linux (and other Unix-es), any calls of [`pwrite`](#pwrite) (and other
 functions to read or write) for a regular file by other threads in the
 WASI process should not be interleaved while [`pwrite`](#pwrite) is executed.
 
@@ -1615,7 +1615,7 @@ The current offset of the file descriptor, relative to the start of the file.
 Write to a file descriptor.
 Note: This is similar to `writev` in POSIX.
 
-Like POSIX, Any calls of [`write`](#write) (and other functions to read or write)
+Like POSIX, any calls of [`write`](#write) (and other functions to read or write)
 for a regular file by other threads in the WASI process should not be
 interleaved while [`write`](#write) is executed.
 

--- a/phases/ephemeral/witx/wasi_ephemeral_fd.witx
+++ b/phases/ephemeral/witx/wasi_ephemeral_fd.witx
@@ -159,10 +159,9 @@
   ;;; Write to a file descriptor, without using and updating the file descriptor's offset.
   ;;; Note: This is similar to `pwritev` in Linux (and other Unix-es).
   ;;;
-  ;;; Like Linux (and other Unix-es), `pwrite` should write all data in the `$fd` is
-  ;;; for a regular file or a symbolic link to a regular file: Any calls of `pwrite`
-  ;;; (and other functions to read or write on the file) by other threads in the WASI
-  ;;; process should not be interleaved while `pwrite` is executed.
+  ;;; Like Linux (and other Unix-es), Any calls of `pwrite` (and other
+  ;;; functions to read or write) for a regular file by other threads in the
+  ;;; WASI process should not be interleaved while `pwrite` is executed.
   (@interface func (export "pwrite")
     (param $fd $fd)
     ;;; List of scatter/gather vectors from which to retrieve data.
@@ -256,10 +255,9 @@
   ;;; Write to a file descriptor.
   ;;; Note: This is similar to `writev` in POSIX.
   ;;;
-  ;;; Like POSIX, `write` should write all data in `$iovs` atomically if the `$fd` is
-  ;;; for a regular file or a symbolic link to a regular file: Any calls of `write`
-  ;;; (and other functions to read or write on the file) by other threads in the WASI
-  ;;; process should not be interleaved while `write` is executed.
+  ;;; Like POSIX, Any calls of `write` (and other functions to read or write)
+  ;;; for a regular file by other threads in the WASI process should not be
+  ;;; interleaved while `write` is executed.
   (@interface func (export "write")
     (param $fd $fd)
     ;;; List of scatter/gather vectors from which to retrieve data.

--- a/phases/ephemeral/witx/wasi_ephemeral_fd.witx
+++ b/phases/ephemeral/witx/wasi_ephemeral_fd.witx
@@ -127,7 +127,7 @@
   )
 
   ;;; Read from a file descriptor, without using and updating the file descriptor's offset.
-  ;;; Note: This is similar to `preadv` in POSIX.
+  ;;; Note: This is similar to `preadv` in Linux (and other Unix-es).
   (@interface func (export "pread")
     (param $fd $fd)
     ;;; List of scatter/gather vectors in which to store data.
@@ -157,7 +157,7 @@
   )
 
   ;;; Write to a file descriptor, without using and updating the file descriptor's offset.
-  ;;; Note: This is similar to `pwritev` in POSIX.
+  ;;; Note: This is similar to `pwritev` in Linux (and other Unix-es).
   (@interface func (export "pwrite")
     (param $fd $fd)
     ;;; List of scatter/gather vectors from which to retrieve data.

--- a/phases/ephemeral/witx/wasi_ephemeral_fd.witx
+++ b/phases/ephemeral/witx/wasi_ephemeral_fd.witx
@@ -159,7 +159,7 @@
   ;;; Write to a file descriptor, without using and updating the file descriptor's offset.
   ;;; Note: This is similar to `pwritev` in Linux (and other Unix-es).
   ;;;
-  ;;; Like Linux (and other Unix-es), Any calls of `pwrite` (and other
+  ;;; Like Linux (and other Unix-es), any calls of `pwrite` (and other
   ;;; functions to read or write) for a regular file by other threads in the
   ;;; WASI process should not be interleaved while `pwrite` is executed.
   (@interface func (export "pwrite")
@@ -255,7 +255,7 @@
   ;;; Write to a file descriptor.
   ;;; Note: This is similar to `writev` in POSIX.
   ;;;
-  ;;; Like POSIX, Any calls of `write` (and other functions to read or write)
+  ;;; Like POSIX, any calls of `write` (and other functions to read or write)
   ;;; for a regular file by other threads in the WASI process should not be
   ;;; interleaved while `write` is executed.
   (@interface func (export "write")

--- a/phases/ephemeral/witx/wasi_ephemeral_fd.witx
+++ b/phases/ephemeral/witx/wasi_ephemeral_fd.witx
@@ -159,10 +159,10 @@
   ;;; Write to a file descriptor, without using and updating the file descriptor's offset.
   ;;; Note: This is similar to `pwritev` in Linux (and other Unix-es).
   ;;;
-  ;;; Like Linux (and other Unix-es), `pwrite` should write all data in `$iovs`
-  ;;; atomically: Any concurrent calls of `pwrite` (and other functions to read or write
-  ;;; on the file) by other threads in the WASI process should see the data in `$iovs`
-  ;;; either written all or not written at all.
+  ;;; Like Linux (and other Unix-es), `pwrite` should write all data in the `$fd` is
+  ;;; for a regular file or a symbolic link to a regular file: Any calls of `pwrite`
+  ;;; (and other functions to read or write on the file) by other threads in the WASI
+  ;;; process should not be interleaved while `pwrite` is executed.
   (@interface func (export "pwrite")
     (param $fd $fd)
     ;;; List of scatter/gather vectors from which to retrieve data.
@@ -256,10 +256,10 @@
   ;;; Write to a file descriptor.
   ;;; Note: This is similar to `writev` in POSIX.
   ;;;
-  ;;; Like POSIX, `write` should write all data in `$iovs`
-  ;;; atomically: Any concurrent calls of `write` (and other functions to read or write
-  ;;; on the file) by other threads in the WASI process should see the data in `$iovs`
-  ;;; either written all or not written at all.
+  ;;; Like POSIX, `write` should write all data in `$iovs` atomically if the `$fd` is
+  ;;; for a regular file or a symbolic link to a regular file: Any calls of `write`
+  ;;; (and other functions to read or write on the file) by other threads in the WASI
+  ;;; process should not be interleaved while `write` is executed.
   (@interface func (export "write")
     (param $fd $fd)
     ;;; List of scatter/gather vectors from which to retrieve data.

--- a/phases/ephemeral/witx/wasi_ephemeral_fd.witx
+++ b/phases/ephemeral/witx/wasi_ephemeral_fd.witx
@@ -158,6 +158,11 @@
 
   ;;; Write to a file descriptor, without using and updating the file descriptor's offset.
   ;;; Note: This is similar to `pwritev` in Linux (and other Unix-es).
+  ;;;
+  ;;; Like Linux (and other Unix-es), `pwrite` should write all data in `$iovs`
+  ;;; atomically: Any concurrent calls of `pwrite` (and other functions to
+  ;;; read or write on the file) should see the data in `$iovs` either written all or
+  ;;; not written at all.
   (@interface func (export "pwrite")
     (param $fd $fd)
     ;;; List of scatter/gather vectors from which to retrieve data.
@@ -250,6 +255,11 @@
 
   ;;; Write to a file descriptor.
   ;;; Note: This is similar to `writev` in POSIX.
+  ;;;
+  ;;; Like POSIX, `write` should write all data in `$iovs`
+  ;;; atomically: Any concurrent calls of `write` (and other functions to
+  ;;; read or write on the file) should see the data in `$iovs` either written all or
+  ;;; not written at all.
   (@interface func (export "write")
     (param $fd $fd)
     ;;; List of scatter/gather vectors from which to retrieve data.

--- a/phases/ephemeral/witx/wasi_ephemeral_fd.witx
+++ b/phases/ephemeral/witx/wasi_ephemeral_fd.witx
@@ -160,9 +160,9 @@
   ;;; Note: This is similar to `pwritev` in Linux (and other Unix-es).
   ;;;
   ;;; Like Linux (and other Unix-es), `pwrite` should write all data in `$iovs`
-  ;;; atomically: Any concurrent calls of `pwrite` (and other functions to
-  ;;; read or write on the file) should see the data in `$iovs` either written all or
-  ;;; not written at all.
+  ;;; atomically: Any concurrent calls of `pwrite` (and other functions to read or write
+  ;;; on the file) by other threads in the WASI process should see the data in `$iovs`
+  ;;; either written all or not written at all.
   (@interface func (export "pwrite")
     (param $fd $fd)
     ;;; List of scatter/gather vectors from which to retrieve data.
@@ -257,9 +257,9 @@
   ;;; Note: This is similar to `writev` in POSIX.
   ;;;
   ;;; Like POSIX, `write` should write all data in `$iovs`
-  ;;; atomically: Any concurrent calls of `write` (and other functions to
-  ;;; read or write on the file) should see the data in `$iovs` either written all or
-  ;;; not written at all.
+  ;;; atomically: Any concurrent calls of `write` (and other functions to read or write
+  ;;; on the file) by other threads in the WASI process should see the data in `$iovs`
+  ;;; either written all or not written at all.
   (@interface func (export "write")
     (param $fd $fd)
     ;;; List of scatter/gather vectors from which to retrieve data.


### PR DESCRIPTION
See the commit message of each commit for details.