### PR TITLE
Move $d_namlen to the end of $dirent

### DIFF
--- a/phases/ephemeral/docs.md
+++ b/phases/ephemeral/docs.md
@@ -558,13 +558,13 @@ The serial number of the file referred to by this directory entry.
 
 Offset: 8
 
-- <a href="#dirent.d_namlen" name="dirent.d_namlen"></a> `d_namlen`: [`dirnamlen`](#dirnamlen)
-The length of the name of the directory entry.
+- <a href="#dirent.d_type" name="dirent.d_type"></a> `d_type`: [`filetype`](#filetype)
+The type of the file referred to by this directory entry.
 
 Offset: 16
 
-- <a href="#dirent.d_type" name="dirent.d_type"></a> `d_type`: [`filetype`](#filetype)
-The type of the file referred to by this directory entry.
+- <a href="#dirent.d_namlen" name="dirent.d_namlen"></a> `d_namlen`: [`dirnamlen`](#dirnamlen)
+The length of the name of the directory entry.
 
 Offset: 20
 

--- a/phases/ephemeral/witx/typenames.witx
+++ b/phases/ephemeral/witx/typenames.witx
@@ -367,10 +367,10 @@
     (field $d_next $dircookie)
     ;;; The serial number of the file referred to by this directory entry.
     (field $d_ino $inode)
-    ;;; The length of the name of the directory entry.
-    (field $d_namlen $dirnamlen)
     ;;; The type of the file referred to by this directory entry.
     (field $d_type $filetype)
+    ;;; The length of the name of the directory entry.
+    (field $d_namlen $dirnamlen)
   )
 )
 


### PR DESCRIPTION
Just a minor (although ABI breaking) nit suggestion that stuck out to me when implementing `fd_readdir`.

Currently `$dirent` has the filetype in-between the name length and the name data so you end up scanning the length of entry's name, writing the type of the entry then going back to write out the name data.

