### PR TITLE
Fix links to dirent struct in fd_readdir description

### DIFF
--- a/phases/old/snapshot_0/docs.md
+++ b/phases/old/snapshot_0/docs.md
@@ -480,7 +480,7 @@ Size: 8
 Alignment: 8
 
 ## <a href="#dirnamlen" name="dirnamlen"></a> `dirnamlen`: `u32`
-The type for the $d_namlen field of $dirent.
+The type for the [`dirent::d_namlen`](#dirent.d_namlen) field of [`dirent`](#dirent) struct.
 
 Size: 4
 
@@ -1541,8 +1541,8 @@ The number of bytes read.
 #### <a href="#fd_readdir" name="fd_readdir"></a> `fd_readdir(fd: fd, buf: Pointer<u8>, buf_len: size, cookie: dircookie) -> (errno, size)`
 Read directory entries from a directory.
 When successful, the contents of the output buffer consist of a sequence of
-directory entries. Each directory entry consists of a dirent_t object,
-followed by dirent_t::d_namlen bytes holding the name of the directory
+directory entries. Each directory entry consists of a [`dirent`](#dirent) object,
+followed by [`dirent::d_namlen`](#dirent.d_namlen) bytes holding the name of the directory
 entry.
 This function fills the output buffer as much as possible, potentially
 truncating the last directory entry. This allows the caller to grow its

--- a/phases/old/snapshot_0/witx/typenames.witx
+++ b/phases/old/snapshot_0/witx/typenames.witx
@@ -317,7 +317,7 @@
 ;;; A reference to the offset of a directory entry.
 (typename $dircookie u64)
 
-;;; The type for the $d_namlen field of $dirent.
+;;; The type for the `dirent::d_namlen` field of `dirent` struct.
 (typename $dirnamlen u32)
 
 ;;; File serial number that is unique within its file system.

--- a/phases/old/snapshot_0/witx/wasi_unstable.witx
+++ b/phases/old/snapshot_0/witx/wasi_unstable.witx
@@ -222,8 +222,8 @@
 
   ;;; Read directory entries from a directory.
   ;;; When successful, the contents of the output buffer consist of a sequence of
-  ;;; directory entries. Each directory entry consists of a dirent_t object,
-  ;;; followed by dirent_t::d_namlen bytes holding the name of the directory
+  ;;; directory entries. Each directory entry consists of a `dirent` object,
+  ;;; followed by `dirent::d_namlen` bytes holding the name of the directory
   ;;; entry.
   ;;
   ;;; This function fills the output buffer as much as possible, potentially

--- a/phases/snapshot/docs.md
+++ b/phases/snapshot/docs.md
@@ -482,7 +482,7 @@ Size: 8
 Alignment: 8
 
 ## <a href="#dirnamlen" name="dirnamlen"></a> `dirnamlen`: `u32`
-The type for the $d_namlen field of $dirent.
+The type for the [`dirent::d_namlen`](#dirent.d_namlen) field of [`dirent`](#dirent) struct.
 
 Size: 4
 
@@ -1538,8 +1538,8 @@ The number of bytes read.
 #### <a href="#fd_readdir" name="fd_readdir"></a> `fd_readdir(fd: fd, buf: Pointer<u8>, buf_len: size, cookie: dircookie) -> (errno, size)`
 Read directory entries from a directory.
 When successful, the contents of the output buffer consist of a sequence of
-directory entries. Each directory entry consists of a dirent_t object,
-followed by dirent_t::d_namlen bytes holding the name of the directory
+directory entries. Each directory entry consists of a [`dirent`](#dirent) object,
+followed by [`dirent::d_namlen`](#dirent.d_namlen) bytes holding the name of the directory
 entry.
 This function fills the output buffer as much as possible, potentially
 truncating the last directory entry. This allows the caller to grow its

--- a/phases/snapshot/witx/typenames.witx
+++ b/phases/snapshot/witx/typenames.witx
@@ -319,7 +319,7 @@
 ;;; The value 0 signifies the start of the directory.
 (typename $dircookie u64)
 
-;;; The type for the $d_namlen field of $dirent.
+;;; The type for the `dirent::d_namlen` field of `dirent` struct.
 (typename $dirnamlen u32)
 
 ;;; File serial number that is unique within its file system.

--- a/phases/snapshot/witx/wasi_snapshot_preview1.witx
+++ b/phases/snapshot/witx/wasi_snapshot_preview1.witx
@@ -219,8 +219,8 @@
 
   ;;; Read directory entries from a directory.
   ;;; When successful, the contents of the output buffer consist of a sequence of
-  ;;; directory entries. Each directory entry consists of a dirent_t object,
-  ;;; followed by dirent_t::d_namlen bytes holding the name of the directory
+  ;;; directory entries. Each directory entry consists of a `dirent` object,
+  ;;; followed by `dirent::d_namlen` bytes holding the name of the directory
   ;;; entry.
   ;;
   ;;; This function fills the output buffer as much as possible, potentially


### PR DESCRIPTION
This commit fixes links in `fd_readdir` description/docs which were
using an outdated (now invalid) ref syntax when referencing `dirent`
struct.

The changes apply to docs only and only to `wasi_unstable` and
`wasi_snapshot_preview1` snapshots. The `wasi_ephemeral` has properly
referenced links.