### PR TITLE
Fix link to event struct

### DIFF
--- a/phases/old/snapshot_0/docs.md
+++ b/phases/old/snapshot_0/docs.md
@@ -788,7 +788,7 @@ Alignment: 2
 The peer of this socket has closed or disconnected.
 
 ## <a href="#event_fd_readwrite" name="event_fd_readwrite"></a> `event_fd_readwrite`: Struct
-The contents of an $event for the [`eventtype::fd_read`](#eventtype.fd_read) and
+The contents of an [`event`](#event) for the [`eventtype::fd_read`](#eventtype.fd_read) and
 [`eventtype::fd_write`](#eventtype.fd_write) variants
 
 Size: 16

--- a/phases/old/snapshot_0/witx/typenames.witx
+++ b/phases/old/snapshot_0/witx/typenames.witx
@@ -503,7 +503,7 @@
   )
 )
 
-;;; The contents of an $event for the `eventtype::fd_read` and
+;;; The contents of an `event` for the `eventtype::fd_read` and
 ;;; `eventtype::fd_write` variants
 (typename $event_fd_readwrite
   (struct

--- a/phases/snapshot/docs.md
+++ b/phases/snapshot/docs.md
@@ -790,7 +790,7 @@ Alignment: 2
 The peer of this socket has closed or disconnected.
 
 ## <a href="#event_fd_readwrite" name="event_fd_readwrite"></a> `event_fd_readwrite`: Struct
-The contents of an $event when type is [`eventtype::fd_read`](#eventtype.fd_read) or
+The contents of an [`event`](#event) when type is [`eventtype::fd_read`](#eventtype.fd_read) or
 [`eventtype::fd_write`](#eventtype.fd_write).
 
 Size: 16

--- a/phases/snapshot/witx/typenames.witx
+++ b/phases/snapshot/witx/typenames.witx
@@ -505,7 +505,7 @@
   )
 )
 
-;;; The contents of an $event when type is `eventtype::fd_read` or
+;;; The contents of an `event` when type is `eventtype::fd_read` or
 ;;; `eventtype::fd_write`.
 (typename $event_fd_readwrite
   (struct


### PR DESCRIPTION
This commit fixes an outdated ref syntax when referencing back to
`event` struct.