### PR TITLE
Add support for multi-call executables

### DIFF
--- a/design/application-abi.md
+++ b/design/application-abi.md
@@ -15,10 +15,17 @@ Current Unstable ABI
 There are two kinds of modules:
 
  - A *command* exports a function named `_start`, with no arguments and no return
-   values. Environments shall call this function once, after instantiating the
-   module and all of its dependencies. After this function exits, the instance
-   is considered terminated and no further use of any of its exports should be
-   permitted.
+   values.
+
+   `_start` is the default export which is called when the user doesn't select a
+   specific function to call. Commands may also export additional functions,
+   (similar to "multi-call" executables), which may be explicitly selected by the
+   user to run instead.
+
+   Functions exported from a command are available to be called without a
+   pre-existing instance. When they are called, the module is instantiated and used
+   by the call, and when the call returns, the instance is considered terminated
+   and may not be accessed.
 
  - A *reactor* exports a function named `_initialize`, with no arguments and no
    return values. Environments shall call this function once, after instantiating

--- a/design/application-abi.md
+++ b/design/application-abi.md
@@ -32,9 +32,9 @@ There are two kinds of modules:
  - All other modules are *reactors*. A reactor may export a function named
    `_initialize`, with no arguments and no return values.
 
-   Reactor instances may assume that the `_initialize` export, if present will
-   be called by the environment at most once. Reactor instances may assume that
-   none of their exports are accessed before that call.
+   If an `_initialize` export is present, reactor instances may assume that it
+   will be called by the environment at most once, and that none of their
+   other exports are accessed before that call.
 
    After being instantiated, and after any `_initialize` function is called,
    a reactor instance remains live, and its exports may be accessed.

--- a/design/application-abi.md
+++ b/design/application-abi.md
@@ -29,10 +29,11 @@ There are two kinds of modules:
    at most once; after the call returns, command instances may assume that none
    of their exports are accessed thereafter.
 
- - A *reactor* exports a function named `_initialize`, with no arguments and no
-   return values. Environments shall call this function once, after instantiating
-   the module and all of its dependencies. After this function exits, the instance
-   remains live, and its exports may be accessed.
+ - All other modules are *reactors*. A reactor may export a function named
+   `_initialize`, with no arguments and no return values. Environments shall call
+   this function once, after instantiating the module and all of its dependencies.
+   After this function exits, the instance remains live, and its exports may be
+   accessed.
 
 These kinds are mutually exclusive; implementations should report an error if
 asked to instantiate a module containing exports which declare it to be of

--- a/design/application-abi.md
+++ b/design/application-abi.md
@@ -58,7 +58,7 @@ these exports.
 
 In the future, as the underlying WebAssembly platform offers more features, we
 we hope to eliminate the requirement to export all of linear memory or all of
-the indirection function table.
+the indirect function table.
 
 Planned Stable ABI
 ------------------

--- a/design/application-abi.md
+++ b/design/application-abi.md
@@ -25,10 +25,9 @@ There are two kinds of modules:
    Except as noted below, commands shall not export any globals, tables, or
    linear memories.
 
-   Functions exported from a command are available to be called without a
-   pre-existing instance. When they are called, the module is instantiated and used
-   by the call, and when the call returns, the instance is considered terminated
-   and shall not be accessed.
+   Command instances may assume that they will be called from the environment
+   at most once; after the call returns, command instances may assume that none
+   of their exports are accessed thereafter.
 
  - A *reactor* exports a function named `_initialize`, with no arguments and no
    return values. Environments shall call this function once, after instantiating

--- a/design/application-abi.md
+++ b/design/application-abi.md
@@ -26,8 +26,8 @@ There are two kinds of modules:
    linear memories.
 
    Command instances may assume that they will be called from the environment
-   at most once; after the call returns, command instances may assume that none
-   of their exports are accessed thereafter.
+   at most once. Command instances may assume that none of their exports are
+   accessed outside the duraction of that call.
 
  - All other modules are *reactors*. A reactor may export a function named
    `_initialize`, with no arguments and no return values. Environments shall call

--- a/design/application-abi.md
+++ b/design/application-abi.md
@@ -36,12 +36,22 @@ These kinds are mutually exclusive; implementations should report an error if
 asked to instantiate a module containing exports which declare it to be of
 multiple kinds.
 
-Regardless of the kind, all programs accessing WASI APIs also export a linear
-memory with the name `memory`. Pointers in WASI API calls are relative to this
-memory's index space.
+Regardless of the kind, all modules accessing WASI APIs also export a linear
+memory with the name `memory`. Data pointers in WASI API calls are relative to
+this memory's index space.
+
+Regardless of the kind, all modules accessing WASI APIs also export a table
+with the name `__indirect_function_table`. Function pointers in WASI API calls
+are relative to this table's index space.
+
+For compatibility with existing toolchains, modules may also export globals
+named `__heap_base` and `__data_end`. Environments shall not access them.
+This provision is deprecated and toolchains are encouraged to avoid providing
+these exports.
 
 In the future, as the underlying WebAssembly platform offers more features, we
-we hope to eliminate the requirement to export all of linear memory.
+we hope to eliminate the requirement to export all of linear memory or all of
+the indirection function table.
 
 Planned Stable ABI
 ------------------

--- a/design/application-abi.md
+++ b/design/application-abi.md
@@ -30,10 +30,14 @@ There are two kinds of modules:
    accessed outside the duraction of that call.
 
  - All other modules are *reactors*. A reactor may export a function named
-   `_initialize`, with no arguments and no return values. Environments shall call
-   this function once, after instantiating the module and all of its dependencies.
-   After this function exits, the instance remains live, and its exports may be
-   accessed.
+   `_initialize`, with no arguments and no return values.
+
+   Reactor instances may assume that the `_initialize` export, if present will
+   be called by the environment at most once. Reactor instances may assume that
+   none of their exports are accessed before that call.
+
+   After being instantiated, and after any `_initialize` function is called,
+   a reactor instance remains live, and its exports may be accessed.
 
 These kinds are mutually exclusive; implementations should report an error if
 asked to instantiate a module containing exports which declare it to be of

--- a/design/application-abi.md
+++ b/design/application-abi.md
@@ -22,10 +22,13 @@ There are two kinds of modules:
    (similar to "multi-call" executables), which may be explicitly selected by the
    user to run instead.
 
+   Except as noted below, commands shall not export any globals, tables, or
+   linear memories.
+
    Functions exported from a command are available to be called without a
    pre-existing instance. When they are called, the module is instantiated and used
    by the call, and when the call returns, the instance is considered terminated
-   and may not be accessed.
+   and shall not be accessed.
 
  - A *reactor* exports a function named `_initialize`, with no arguments and no
    return values. Environments shall call this function once, after instantiating


### PR DESCRIPTION
This expands the definitions of command to allow alternate functions to be exported, in the manner of multi-call executables.

This also includes a description of the `__indirect_function_table` export, as well as the `__heap_case` and `__data_end` exports.