### PR TITLE
Fix link in phases/README.md

### DIFF
--- a/phases/README.md
+++ b/phases/README.md
@@ -9,7 +9,7 @@ for a balance between the need for stability to allow people to build
 compatible implementations, libraries, and tools and gain implementation
 experience, and the need for proposals to evolve.
 
-[phases process]: https://github.com/WebAssembly/WASI/blob/master/phases/README.md
+[process]: https://github.com/WebAssembly/WASI/blob/master/phases/README.md
 
 ## The ephemeral/snapshot/old Phases
 

--- a/phases/README.md
+++ b/phases/README.md
@@ -9,7 +9,7 @@ for a balance between the need for stability to allow people to build
 compatible implementations, libraries, and tools and gain implementation
 experience, and the need for proposals to evolve.
 
-[process]: https://github.com/WebAssembly/WASI/blob/master/phases/README.md
+[process]: https://github.com/WebAssembly/WASI/blob/master/docs/Process.md
 
 ## The ephemeral/snapshot/old Phases
 


### PR DESCRIPTION
The link now properly renders, and leads to... the README itself?

Should it even be kept (or maybe changed to lead elsewhere)?