### PR TITLE
witx: Add trait implementations to `Id`

### DIFF
--- a/tools/witx/src/ast.rs
+++ b/tools/witx/src/ast.rs
@@ -20,6 +20,24 @@ impl AsRef<str> for Id {
     }
 }
 
+impl PartialEq<&str> for Id {
+    fn eq(&self, rhs: &&str) -> bool {
+        PartialEq::eq(self.as_ref(), *rhs)
+    }
+}
+
+impl PartialEq<Id> for &str {
+    fn eq(&self, rhs: &Id) -> bool {
+        PartialEq::eq(*self, rhs.as_ref())
+    }
+}
+
+impl From<&str> for Id {
+    fn from(s: &str) -> Self {
+        Self::new(s)
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct Document {
     definitions: Vec<Definition>,

--- a/tools/witx/src/ast.rs
+++ b/tools/witx/src/ast.rs
@@ -14,6 +14,12 @@ impl Id {
     }
 }
 
+impl AsRef<str> for Id {
+    fn as_ref(&self) -> &str {
+        self.0.as_ref()
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct Document {
     definitions: Vec<Definition>,


### PR DESCRIPTION
While working on bytecodealliance/wasmtime#1793, I noticed that `Id` cannot be compared against strings, or referenced as a string slice. While `as_str` can be used, this often means hanging onto a temporary value, i.e. `let id_str: &str = id.as_str()`.

Because `Id` is a newtype wrapper around a single `String`, it felt like these would be both useful & safe to expose a few more trait implementations, delegating to the underlying `String` value.

After applying these changes, this code will compile:

```rust
use witx::Id;

fn main() {
    let id = Id::new("hello"); // An example of a

    // Compare to string slices, as the lhs.
    let _ = id == "hello";

    // Compare to string slices, as the rhs.
    let _ = "hello" == id;

    // Call `Into::into` and `From::from` on string slices.
    let _: Id = "call into on a string".into();
    let _ = Id::from("call from, on a string");
}
```