### PR TITLE
Describe legacy commands.

### DIFF
--- a/legacy/application-abi.md
+++ b/legacy/application-abi.md
@@ -17,6 +17,14 @@ There are two kinds of modules:
  - A *command* exports a function named `_start`, with no arguments and no return
    values.
 
+   `_start` is the default export which is called when the user doesn't select a
+   specific function to call. Commands may also export additional functions,
+   (similar to "multi-call" executables), which may be explicitly selected by the
+   user to run instead.
+
+   Except as noted below, commands shall not export any mutable globals, tables,
+   or linear memories.
+
    Command instances may assume that they will be called from the environment
    at most once. Command instances may assume that none of their exports are
    accessed outside the duration of that call.


### PR DESCRIPTION
The core idea of legacy commands is that all function exports are
command entrypoints, and they expect to be called on a fresh instance
which lives only for the direction of the call.

This is a generalization of the existing `_start` convention, which
already has the expectation of a fresh instance  which lives only for
the direction of the call, and is one of the pieces need to enable
user-defined command entrypoints which don't take string arguments and
don't return an i32 status code.

To show how this works in practice, the following patches implement
this new behavior in wasm-ld and wasi-libc:
 - https://reviews.llvm.org/D81689
 - https://github.com/WebAssembly/wasi-libc/pull/203