### PR TITLE
Remove reference to non existent modules.md file

### DIFF
--- a/design/application-abi.md
+++ b/design/application-abi.md
@@ -1,7 +1,7 @@
 WASI Application ABI
 ====================
 
-In addition to the APIs defined by the various WASI [modules](modules.md) there
+In addition to the APIs defined by the various WASI modules there
 are also certain expectations that the WASI runtime places on an application
 that wishes to be portable across WASI implementations.
 


### PR DESCRIPTION
I couldn't find a modules.md anywhere else in this repo to link to, so just removed the broken reference.