### PR TITLE
CI: use $GITHUB_PATH rather than add-path

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Install Rust (macos)
       run: |
         curl https://sh.rustup.rs | sh -s -- -y
-        echo "##[add-path]$HOME/.cargo/bin"
+        echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       if: matrix.os == 'macos-latest'
     - run: cargo fetch
       working-directory: tools/witx


### PR DESCRIPTION
In accordance with this advisory it's recommended we move to a
different scheme of setting env vars and updating PATH:

https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/