### PR TITLE
Add wasi-nn to proposals

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,24 +3,25 @@
 ![WASI](WASI.png)
 
 This repository is for the WebAssembly System Interface (WASI) Subgroup of the
-[WebAssembly Community Group]. Its [Charter] describes the goals, scope and
-deliverables of the group. The repository may contain meeting notes, reports,
-documentation, specifications and/or software produced by the group (although
-larger projects may also have their own repositories).
+[WebAssembly Community Group]. It includes:
+ - [charter]: describes the goals, scope and deliverables of the group
+ - [docs]: learn more about WASI
+ - [meetings]: schedules and agendas for video conference and in-person meetings
+ - [phases]: the current WASI specifications
+ - [proposals]: the status of each new specification proposal
 
+[charter]: Charter.md
+[docs]: docs
+[meetings]: meetings/README.md
+[phases]: phases/README.md
+[proposals]: docs/Proposals.md
 [WebAssembly Community Group]: https://www.w3.org/community/webassembly/
-[Charter]: Charter.md
 
 We'll be adding more content here before long, but for now, check out these:
  - https://hacks.mozilla.org/2019/03/standardizing-wasi-a-webassembly-system-interface/ - Blog post introducing WASI
- - https://wasi.dev/ - Links to more information about WASI, including
-   how to get started using it.
+ - https://wasi.dev/ - Links to more information about WASI, including how to get started using it.
  - https://github.com/WebAssembly/WASI/issues - This repo's issue tracker
 
-The issue tracker is the place to ask questions, make suggestions, and start
-discussions.
+### Contributing
 
-Schedules and agendas for video conference and in-person meetings are posted
-[here](meetings/README.md).
-
-API specification proposals are [here](phases/README.md).
+The issue tracker is the place to ask questions, make suggestions, and start discussions.

--- a/docs/Proposals.md
+++ b/docs/Proposals.md
@@ -38,6 +38,7 @@ Proposals follow [this process document](https://github.com/WebAssembly/WASI/blo
 | Proposal                                                                       | Champion                               |
 | ------------------------------------------------------------------------------ | -------------------------------------- |
 | [Crypto][wasi-crypto]                                                          | Frank Denis and Daiki Ueno             |
+| [Machine Learning (wasi-nn)][wasi-nn]                                          | Andrew Brown and Mingqiu Sun           |
 
 ### Phase 0 - Pre-Proposal (CG)
 
@@ -55,5 +56,6 @@ Please see [Contributing to WebAssembly](https://github.com/WebAssembly/WASI/blo
 [wasi-clocks]: https://github.com/WebAssembly/wasi-clocks
 [wasi-random]: https://github.com/WebAssembly/wasi-random
 [wasi-misc]: https://github.com/WebAssembly/wasi-misc
+[wasi-nn]: https://github.com/WebAssembly/wasi-nn
 [wasi-crypto]: https://github.com/WebAssembly/wasi-crypto
 [wasi-proxy-wasm]: https://github.com/proxy-wasm/spec

--- a/docs/Proposals.md
+++ b/docs/Proposals.md
@@ -50,12 +50,12 @@ Proposals follow [this process document](https://github.com/WebAssembly/WASI/blo
 
 Please see [Contributing to WebAssembly](https://github.com/WebAssembly/WASI/blob/master/Contributing.md) for the most up-to-date information on contributing proposals to standard.
 
-[wasi-io]: https://github.com/WebAssembly/wasi-io
-[wasi-filesystem]: https://github.com/WebAssembly/wasi-filesystem
-[wasi-command-line]: https://github.com/WebAssembly/wasi-classic-command
 [wasi-clocks]: https://github.com/WebAssembly/wasi-clocks
-[wasi-random]: https://github.com/WebAssembly/wasi-random
+[wasi-command-line]: https://github.com/WebAssembly/wasi-classic-command
+[wasi-crypto]: https://github.com/WebAssembly/wasi-crypto
+[wasi-filesystem]: https://github.com/WebAssembly/wasi-filesystem
+[wasi-io]: https://github.com/WebAssembly/wasi-io
 [wasi-misc]: https://github.com/WebAssembly/wasi-misc
 [wasi-nn]: https://github.com/WebAssembly/wasi-nn
-[wasi-crypto]: https://github.com/WebAssembly/wasi-crypto
 [wasi-proxy-wasm]: https://github.com/proxy-wasm/spec
+[wasi-random]: https://github.com/WebAssembly/wasi-random

--- a/docs/Proposals.md
+++ b/docs/Proposals.md
@@ -49,11 +49,11 @@ Proposals follow [this process document](https://github.com/WebAssembly/WASI/blo
 
 Please see [Contributing to WebAssembly](https://github.com/WebAssembly/WASI/blob/master/Contributing.md) for the most up-to-date information on contributing proposals to standard.
 
-[wasi-io]: https://github.com/WebAssembly/WASI/phases
-[filesystem]: https://github.com/WebAssembly/WASI/phases
-[wasi-command-line]: https://github.com/WebAssembly/WASI/phases
-[clocks]: https://github.com/WebAssembly/WASI/phases
-[random]: https://github.com/WebAssembly/WASI/phases
-[misc]: https://github.com/WebAssembly/WASI/phases
-[wasi-crypto]: https://github.com/WebAssembly/WASI-crypto
-[wasi-proxy-wasm]: https://github.com/WebAssembly/WASI
+[wasi-io]: https://github.com/WebAssembly/wasi-io
+[wasi-filesystem]: https://github.com/WebAssembly/wasi-filesystem
+[wasi-command-line]: https://github.com/WebAssembly/wasi-classic-command
+[wasi-clocks]: https://github.com/WebAssembly/wasi-clocks
+[wasi-random]: https://github.com/WebAssembly/wasi-random
+[wasi-misc]: https://github.com/WebAssembly/wasi-misc
+[wasi-crypto]: https://github.com/WebAssembly/wasi-crypto
+[wasi-proxy-wasm]: https://github.com/proxy-wasm/spec


### PR DESCRIPTION
This also tweaks the proposals page and adds the proposals page to the main README (re-organizing it a bit in the process).