### PR TITLE
Create documentation landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,17 +11,14 @@ This repository is for the WebAssembly System Interface (WASI) Subgroup of the
  - [proposals]: the status of each new specification proposal
 
 [charter]: Charter.md
-[docs]: docs
+[docs]: docs/README.md
 [meetings]: meetings/README.md
 [phases]: phases/README.md
 [proposals]: docs/Proposals.md
 [WebAssembly Community Group]: https://www.w3.org/community/webassembly/
 
-We'll be adding more content here before long, but for now, check out these:
- - https://hacks.mozilla.org/2019/03/standardizing-wasi-a-webassembly-system-interface/ - Blog post introducing WASI
- - https://wasi.dev/ - Links to more information about WASI, including how to get started using it.
- - https://github.com/WebAssembly/WASI/issues - This repo's issue tracker
-
 ### Contributing
 
-The issue tracker is the place to ask questions, make suggestions, and start discussions.
+The [issue tracker] is the place to ask questions, make suggestions, and start discussions.
+
+[issue tracker]: https://github.com/WebAssembly/WASI/issues

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,15 @@
+# Documentation
+
+WASI documentation includes:
+ - [Overview](WASI-overview.md): provides an introduction to WASI and its history
+ - [Goals](HighLevelGoals.md): a succinct list of WASI's design goals
+ - [Design Principles](DesignPrinciples.md): discusses details on the principles of capability-based security, scope,
+ POSIX/Web, etc.
+ - [WITX](witx.md): an introduction to the WITX specification language
+ - [Process](Process.md): describes how to move a WASI proposal in to the specification
+ - [Proposals](Proposals.md): lists the current WASI proposals by phase
+
+Additionally, here are some links that may be helpful in understanding WASI:
+ - The blog post introducing WASI: [Standardizing WASI: A system interface to run WebAssembly outside the web](https://hacks.mozilla.org/2019/03/standardizing-wasi-a-webassembly-system-interface/)
+ - The [wasi.dev](https://wasi.dev) web site includes links to more information about WASI, including how to get started using it
+ - This repository's [issue tracker](https://github.com/WebAssembly/WASI/issues) 


### PR DESCRIPTION
As discussed in https://github.com/WebAssembly/WASI/pull/329#discussion_r505020459, this change creates a landing page explaining roughly what you get in each of the documentation pages and moves the helpful links from the main README to this page.