### PR TITLE
Add an agenda for the 11-19 meeting.

### DIFF
--- a/meetings/2020/WASI-11-19.md
+++ b/meetings/2020/WASI-11-19.md
@@ -1,9 +1,9 @@
 ![WASI logo](/WASI.png)
 
-## Agenda for the November 5 video call of WASI Subgroup
+## Agenda for the November 19 video call of WASI Subgroup
 
 - **Where**: zoom.us
-- **When**: November 5, 16:00-17:00 UTC
+- **When**: November 19, 16:00-17:00 UTC
 - **Location**: *link on calendar invite*
 - **Contact**:
     - Name: Dan Gohman
@@ -25,7 +25,6 @@ Installation is required, see the calendar invite.
     1. Please help add your name to the meeting notes.
     1. Please help take notes.
     1. Thanks!
-1. Update from Dan
 1. Review of action items from previous meeting(s).
     1. Ralph Squillance to write up a draft on "WASI experimental" or
        versioning for WASI API experimentation.
@@ -33,5 +32,6 @@ Installation is required, see the calendar invite.
     1. https://github.com/WebAssembly/wasi-filesystem/issues/7
 1. Filesystem Case Insensitivity
     1. https://github.com/WebAssembly/wasi-filesystem/issues/5
+    1. https://github.com/nicowilliams/ietf-fs-i18n
 
 ## Meeting Notes


### PR DESCRIPTION
This updates the agenda from 11-05 which didn't happen due to meeting
logistics, and adds another link for the case insensitivity discussion.