### PR TITLE
witx: remove supertypes from the handle type

### DIFF
--- a/tools/witx/src/ast.rs
+++ b/tools/witx/src/ast.rs
@@ -295,9 +295,7 @@ pub struct UnionVariant {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct HandleDatatype {
-    pub supertypes: Vec<TypeRef>,
-}
+pub struct HandleDatatype {}
 
 #[derive(Debug, Clone)]
 pub struct Module {

--- a/tools/witx/src/parser.rs
+++ b/tools/witx/src/parser.rs
@@ -274,7 +274,7 @@ pub enum TypedefSyntax<'a> {
     Flags(FlagsSyntax<'a>),
     Struct(StructSyntax<'a>),
     Union(UnionSyntax<'a>),
-    Handle(HandleSyntax<'a>),
+    Handle(HandleSyntax),
     Array(Box<TypedefSyntax<'a>>),
     Pointer(Box<TypedefSyntax<'a>>),
     ConstPointer(Box<TypedefSyntax<'a>>),
@@ -485,18 +485,12 @@ impl<'a> Parse<'a> for UnionSyntax<'a> {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct HandleSyntax<'a> {
-    pub supertypes: Vec<wast::Id<'a>>,
-}
+pub struct HandleSyntax {}
 
-impl<'a> Parse<'a> for HandleSyntax<'a> {
+impl<'a> Parse<'a> for HandleSyntax {
     fn parse(parser: Parser<'a>) -> Result<Self> {
         parser.parse::<kw::handle>()?;
-        let mut supertypes = Vec::new();
-        while !parser.is_empty() {
-            supertypes.push(parser.parse()?);
-        }
-        Ok(HandleSyntax { supertypes })
+        Ok(HandleSyntax {})
     }
 }
 

--- a/tools/witx/src/render.rs
+++ b/tools/witx/src/render.rs
@@ -234,13 +234,7 @@ impl UnionDatatype {
 
 impl HandleDatatype {
     pub fn to_sexpr(&self) -> SExpr {
-        let header = vec![SExpr::word("handle")];
-        let supertypes = self
-            .supertypes
-            .iter()
-            .map(|s| s.to_sexpr())
-            .collect::<Vec<SExpr>>();
-        SExpr::Vec([header, supertypes].concat())
+        SExpr::Vec(vec![SExpr::word("handle")])
     }
 }
 impl IntRepr {

--- a/tools/witx/src/validate.rs
+++ b/tools/witx/src/validate.rs
@@ -454,42 +454,10 @@ impl DocValidationScope<'_> {
 
     fn validate_handle(
         &self,
-        syntax: &HandleSyntax,
+        _syntax: &HandleSyntax,
         _span: wast::Span,
     ) -> Result<HandleDatatype, ValidationError> {
-        let supertypes = syntax
-            .supertypes
-            .iter()
-            .map(|id_syntax| {
-                let id = self.get(&id_syntax)?;
-                match self.doc.entries.get(&id) {
-                    Some(Entry::Typename(weak_ref)) => {
-                        let named_dt = weak_ref.upgrade().expect("weak backref to defined type");
-                        match &*named_dt.type_() {
-                            Type::Handle { .. } => Ok(TypeRef::Name(named_dt)),
-                            other => Err(ValidationError::WrongKindName {
-                                name: id_syntax.name().to_string(),
-                                location: self.location(id_syntax.span()),
-                                expected: "handle",
-                                got: other.kind(),
-                            }),
-                        }
-                    }
-                    Some(entry) => Err(ValidationError::WrongKindName {
-                        name: id_syntax.name().to_string(),
-                        location: self.location(id_syntax.span()),
-                        expected: "handle",
-                        got: entry.kind(),
-                    }),
-                    None => Err(ValidationError::Recursive {
-                        name: id_syntax.name().to_string(),
-                        location: self.location(id_syntax.span()),
-                    }),
-                }
-            })
-            .collect::<Result<Vec<TypeRef>, _>>()?;
-
-        Ok(HandleDatatype { supertypes })
+        Ok(HandleDatatype {})
     }
 
     fn validate_int_repr(


### PR DESCRIPTION
the idea here was to enable handles to have a subtyping hierarchy,
but this isnt compatible with wasm extern refs and we never used it
anywhere, so its safe to delete all this code.

See also #357 