### PR TITLE
Cancel 12-17 meeting and add agendas for 01-14 and 01-28.

### DIFF
--- a/meetings/2021/WASI-01-14.md
+++ b/meetings/2021/WASI-01-14.md
@@ -1,0 +1,34 @@
+![WASI logo](/WASI.png)
+
+## Agenda for the January 14 video call of WASI Subgroup
+
+- **Where**: zoom.us
+- **When**: January 14, 17:00-18:00 UTC
+- **Location**: *link on calendar invite*
+- **Contact**:
+    - Name: Lin Clark
+    - Email: lclark@fastly.com
+
+### Registration
+
+None required if you've attended before. Email Lin Clark to sign up if it's
+your first time. The meeting is open to CG members only.
+
+## Logistics
+
+The meeting will be on a zoom.us video conference.
+Installation is required, see the calendar invite.
+
+## Agenda items
+
+1. Opening, welcome and roll call
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Review of action items from previous meeting(s).
+    1. Dan report on repository organization progress
+1. Proposals and discussions
+    1. Discussion: Testing guidelines for proposals
+    1. _Sumbit a PR to add your agenda item here_
+
+## Meeting Notes

--- a/meetings/2021/WASI-01-28.md
+++ b/meetings/2021/WASI-01-28.md
@@ -1,9 +1,9 @@
 ![WASI logo](/WASI.png)
 
-## Agenda for the December 17 video call of WASI Subgroup
+## Agenda for the January 28 video call of WASI Subgroup
 
 - **Where**: zoom.us
-- **When**: December 17, 17:00-18:00 UTC
+- **When**: January 28, 17:00-18:00 UTC
 - **Location**: *link on calendar invite*
 - **Contact**:
     - Name: Lin Clark
@@ -28,6 +28,8 @@ Installation is required, see the calendar invite.
 1. Review of action items from previous meeting(s).
     1. Dan report on repository organization progress
 1. Proposals and discussions
+    1. Presentation: Update from Luke Wagner on handles and resources in interface types
+    1. Discussion: Transitioning WASI APIs to use IT handles
     1. _Sumbit a PR to add your agenda item here_
 
 ## Meeting Notes

--- a/meetings/README.md
+++ b/meetings/README.md
@@ -44,4 +44,7 @@ Meetings of the WASI Subgroup of the W3C WebAssembly Community Group (CG) follow
  * [WASI October 22nd video call](2020/WASI-10-22.md)
  * [WASI November 19th video call](2020/WASI-11-19.md)
  * [WASI December 3rd video call](2020/WASI-12-03.md)
- * [WASI December 17th video call](2020/WASI-12-17.md)
+
+ ### 2020
+ * [WASI January 14th video call](2021/WASI-01-14.md)
+ * [WASI January 28th video call](2021/WASI-01-28.md)

--- a/meetings/README.md
+++ b/meetings/README.md
@@ -45,6 +45,6 @@ Meetings of the WASI Subgroup of the W3C WebAssembly Community Group (CG) follow
  * [WASI November 19th video call](2020/WASI-11-19.md)
  * [WASI December 3rd video call](2020/WASI-12-03.md)
 
- ### 2020
+ ### 2021
  * [WASI January 14th video call](2021/WASI-01-14.md)
  * [WASI January 28th video call](2021/WASI-01-28.md)


### PR DESCRIPTION
We probably shouldn't start any new projects right before the holidays and we don't have any urgent old business to close out, so I'm planning to cancel the meeting on Thursday.

In January, we'll be able to start on some interesting work, including defining testing guidelines for proposals and starting to switch over to interface types for handles. I added agendas including this work. 

I'll leave this issue open for a few hours in case anyone has an urgent agenda item for Thursday, but barring that, I'll go ahead and cancel.