### PR TITLE
Add the `(@witx noreturn)` annotation to proc_exit

### DIFF
--- a/phases/old/snapshot_0/witx/wasi_unstable.witx
+++ b/phases/old/snapshot_0/witx/wasi_unstable.witx
@@ -465,6 +465,7 @@
   (@interface func (export "proc_exit")
     ;;; The exit code returned by the process.
     (param $rval $exitcode)
+    (@witx noreturn)
   )
 
   ;;; Send a signal to the process of the calling thread.

--- a/phases/snapshot/witx/wasi_snapshot_preview1.witx
+++ b/phases/snapshot/witx/wasi_snapshot_preview1.witx
@@ -462,6 +462,7 @@
   (@interface func (export "proc_exit")
     ;;; The exit code returned by the process.
     (param $rval $exitcode)
+    (@witx noreturn)
   )
 
   ;;; Send a signal to the process of the calling thread.

--- a/tools/witx/Cargo.toml
+++ b/tools/witx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "witx"
-version = "0.8.7"
+version = "0.8.8"
 description = "Parse and validate witx file format"
 homepage = "https://github.com/WebAssembly/WASI"
 repository = "https://github.com/WebAssembly/WASI"

--- a/tools/witx/src/render.rs
+++ b/tools/witx/src/render.rs
@@ -315,7 +315,10 @@ impl InterfaceFunc {
             })
             .collect();
         let attrs = if self.noreturn {
-            vec![SExpr::annot("witx"), SExpr::word("noreturn")]
+            vec![SExpr::Vec(vec![
+                SExpr::annot("witx"),
+                SExpr::word("noreturn"),
+            ])]
         } else {
             vec![]
         };


### PR DESCRIPTION
The noreturn annotation was invented solely for the sake of proc_exit,
but we never actually used it in the spec documents.

This annotation sets the `noreturn` bit in the `InterfaceFunc` struct.
Downstream tools are free to do with that bit what they will.