### PR TITLE
correct WASI branch name references from `master` to `main`

### DIFF
--- a/docs/DesignPrinciples.md
+++ b/docs/DesignPrinciples.md
@@ -80,7 +80,7 @@ so.
 WASI also aims to include domain-specific APIs, such as
 database, blockchain, or specialized APIs for embedded
 systems. Another key building block for WASI is [optional
-imports](https://github.com/WebAssembly/WASI/blob/master/design/optional-imports.md),
+imports](https://github.com/WebAssembly/WASI/blob/main/design/optional-imports.md),
 which give applications the ability to dynamically test for the
 availability of APIs.
 
@@ -226,7 +226,7 @@ we're not actually depending on them yet, however we are carefully
 aligning with them so that we'll be ready when they are.
 
 As another example, WASI's
-[witx](https://github.com/WebAssembly/WASI/blob/master/docs/witx.md)
+[witx](https://github.com/WebAssembly/WASI/blob/main/docs/witx.md)
 file format is designed to be a
 straightforward superset of the [module linking
 proposal](https://github.com/WebAssembly/module-linking/blob/master/proposals/module-linking/Explainer.md)'s

--- a/docs/Proposals.md
+++ b/docs/Proposals.md
@@ -6,11 +6,11 @@ adoption of this process and so don't fit exactly into the defined phases,
 however our intention is to align them going forward.
 
 [WASI]: https://github.com/WebAssembly/WASI
-[proposals page]: https://github.com/WebAssembly/proposals/blob/master/README.md
+[proposals page]: https://github.com/WebAssembly/proposals/blob/main/README.md
 
 ## Active proposals
 
-Proposals follow [this process document](https://github.com/WebAssembly/WASI/blob/master/docs/Process.md).
+Proposals follow [this process document](https://github.com/WebAssembly/WASI/blob/main/docs/Process.md).
 
 ### Phase 4 - Standardize the Feature (WG)
 

--- a/meetings/2019/WASI-05-02.md
+++ b/meetings/2019/WASI-05-02.md
@@ -63,7 +63,7 @@ Installation is required, see the calendar invite.
 
 2019-05-02 WebAssembly CG WASI Subgroup Video Meeting Notes
 
-Agenda: https://github.com/WebAssembly/WASI/blob/master/meetings/2019/WASI-05-02.md
+Agenda: https://github.com/WebAssembly/WASI/blob/main/meetings/2019/WASI-05-02.md
 
 Attendees:
 

--- a/meetings/2019/WASI-05-16.md
+++ b/meetings/2019/WASI-05-16.md
@@ -64,7 +64,7 @@ Installation is required, see the calendar invite.
 
 2019-05-02 WebAssembly CG WASI Subgroup Video Meeting Notes
 
-Agenda: https://github.com/WebAssembly/WASI/blob/master/meetings/2019/WASI-05-16.md
+Agenda: https://github.com/WebAssembly/WASI/blob/main/meetings/2019/WASI-05-16.md
 
 Attendees:
 

--- a/meetings/2019/WASI-05-30.md
+++ b/meetings/2019/WASI-05-30.md
@@ -54,7 +54,7 @@ Installation is required, see the calendar invite.
 
 2019-05-02 WebAssembly CG WASI Subgroup Video Meeting Notes
 
-Agenda: https://github.com/WebAssembly/WASI/blob/master/meetings/2019/WASI-05-30.md
+Agenda: https://github.com/WebAssembly/WASI/blob/main/meetings/2019/WASI-05-30.md
 
 Attendees:
 

--- a/meetings/2019/WASI-06-27.md
+++ b/meetings/2019/WASI-06-27.md
@@ -57,7 +57,7 @@ Installation is required, see the calendar invite.
 
 2019-06-27 WebAssembly CG WASI Subgroup Video Meeting Notes
 
-Agenda: https://github.com/WebAssembly/WASI/blob/master/meetings/2019/WASI-06-27.md
+Agenda: https://github.com/WebAssembly/WASI/blob/main/meetings/2019/WASI-06-27.md
 
 Attendees:
 

--- a/meetings/2019/WASI-07-18.md
+++ b/meetings/2019/WASI-07-18.md
@@ -53,7 +53,7 @@ Installation is required, see the calendar invite.
 
 2019-07-18 WebAssembly CG WASI Subgroup Video Meeting Notes
 
-Agenda: https://github.com/WebAssembly/WASI/blob/master/meetings/2019/WASI-07-18.md
+Agenda: https://github.com/WebAssembly/WASI/blob/main/meetings/2019/WASI-07-18.md
 
 Attendees:
 

--- a/meetings/2019/WASI-10-15.md
+++ b/meetings/2019/WASI-10-15.md
@@ -73,7 +73,7 @@ Jorge: Version management?
 Pat: optional imports may alleviate some of the versioning problems too
 
 
-Presentation: [“What HTTP Needs from WebAssembly”](https://github.com/WebAssembly/WASI/blob/master/meetings/2019/What%20HTTP%20Needs%20from%20WebAssembly.pdf), Mark Nottingham
+Presentation: [“What HTTP Needs from WebAssembly”](https://github.com/WebAssembly/WASI/blob/main/meetings/2019/What%20HTTP%20Needs%20from%20WebAssembly.pdf), Mark Nottingham
 
 Roberto: What about multiple headers with one name?
 Mark: [paraphrase] we probably need to talk about that
@@ -82,7 +82,7 @@ Dan: Does this include DNS?
 Mark: Yes, the API accepts names, and they are translated implicitly
 
 Discussion of optional imports, which will be important as different use cases will need different parts of these APIs.
-Spec: https://github.com/WebAssembly/WASI/blob/master/design/optional-imports.md
+Spec: https://github.com/WebAssembly/WASI/blob/main/design/optional-imports.md
 
 (general presentation of the people in the meeting)
 

--- a/phases/README.md
+++ b/phases/README.md
@@ -9,7 +9,7 @@ for a balance between the need for stability to allow people to build
 compatible implementations, libraries, and tools and gain implementation
 experience, and the need for proposals to evolve.
 
-[process]: https://github.com/WebAssembly/WASI/blob/master/docs/Process.md
+[process]: https://github.com/WebAssembly/WASI/blob/main/docs/Process.md
 
 ## The ephemeral/snapshot/old Phases
 

--- a/phases/old/snapshot_0/witx/typenames.witx
+++ b/phases/old/snapshot_0/witx/typenames.witx
@@ -2,7 +2,7 @@
 ;;
 ;; Some content here is derived from [CloudABI](https://github.com/NuxiNL/cloudabi).
 ;;
-;; This is a `witx` file. See [here](https://github.com/WebAssembly/WASI/tree/master/docs/witx.md)
+;; This is a `witx` file. See [here](https://github.com/WebAssembly/WASI/tree/main/docs/witx.md)
 ;; for an explanation of what that means.
 
 (typename $size u32)

--- a/snapshots/make-snapshot.sh
+++ b/snapshots/make-snapshot.sh
@@ -41,7 +41,7 @@ update_repo() {
     pushdir repos
         if [ -d ${repo} ]; then
             log_and_run git -C ${repo} fetch origin
-            log_and_run git -C ${repo} reset origin/master --hard
+            log_and_run git -C ${repo} reset origin/main --hard
         else
             log_and_run git clone https://github.com/WebAssembly/${repo}
         fi
@@ -67,13 +67,13 @@ merge_with_WASI() {
     pushdir repos/${repo}
         # Create and checkout "try-merge" branch.
         if ! git branch | grep try-merge >/dev/null; then
-            log_and_run git branch try-merge origin/master
+            log_and_run git branch try-merge origin/main
         fi
         log_and_run git checkout try-merge
 
-        # Attempt to merge with WASI/master.
-        log_and_run git reset origin/master --hard
-        try_log_and_run git merge -q WASI/master -m "merged"
+        # Attempt to merge with WASI/main.
+        log_and_run git reset origin/main --hard
+        try_log_and_run git merge -q WASI/main -m "merged"
         if [ $? -ne 0 ]; then
             # Ignore merge conflicts in non-test directories.
             # We don't care about those changes.
@@ -139,7 +139,7 @@ for repo in ${repos}; do
     if [ $(git status -s ${dest_dir} | wc -l) -ne 0 ]; then
         log_and_run git add ${dest_dir}/*
 
-        repo_sha=$(git -C repos/${repo} log --max-count=1 --oneline origin/master| sed -e 's/ .*//')
+        repo_sha=$(git -C repos/${repo} log --max-count=1 --oneline origin/main| sed -e 's/ .*//')
         echo "  ${repo}:" >> $commit_message_file
         echo "    https://github.com/WebAssembly/${repo}/commit/${repo_sha}" >> $commit_message_file
     fi


### PR DESCRIPTION
Closes #290