### PR TITLE
Link to the pdf, which can be read without making a clone of the repo.

### DIFF
--- a/meetings/2021/WASI-03-11.md
+++ b/meetings/2021/WASI-03-11.md
@@ -28,10 +28,10 @@ The meeting will be on a zoom.us video conference.
 1. Announcements
     1. _Sumbit a PR to add your announcement here_
 1. Proposals and discussions
-    1. Presentation: Passing capabilities into programs with Typed Main (Dan Gohman) ([slides])
-    1. _Sumbit a PR to add your agenda item here_
+    1. Presentation: Passing capabilities into programs with Typed Main (Dan Gohman) ([slides] [html files])
 
-[slides]: presentations/2021-03-11-gohman-typed-main/index.html
+[slides]: presentations/2021-03-11-gohman-typed-main.pdf
+[html files]: presentations/2021-03-11-gohman-typed-main/index.html
 
 ### Attendees
 

--- a/meetings/2021/WASI-03-25.md
+++ b/meetings/2021/WASI-03-25.md
@@ -28,6 +28,7 @@ The meeting will be on a zoom.us video conference.
 1. Announcements
     1. _Sumbit a PR to add your announcement here_
 1. Proposals and discussions
-    1. Better OS-agnosticism with I/O Types (Dan Gohman) ([slides])
+    1. Better OS-agnosticism with I/O Types (Dan Gohman) ([slides] [html files])
 
-[slides]: presentations/2021-03-25-gohman-io-types/index.html
+[slides]: presentations/2021-03-25-gohman-io-types.pdf
+[html files]: presentations/2021-03-25-gohman-io-types/index.html


### PR DESCRIPTION
Github doesn't make it easy to read the HTML files checked into the repo from the online interface, so add links to the PDF documents.