### PR TITLE
Add an `option` shorthand to witx.

### DIFF
--- a/tools/witx/src/ast.rs
+++ b/tools/witx/src/ast.rs
@@ -396,7 +396,7 @@ impl Variant {
     /// If this variant looks like an `expected` shorthand, return the ok/err
     /// types associated with this result.
     ///
-    /// Only matches variants fo the form:
+    /// Only matches variants of the form:
     ///
     /// ```text
     /// (variant
@@ -414,6 +414,32 @@ impl Variant {
             return None;
         }
         Some((self.cases[0].tref.as_ref(), self.cases[1].tref.as_ref()))
+    }
+
+    /// If this variant looks like an `option` shorthand, return the some
+    /// type associated with this result.
+    ///
+    /// Only matches variants of the form:
+    ///
+    /// ```text
+    /// (variant
+    ///     (case "some" some?)
+    ///     (case "none"))
+    /// ```
+    pub fn as_option(&self) -> Option<Option<&TypeRef>> {
+        if self.cases.len() != 2 {
+            return None;
+        }
+        if self.cases[0].name != "some" {
+            return None;
+        }
+        if self.cases[1].name != "none" {
+            return None;
+        }
+        if self.cases[1].tref.is_some() {
+            return None;
+        }
+        Some(self.cases[0].tref.as_ref())
     }
 
     /// Returns whether this variant type is "bool-like" meaning that it matches

--- a/tools/witx/src/docs/ast.rs
+++ b/tools/witx/src/docs/ast.rs
@@ -340,6 +340,12 @@ impl TypeRef {
                             None => "()".to_string(),
                         };
                         format!("Result<{}, {}>", ok, err)
+                    } else if let Some(some) = v.as_option() {
+                        let some = match some {
+                            Some(ty) => ty.type_name(),
+                            None => "()".to_string(),
+                        };
+                        format!("Option<{}>", some)
                     } else if v.is_bool() {
                         format!("bool")
                     } else {

--- a/tools/witx/src/parser.rs
+++ b/tools/witx/src/parser.rs
@@ -31,6 +31,7 @@ mod kw {
     wast::custom_keyword!(handle);
     wast::custom_keyword!(list);
     wast::custom_keyword!(noreturn);
+    wast::custom_keyword!(option);
     wast::custom_keyword!(pointer);
     wast::custom_keyword!(record);
     wast::custom_keyword!(r#const = "const");
@@ -283,6 +284,7 @@ pub enum TypedefSyntax<'a> {
     Enum(EnumSyntax<'a>),
     Tuple(TupleSyntax<'a>),
     Expected(ExpectedSyntax<'a>),
+    Option(OptionSyntax<'a>),
     Flags(FlagsSyntax<'a>),
     Record(RecordSyntax<'a>),
     Union(UnionSyntax<'a>),
@@ -319,6 +321,8 @@ impl<'a> Parse<'a> for TypedefSyntax<'a> {
                     Ok(TypedefSyntax::Tuple(parser.parse()?))
                 } else if l.peek::<kw::expected>() {
                     Ok(TypedefSyntax::Expected(parser.parse()?))
+                } else if l.peek::<kw::option>() {
+                    Ok(TypedefSyntax::Option(parser.parse()?))
                 } else if l.peek::<kw::flags>() {
                     Ok(TypedefSyntax::Flags(parser.parse()?))
                 } else if l.peek::<kw::record>() {
@@ -430,6 +434,23 @@ impl<'a> Parse<'a> for ExpectedSyntax<'a> {
             })
         })?;
         Ok(ExpectedSyntax { ok, err })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OptionSyntax<'a> {
+    pub some: Option<Box<TypedefSyntax<'a>>>,
+}
+
+impl<'a> Parse<'a> for OptionSyntax<'a> {
+    fn parse(parser: Parser<'a>) -> Result<Self> {
+        parser.parse::<kw::option>()?;
+        let some = if !parser.is_empty() && !parser.peek2::<kw::error>() {
+            Some(Box::new(parser.parse()?))
+        } else {
+            None
+        };
+        Ok(OptionSyntax { some })
     }
 }
 

--- a/tools/witx/tests/witxt.rs
+++ b/tools/witx/tests/witxt.rs
@@ -370,6 +370,8 @@ impl witx::Bindgen for AbiBindgen<'_> {
             ReturnPointerGet { n } => self.assert(&format!("return_pointer.get{}", n)),
             ResultLift => self.assert("result.lift"),
             ResultLower { .. } => self.assert("result.lower"),
+            OptionLift => self.assert("option.lift"),
+            OptionLower { .. } => self.assert("option.lower"),
             EnumLift { .. } => self.assert("enum.lift"),
             EnumLower { .. } => self.assert("enum.lower"),
             TupleLift { .. } => self.assert("tuple.lift"),

--- a/tools/witx/tests/witxt/abi.witxt
+++ b/tools/witx/tests/witxt/abi.witxt
@@ -339,6 +339,13 @@
   )
   "ABI error: only named types are allowed in results"
 )
+(assert_invalid
+  (witx
+    (typename $a (option f32))
+    (module $x (@interface func (export "f") (result $p $a)))
+  )
+  "ABI error: only named types are allowed in options"
+)
 
 ;; Result<(), $errno>
 (assert_abi
@@ -486,5 +493,44 @@
     block.finish
 
     result.lower
+    return)
+)
+
+;; Option<$ty>
+(assert_abi
+  (witx
+    (typename $size u32)
+    (typename $a (option $size))
+    (module $x (@interface func (export "f") (result $p $a)))
+  )
+  (wasm (param i32) (result i32))
+
+  (call_wasm
+    ;; make space for the return value and push its pointer
+    allocate-space
+    return_pointer.get0
+
+    call.wasm
+
+    ;; some block, load the return pointer and have it be the result for the `Some`
+    block.push
+      return_pointer.get0
+      load
+    block.finish
+
+    option.lift
+    return)
+
+  (call_interface
+    call.interface
+
+    ;; store the successful result at the first return pointer (the first param)
+    block.push
+      variant-payload
+      get-arg0
+      store
+    block.finish
+
+    option.lower
     return)
 )

--- a/tools/witx/tests/witxt/shorthand.witxt
+++ b/tools/witx/tests/witxt/shorthand.witxt
@@ -7,25 +7,37 @@
 (witx $a
   (typename $a (expected (error))))
 (witx $b
-  (typename $a (variant (case $ok) (case $err))))
+  (typename $a (variant (@witx tag u8) (case $ok) (case $err))))
+(assert_representable eq $a "a" $b "a")
+
+(witx $a
+  (typename $a (option)))
+(witx $b
+  (typename $a (variant (@witx tag u8) (case $some) (case $none))))
 (assert_representable eq $a "a" $b "a")
 
 (witx $a
   (typename $a (expected (error u32))))
 (witx $b
-  (typename $a (variant (case $ok) (case $err u32))))
+  (typename $a (variant (@witx tag u8) (case $ok) (case $err u32))))
 (assert_representable eq $a "a" $b "a")
 
 (witx $a
   (typename $a (expected u32 (error))))
 (witx $b
-  (typename $a (variant (case $ok u32) (case $err))))
+  (typename $a (variant (@witx tag u8) (case $ok u32) (case $err))))
 (assert_representable eq $a "a" $b "a")
 
 (witx $a
   (typename $a (expected u32 (error u64))))
 (witx $b
-  (typename $a (variant (case $ok u32) (case $err u64))))
+  (typename $a (variant (@witx tag u8) (case $ok u32) (case $err u64))))
+(assert_representable eq $a "a" $b "a")
+
+(witx $a
+  (typename $a (option u32)))
+(witx $b
+  (typename $a (variant (@witx tag u8) (case $some u32) (case $none))))
 (assert_representable eq $a "a" $b "a")
 
 (witx $a


### PR DESCRIPTION
I was mocking up a witx description for #322 and had a use for an
`option` type. Of course, I could also just emit a variant manually,
or reuse `expected` by omitting the error type, but `option` better
conveys the sense that the `none` case doesn't necessarily represent
an error.