### PR TITLE
Enable more than one `handle` type in `*.witx`

### DIFF
--- a/phases/ephemeral/witx/typenames.witx
+++ b/phases/ephemeral/witx/typenames.witx
@@ -281,8 +281,9 @@
   )
 )
 
+(resource $fd)
 ;;; A file descriptor handle.
-(typename $fd (handle))
+(typename $fd (handle $fd))
 
 ;;; A region of memory for scatter/gather reads.
 (typename $iovec

--- a/phases/old/snapshot_0/witx/typenames.witx
+++ b/phases/old/snapshot_0/witx/typenames.witx
@@ -273,8 +273,9 @@
   )
 )
 
+(resource $fd)
 ;;; A file descriptor handle.
-(typename $fd (handle))
+(typename $fd (handle $fd))
 
 ;;; A region of memory for scatter/gather reads.
 (typename $iovec

--- a/phases/snapshot/witx/typenames.witx
+++ b/phases/snapshot/witx/typenames.witx
@@ -273,8 +273,9 @@
   )
 )
 
+(resource $fd)
 ;;; A file descriptor handle.
-(typename $fd (handle))
+(typename $fd (handle $fd))
 
 ;;; A region of memory for scatter/gather reads.
 (typename $iovec

--- a/tools/witx/src/toplevel.rs
+++ b/tools/witx/src/toplevel.rs
@@ -165,19 +165,4 @@ mod test {
             e => panic!("wrong error: {:?}", e),
         }
     }
-
-    #[test]
-    fn use_invalid() {
-        match parse_witx_with("/a", &MockFs::new(&[("/a", "(use bbbbbbb)")]))
-            .err()
-            .unwrap()
-        {
-            WitxError::Parse(e) => {
-                let err = e.to_string();
-                assert!(err.contains("expected an identifier"), "bad error: {}", err);
-                assert!(err.contains("/a:1:6"));
-            }
-            e => panic!("wrong error: {:?}", e),
-        }
-    }
 }

--- a/tools/witx/src/validate.rs
+++ b/tools/witx/src/validate.rs
@@ -6,7 +6,8 @@ use crate::{
         VariantSyntax,
     },
     Abi, BuiltinType, Case, Constant, Function, HandleDatatype, Id, IntRepr, Location, Module,
-    ModuleId, NamedType, Param, RecordDatatype, RecordKind, RecordMember, Type, TypeRef, Variant,
+    ModuleId, NamedType, Param, RecordDatatype, RecordKind, RecordMember, Resource, ResourceId,
+    Type, TypeRef, Variant,
 };
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
@@ -131,6 +132,7 @@ impl IdentValidation {
 pub struct ModuleValidation<'a> {
     module: Module,
     type_ns: IdentValidation,
+    resource_ns: IdentValidation,
     func_ns: IdentValidation,
     constant_ns: HashMap<Id, IdentValidation>,
     bool_ty: TypeRef,
@@ -145,6 +147,7 @@ impl<'a> ModuleValidation<'a> {
         Self {
             module: Module::new(name, module_id),
             type_ns: IdentValidation::new(),
+            resource_ns: IdentValidation::new(),
             func_ns: IdentValidation::new(),
             constant_ns: HashMap::new(),
             bool_ty: TypeRef::Value(Rc::new(Type::Variant(Variant {
@@ -193,22 +196,59 @@ impl<'a> ModuleValidation<'a> {
                     self.type_ns.introduce(ty.name.as_str(), loc)?;
                     self.module.push_type(ty.clone());
                 }
+                for r in module.resources() {
+                    let loc = self.location(span);
+                    self.resource_ns.introduce(r.name.as_str(), loc)?;
+                    self.module.push_resource(r.clone());
+                }
             }
             UsedNames::List(names) => {
                 for name in names {
-                    let loc = self.location(name.span());
-                    let id = self.type_ns.introduce(name.name(), loc)?;
-                    let ty = match module.typename(&id) {
-                        Some(ty) => ty,
-                        None => {
-                            return Err(ValidationError::UnknownName {
-                                name: name.name().to_string(),
-                                location: self.location(name.span()),
-                            }
-                            .into());
+                    let mut used = false;
+                    let id = Id::new(name.other_name.name());
+                    let other_loc = self.location(name.other_name.span());
+                    let our_loc = self.location(name.our_name.span());
+
+                    if let Some(ty) = module.typename(&id) {
+                        let id = self
+                            .type_ns
+                            .introduce(name.our_name.name(), our_loc.clone())?;
+                        let ty = if name.other_name.name() == name.our_name.name() {
+                            ty
+                        } else {
+                            Rc::new(NamedType {
+                                name: id,
+                                module: self.module.module_id().clone(),
+                                tref: TypeRef::Name(ty),
+                                docs: String::new(),
+                            })
+                        };
+                        self.module.push_type(ty);
+                        used = true;
+                    }
+
+                    if let Some(r) = module.resource(&id) {
+                        let id = self.resource_ns.introduce(name.our_name.name(), our_loc)?;
+                        let r = if name.other_name.name() == name.our_name.name() {
+                            r
+                        } else {
+                            Rc::new(Resource {
+                                name: id,
+                                resource_id: r.resource_id.clone(),
+                                docs: String::new(),
+                            })
+                        };
+                        self.module.push_resource(r);
+                        used = true;
+                    }
+
+                    if !used {
+                        return Err(ValidationError::UnknownName {
+                            name: name.other_name.name().to_string(),
+                            location: other_loc,
                         }
-                    };
-                    self.module.push_type(ty);
+                        .into());
+                    }
                 }
             }
         }
@@ -228,9 +268,24 @@ impl<'a> ModuleValidation<'a> {
                 let tref = self.validate_datatype(&decl.def, true, decl.ident.span())?;
 
                 self.module.push_type(Rc::new(NamedType {
-                    name: name.clone(),
+                    name,
                     module: self.module.module_id().clone(),
                     tref,
+                    docs,
+                }));
+            }
+
+            DeclSyntax::Resource(decl) => {
+                let loc = self.location(decl.ident.span());
+                let name = self.resource_ns.introduce(decl.ident.name(), loc)?;
+                let docs = comments.docs();
+
+                self.module.push_resource(Rc::new(Resource {
+                    name: name.clone(),
+                    resource_id: ResourceId {
+                        name,
+                        module_id: self.module.module_id().clone(),
+                    },
                     docs,
                 }));
             }
@@ -631,10 +686,15 @@ impl<'a> ModuleValidation<'a> {
 
     fn validate_handle(
         &self,
-        _syntax: &HandleSyntax,
+        syntax: &HandleSyntax,
         _span: wast::Span,
     ) -> Result<HandleDatatype, ValidationError> {
-        Ok(HandleDatatype {})
+        let loc = self.location(syntax.resource.span());
+        let name = self.resource_ns.get(syntax.resource.name(), loc)?;
+        let resource = self.module.resource(&name).unwrap();
+        Ok(HandleDatatype {
+            resource_id: resource.resource_id.clone(),
+        })
     }
 
     fn validate_int_repr(

--- a/tools/witx/tests/witxt.rs
+++ b/tools/witx/tests/witxt.rs
@@ -530,19 +530,23 @@ impl Witx<'_> {
                 let mut validator = witx::ModuleValidation::new(contents, file);
                 for t in doc.decls.iter() {
                     match &t.item {
-                        TopLevelSyntax::Decl(d) => validator.validate_decl(&d, &t.comments)?,
+                        TopLevelSyntax::Decl(d) => validator
+                            .validate_decl(&d, &t.comments)
+                            .map_err(|e| anyhow::anyhow!("{}", e.report()))?,
                         TopLevelSyntax::Use(_) => unimplemented!(),
                     }
                 }
                 for f in doc.functions.iter() {
-                    validator.validate_function(&f.item, &f.comments)?;
+                    validator
+                        .validate_function(&f.item, &f.comments)
+                        .map_err(|e| anyhow::anyhow!("{}", e.report()))?;
                 }
                 Ok(validator.into_module())
             }
             WitxDef::Fs(path) => {
                 let parent = file.parent().unwrap();
                 let path = parent.join(path);
-                Ok(witx::load(&path)?)
+                Ok(witx::load(&path).map_err(|e| anyhow::anyhow!("{}", e.report()))?)
             }
         }
     }

--- a/tools/witx/tests/witxt/abi.witxt
+++ b/tools/witx/tests/witxt/abi.witxt
@@ -131,7 +131,8 @@
 ;; handle parameter
 (assert_abi
   (witx
-    (typename $a (handle))
+    (resource $a)
+    (typename $a (handle $a))
     (module $x (@interface func (export "f") (param $p $a)))
   )
   (wasm (param i32))
@@ -284,7 +285,8 @@
 ;; handle return
 (assert_abi
   (witx
-    (typename $a (handle))
+    (resource $a)
+    (typename $a (handle $a))
     (module $x (@interface func (export "f") (result $p $a)))
   )
   (wasm (result i32))

--- a/tools/witx/tests/witxt/anonymous.witxt
+++ b/tools/witx/tests/witxt/anonymous.witxt
@@ -27,7 +27,8 @@
 
 (assert_invalid
   (witx
-    (typename $a (@witx pointer (handle)))
+    (resource $x)
+    (typename $a (@witx pointer (handle $x)))
   )
   "Anonymous structured types")
 

--- a/tools/witx/tests/witxt/resources.witxt
+++ b/tools/witx/tests/witxt/resources.witxt
@@ -1,0 +1,41 @@
+(assert_invalid
+  (witx (typename $x (handle $y)))
+  "Unknown name `y`")
+
+(assert_invalid
+  (witx
+    (typename $y u32)
+    (typename $x (handle $y)))
+  "Unknown name `y`")
+
+(assert_invalid
+  (witx
+    (resource $x)
+    (resource $x))
+  "Redefinition of name `x`")
+
+(witx
+  (resource $x)
+  (typename $x (handle $x)))
+
+(witx $a
+  (resource $x)
+  (typename $x (handle $x))
+  (typename $y (handle $x))
+)
+
+(assert_eq $a "x" $a "y")
+
+(witx $a
+  (resource $x)
+  (resource $y)
+  (typename $x (handle $x))
+  (typename $y (handle $y))
+)
+
+(assert_ne $a "x" $a "y")
+
+(witx $a (load "resources/multi.witx"))
+
+(assert_eq $a "x1" $a "x2")
+(assert_ne $a "y1" $a "y2")

--- a/tools/witx/tests/witxt/resources/multi.witx
+++ b/tools/witx/tests/witxt/resources/multi.witx
@@ -1,0 +1,11 @@
+(use ($x as $other_x) ($y as $other_y) from $other)
+
+;; this resource named `y` shouldn't be the same as another resource named `y`
+;; defined elsewhere.
+(resource $y)
+
+(typename $x1 (handle $other_x))
+(typename $x2 (handle $other_x))
+
+(typename $y1 (handle $other_y))
+(typename $y2 (handle $y))

--- a/tools/witx/tests/witxt/resources/other.witx
+++ b/tools/witx/tests/witxt/resources/other.witx
@@ -1,0 +1,2 @@
+(resource $x)
+(resource $y)


### PR DESCRIPTION
This commit reworks how handle types work at the representation level in
`*.witx` file to follow the expected design of resources in the
interface types specification. Previously handle types were simply
`(handle)`, which meant that there could only be one actual handle type
in the world (structurally at least). After this commit, however, there
can be multiple handle types.

First abstract types must be introduced as a `resource`, for example:

    (resource $fd)

This declares that the module exports a type named `$fd` and it's
abstract in that the representation is not known. At the interface layer
you can't pass an `$fd` directly because it's representation is not
known. To do that, however, you can do:

    (param $x (handle $fd))

The `handle` type now refers to a particular `resource` that it refers
to. Values of type `handle T` can exist and are what's passed at the
boundaries.

This is all largely just an internal structuring concern at this point.
This has no ramifications for WASI which still has an `$fd` type for
functions that is represented with an `i32`. This is largely a
forward-looking change to allow multiple types of resources defined by
different modules and all used by one another.

This commit also updates `use` syntax where `use` will pull from either
the type or the resource namespace. Furthermore a new `(use ($foo as
$bar) ...)` syntax was added to locally renamed something within a module.