### PR TITLE
Fix path canonicalization in witx `use` statements

### DIFF
--- a/tools/witx/src/io.rs
+++ b/tools/witx/src/io.rs
@@ -52,7 +52,7 @@ impl WitxIo for Filesystem {
 }
 
 pub struct MockFs {
-    map: HashMap<String, String>,
+    map: HashMap<PathBuf, String>,
 }
 
 impl MockFs {
@@ -60,7 +60,7 @@ impl MockFs {
         MockFs {
             map: strings
                 .iter()
-                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .map(|(k, v)| (PathBuf::from(k), v.to_string()))
                 .collect(),
         }
     }
@@ -68,7 +68,7 @@ impl MockFs {
 
 impl WitxIo for MockFs {
     fn fgets(&self, path: &Path) -> Result<String, WitxError> {
-        if let Some(entry) = self.map.get(path.to_str().unwrap()) {
+        if let Some(entry) = self.map.get(path) {
             Ok(entry.to_string())
         } else {
             Err(WitxError::Io(
@@ -78,7 +78,7 @@ impl WitxIo for MockFs {
         }
     }
     fn fget_line(&self, path: &Path, line: usize) -> Result<String, WitxError> {
-        if let Some(entry) = self.map.get(path.to_str().unwrap()) {
+        if let Some(entry) = self.map.get(path) {
             entry
                 .lines()
                 .skip(line - 1)

--- a/tools/witx/src/toplevel.rs
+++ b/tools/witx/src/toplevel.rs
@@ -43,14 +43,11 @@ fn parse_file(
     definitions: &mut Vec<Definition>,
     parsed: &mut HashSet<PathBuf>,
 ) -> Result<(), WitxError> {
-    eprintln!("parsing file at path='{:?}' root='{:?}'", &path, &root);
     let path = io.canonicalize(&root.join(path))?;
-    eprintln!("canonical-path='{:?}'", &path);
     if !parsed.insert(path.clone()) {
         return Ok(());
     }
     let input = io.fgets(&path)?;
-    eprintln!(""); // this one is just for space
 
     let adjust_err = |mut error: wast::Error| {
         error.set_path(&path);
@@ -69,7 +66,6 @@ fn parse_file(
                     .map_err(WitxError::Validation)?;
             }
             TopLevelSyntax::Use(u) => {
-                eprintln!("found a use statement, parsing file at {:?}", &u);
                 let root = path.parent().unwrap_or(root);
                 parse_file(u.as_ref(), io, root, validator, definitions, parsed)?;
             }

--- a/tools/witx/src/toplevel.rs
+++ b/tools/witx/src/toplevel.rs
@@ -70,6 +70,7 @@ fn parse_file(
             }
             TopLevelSyntax::Use(u) => {
                 eprintln!("found a use statement, parsing file at {:?}", &u);
+                let root = path.parent().unwrap_or(root);
                 parse_file(u.as_ref(), io, root, validator, definitions, parsed)?;
             }
         }

--- a/tools/witx/src/toplevel.rs
+++ b/tools/witx/src/toplevel.rs
@@ -150,6 +150,10 @@ mod test {
                     "(use \"sibling.witx\")\n(typename $b_float f64)",
                 ),
                 ("/subdir/sibling.witx", "(typename $c_int u32)"),
+                // This definition looks just like subdir/sibling.witx but
+                // defines c_int differently - this test shows it does Not get
+                // included by subdir/child.witx's use.
+                ("/sibling.witx", "(typename $c_int u64)"),
             ]),
         )
         .expect("parse");

--- a/tools/witx/src/toplevel.rs
+++ b/tools/witx/src/toplevel.rs
@@ -43,11 +43,14 @@ fn parse_file(
     definitions: &mut Vec<Definition>,
     parsed: &mut HashSet<PathBuf>,
 ) -> Result<(), WitxError> {
+    eprintln!("parsing file at path='{:?}' root='{:?}'", &path, &root);
     let path = io.canonicalize(&root.join(path))?;
+    eprintln!("canonical-path='{:?}'", &path);
     if !parsed.insert(path.clone()) {
         return Ok(());
     }
     let input = io.fgets(&path)?;
+    eprintln!(""); // this one is just for space
 
     let adjust_err = |mut error: wast::Error| {
         error.set_path(&path);
@@ -66,6 +69,7 @@ fn parse_file(
                     .map_err(WitxError::Validation)?;
             }
             TopLevelSyntax::Use(u) => {
+                eprintln!("found a use statement, parsing file at {:?}", &u);
                 parse_file(u.as_ref(), io, root, validator, definitions, parsed)?;
             }
         }


### PR DESCRIPTION
:bat: :sparkles: **Hello**!

This branch fixes a bug I have found in the `witx` crate, involving `use` statements.

:bug: **The Bug**

Paths in .._transitive_(?) `use` statements (_e.g. document A imports document B, which imports document C_) are evaluated relative to the original root document, rather than the import-_er_ document B.

This is better understood with an example (_see below_), or consulting the test case added here, `multi_use_with_layered_dirs`. Note that unlike the existing `multi_use` test, these documents do not all live within the same directory in the file system.

:scroll: **Example**

```
;; /root.witx
(use "subdir/child.witx")
```

```
;; /subdir/child.witx"
(use "sibling.witx")
(typename $b_float f64)
```

```
;; /subdir/sibling.witx
(typename $c_int u32)
```

Today, when `root.witx` is loaded, we'll run into an error that `/sibling.witx` does not exist.

**☭ The Fix**

The fix for this turns out to be a single line of code! That can be found in 963c5cf.

It turns out that when we were recursing in `witx::toplevel::parse_file` upon the discovery of a `use` statement, we'd pass the original `root` along, rather than providing the directory of the given document.