### PR TITLE
reintroduce witx::phases (partial revert #398)

### DIFF
--- a/tools/witx/src/lib.rs
+++ b/tools/witx/src/lib.rs
@@ -10,6 +10,8 @@ mod io;
 mod layout;
 /// Witx syntax parsing from SExprs
 pub mod parser;
+/// Paths to witx documents for various proposal phases
+pub mod phases;
 /// Calculate required polyfill between interfaces
 pub mod polyfill;
 /// Render ast to text

--- a/tools/witx/src/phases.rs
+++ b/tools/witx/src/phases.rs
@@ -1,0 +1,75 @@
+use anyhow::{bail, Result};
+use std::env;
+use std::path::{Path, PathBuf};
+
+pub fn docs_path(phase_paths: &[PathBuf]) -> PathBuf {
+    phase_paths
+        .get(0)
+        .expect("at least one path")
+        .parent()
+        .expect("drop file")
+        .join("../docs.md")
+}
+
+pub fn snapshot() -> Result<Vec<PathBuf>> {
+    let root = repo_root()?;
+    let snapshot = root.join("phases/snapshot/witx");
+    let paths = vec![snapshot.join("wasi_snapshot_preview1.witx")];
+    ensure_exists(&paths)?;
+    Ok(paths)
+}
+
+pub fn ephemeral() -> Result<Vec<PathBuf>> {
+    let root = repo_root()?;
+    let ephemeral = root.join("phases/ephemeral/witx");
+    let paths = vec![
+        ephemeral.join("wasi_ephemeral_args.witx"),
+        ephemeral.join("wasi_ephemeral_clock.witx"),
+        ephemeral.join("wasi_ephemeral_environ.witx"),
+        ephemeral.join("wasi_ephemeral_fd.witx"),
+        ephemeral.join("wasi_ephemeral_path.witx"),
+        ephemeral.join("wasi_ephemeral_poll.witx"),
+        ephemeral.join("wasi_ephemeral_proc.witx"),
+        ephemeral.join("wasi_ephemeral_random.witx"),
+        ephemeral.join("wasi_ephemeral_sched.witx"),
+        ephemeral.join("wasi_ephemeral_sock.witx"),
+    ];
+    ensure_exists(&paths)?;
+    Ok(paths)
+}
+
+pub mod old {
+    use super::*;
+    pub fn snapshot_0() -> Result<Vec<PathBuf>> {
+        let root = repo_root()?;
+        let snapshot_0 = root.join("phases/old/snapshot_0/witx");
+        let paths = vec![snapshot_0.join("wasi_unstable.witx")];
+        ensure_exists(&paths)?;
+        Ok(paths)
+    }
+}
+
+fn repo_root() -> Result<PathBuf> {
+    let repo_root = if let Ok(e) = env::var("WASI_REPO") {
+        PathBuf::from(e)
+    } else {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
+    };
+    if repo_root.exists() {
+        Ok(repo_root)
+    } else {
+        bail!("could not find WASI repo root - try setting WASI_REPO env variable")
+    }
+}
+
+fn ensure_exists(paths: &[PathBuf]) -> Result<()> {
+    for p in paths.iter() {
+        if !p.exists() {
+            bail!(
+                "{} does not exist - is WASI_REPO set to repository root?",
+                Path::display(p)
+            )
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
Per this discussion from #434:

> It looks like the crate was last published at
> [7ec4b1a](https://github.com/WebAssembly/WASI/commit/7ec4b1a65621ed3dd98fb67ab3746b4f29b4a62b)
> ([diff from
> `main`](https://github.com/webassembly/WASI/compare/ef8c1a53feb2dfb763d4ea5c7d9e0a0126b45579...main)),
> and if we'd like to make an 0.9.1 release (ideally just a bugfix
> release), I think there's another breaking change we merged in the
> meantime, notably the deletion of `tools/witx/src/phases.rs`, which I
> think happened as #398. I think we may need to revert that as well
> before publishing 0.9.1?

-- [@alexcrichton](https://github.com/WebAssembly/WASI/pull/434#issuecomment-866050346)

This reintroduces 'witx::phases', so that we do not include any breaking
changes in what ought to be a pure bug release.