### PR TITLE
Update docs.md

### DIFF
--- a/phases/snapshot/docs.md
+++ b/phases/snapshot/docs.md
@@ -2011,7 +2011,7 @@ The path at which to create the directory.
 
 #### <a href="#path_filestat_get" name="path_filestat_get"></a> `path_filestat_get(fd: fd, flags: lookupflags, path: string) -> Result<filestat, errno>`
 Return the attributes of a file or directory.
-Note: This is similar to `stat` in POSIX.
+Note: This is similar to `fstatat` in POSIX.
 
 ##### Params
 - <a href="#path_filestat_get.fd" name="path_filestat_get.fd"></a> `fd`: [`fd`](#fd)


### PR DESCRIPTION
According to man
```
       int stat(const char *pathname, struct stat *statbuf);
       int fstat(int fd, struct stat *statbuf);
       int lstat(const char *pathname, struct stat *statbuf);
...
       int fstatat(int dirfd, const char *pathname, struct stat *statbuf,
                   int flags);
```
`path_filestate_get` should be closer to `fstatat` instead of `stat`