### PR TITLE
Add `sock_accept()` to snapshot1

### DIFF
--- a/phases/snapshot/docs.md
+++ b/phases/snapshot/docs.md
@@ -2011,7 +2011,7 @@ The path at which to create the directory.
 
 #### <a href="#path_filestat_get" name="path_filestat_get"></a> `path_filestat_get(fd: fd, flags: lookupflags, path: string) -> Result<filestat, errno>`
 Return the attributes of a file or directory.
-Note: This is similar to `fstatat` in POSIX.
+Note: This is similar to `stat` in POSIX.
 
 ##### Params
 - <a href="#path_filestat_get.fd" name="path_filestat_get.fd"></a> `fd`: [`fd`](#fd)

--- a/phases/snapshot/docs.md
+++ b/phases/snapshot/docs.md
@@ -450,6 +450,11 @@ The right to invoke [`sock_shutdown`](#sock_shutdown).
 
 Bit: 28
 
+- <a href="#rights.sock_accept" name="rights.sock_accept"></a> `sock_accept`: `bool`
+The right to invoke [`sock_accept`](#sock_accept).
+
+Bit: 29
+
 ## <a href="#fd" name="fd"></a> `fd`: `Handle`
 A file descriptor handle.
 
@@ -2412,6 +2417,33 @@ The buffer to fill with random data.
 - <a href="#random_get.error.ok" name="random_get.error.ok"></a> `ok`
 
 - <a href="#random_get.error.err" name="random_get.error.err"></a> `err`: [`errno`](#errno)
+
+
+---
+
+#### <a href="#sock_accept" name="sock_accept"></a> `sock_accept(fd: fd, flags: fdflags) -> Result<fd, errno>`
+Accept a new incoming connection.
+Note: This is similar to `accept` in POSIX.
+
+##### Params
+- <a href="#sock_accept.fd" name="sock_accept.fd"></a> `fd`: [`fd`](#fd)
+The listening socket.
+
+- <a href="#sock_accept.flags" name="sock_accept.flags"></a> `flags`: [`fdflags`](#fdflags)
+The desired values of the file descriptor flags.
+
+##### Results
+- <a href="#sock_accept.error" name="sock_accept.error"></a> `error`: `Result<fd, errno>`
+New socket connection
+
+###### Variant Layout
+- size: 8
+- align: 4
+- tag_size: 4
+###### Variant cases
+- <a href="#sock_accept.error.ok" name="sock_accept.error.ok"></a> `ok`: [`fd`](#fd)
+
+- <a href="#sock_accept.error.err" name="sock_accept.error.err"></a> `err`: [`errno`](#errno)
 
 
 ---

--- a/phases/snapshot/witx/typenames.witx
+++ b/phases/snapshot/witx/typenames.witx
@@ -270,6 +270,8 @@
     $poll_fd_readwrite
     ;;; The right to invoke `sock_shutdown`.
     $sock_shutdown
+    ;;; The right to invoke `sock_accept`.
+    $sock_accept
   )
 )
 

--- a/phases/snapshot/witx/wasi_snapshot_preview1.witx
+++ b/phases/snapshot/witx/wasi_snapshot_preview1.witx
@@ -473,6 +473,17 @@
     (result $error (expected (error $errno)))
   )
 
+  ;;; Accept a new incoming connection.
+  ;;; Note: This is similar to `accept` in POSIX.
+  (@interface func (export "sock_accept")
+    ;;; The listening socket.
+    (param $fd $fd)
+    ;;; The desired values of the file descriptor flags.
+    (param $flags $fdflags)
+    ;;; New socket connection
+    (result $error (expected $fd (error $errno)))
+  )
+
   ;;; Receive a message from a socket.
   ;;; Note: This is similar to `recv` in POSIX, though it also supports reading
   ;;; the data into multiple buffers in the manner of `readv`.


### PR DESCRIPTION
# Update

Today (2022-01-13) we discussed this PR in the WASI subgroup call. There was general agreement that updating snapshot1 with an `accept()` call was a valuable endeavor. I have updated the PR as I believe it is now ready for merge.

Although this proposal previously suggested the publication of a `snapshot2`, the consensus on the call was that implicitly updating `snapshot1` is the preferred route.

This proposal needs to be adopted and implemented in the `libc` implementation before transitioning to streams so that consumers can lock to an older version (per @sunfishcode).

# Overview

WASI snapshot1 is very broadly implemented. It is also fairly usable for a number of cases. However, for networking its use is quite limited. This is particularly because there are a few omissions that create real blockers in downstream users of this API. For this reason while there has been extensive demand to support WASI in the Rust ecosystem, real penetration of support in the crate ecosystem remains elusive for major networking libraries.

This PR sets out to add `accept()`, which makes it possible to accept distinct connections inside of wasm.
  
# Supporting Accept

All network APIs need to support calling `accept()` on pre-opened listening sockets. For example, this is widely implemented in `systemd` and other init systems.

For example, in Rust you can create a `TcpListener` from a `RawFd` on Unix platforms and a parallel exists for Windows. This doesn't work on WASI, but only because we are missing the `accept()` call. Enabling the creation of a `TcpListener` in Rust from a pre-opened listening socket would substantially increase the usability of WASM and would incentivize the adoption by frameworks like `tokio`.

# Proposal

While I'm aware of the great strides being taken to modularize WASI, I am essentially proposing an incremental `snapshot2` aimed at improving the existing toolchain support.

# CC

@tschneidereit @lukewagner @sunfishcode @wgwoods @MikeCamel