### PR TITLE
Fix broken links to the witx documents

### DIFF
--- a/Proposals.md
+++ b/Proposals.md
@@ -76,7 +76,7 @@ For some APIs, it makes sense to add new features after the API itself has reach
 Some APIs may require backwards-incompatible changes over time. In these cases, we allow proposals to increment the major version number _only if_ the old API can be implmented in terms of the new API. As part of the new version, champions are expected to provide a tool that enables this backwards-compatibility. If that is not possible, then a new API proposal with a new name should be started. The original API can then be deprecated over time if it makes sense to do so.
 
 [WebAssembly CG Phases process]: https://github.com/WebAssembly/meetings/blob/master/process/phases.md
-[witx]: https://github.com/WebAssembly/WASI/blob/master/docs/witx.md
+[witx]: https://github.com/WebAssembly/WASI/blob/main/tools/witx-docs.md
 [ephemeral/snapshot/old process]: https://github.com/WebAssembly/WASI/blob/master/phases/README.md
 
 [wasi-blob-store]: https://github.com/WebAssembly/wasi-blob-store

--- a/phases/ephemeral/witx/typenames.witx
+++ b/phases/ephemeral/witx/typenames.witx
@@ -2,7 +2,7 @@
 ;;
 ;; Some content here is derived from [CloudABI](https://github.com/NuxiNL/cloudabi).
 ;;
-;; This is a `witx` file. See [here](https://github.com/WebAssembly/WASI/tree/master/docs/witx.md)
+;; This is a `witx` file. See [here](https://github.com/WebAssembly/WASI/tree/main/tools/witx-docs.md)
 ;; for an explanation of what that means.
 
 ;;; An array size.

--- a/phases/ephemeral/witx/wasi_ephemeral_clock.witx
+++ b/phases/ephemeral/witx/wasi_ephemeral_clock.witx
@@ -2,7 +2,7 @@
 ;;
 ;; Some content here is derived from [CloudABI](https://github.com/NuxiNL/cloudabi).
 ;;
-;; This is a `witx` file. See [here](https://github.com/WebAssembly/WASI/tree/master/docs/witx.md)
+;; This is a `witx` file. See [here](https://github.com/WebAssembly/WASI/tree/main/tools/witx-docs.md)
 ;; for an explanation of what that means.
 
 (use "typenames.witx")

--- a/phases/ephemeral/witx/wasi_ephemeral_environ.witx
+++ b/phases/ephemeral/witx/wasi_ephemeral_environ.witx
@@ -1,6 +1,6 @@
 ;; WASI Environment Variables.
 ;;
-;; This is a `witx` file. See [here](https://github.com/WebAssembly/WASI/tree/master/docs/witx.md)
+;; This is a `witx` file. See [here](https://github.com/WebAssembly/WASI/tree/main/tools/witx-docs.md)
 ;; for an explanation of what that means.
 
 (use "typenames.witx")

--- a/phases/ephemeral/witx/wasi_ephemeral_path.witx
+++ b/phases/ephemeral/witx/wasi_ephemeral_path.witx
@@ -2,7 +2,7 @@
 ;;
 ;; Some content here is derived from [CloudABI](https://github.com/NuxiNL/cloudabi).
 ;;
-;; This is a `witx` file. See [here](https://github.com/WebAssembly/WASI/tree/master/docs/witx.md)
+;; This is a `witx` file. See [here](https://github.com/WebAssembly/WASI/tree/main/tools/witx-docs.md)
 ;; for an explanation of what that means.
 
 (use "typenames.witx")

--- a/phases/ephemeral/witx/wasi_ephemeral_poll.witx
+++ b/phases/ephemeral/witx/wasi_ephemeral_poll.witx
@@ -2,7 +2,7 @@
 ;;
 ;; Some content here is derived from [CloudABI](https://github.com/NuxiNL/cloudabi).
 ;;
-;; This is a `witx` file. See [here](https://github.com/WebAssembly/WASI/tree/master/docs/witx.md)
+;; This is a `witx` file. See [here](https://github.com/WebAssembly/WASI/tree/main/tools/witx-docs.md)
 ;; for an explanation of what that means.
 
 (use "typenames.witx")

--- a/phases/ephemeral/witx/wasi_ephemeral_proc.witx
+++ b/phases/ephemeral/witx/wasi_ephemeral_proc.witx
@@ -2,7 +2,7 @@
 ;;
 ;; Some content here is derived from [CloudABI](https://github.com/NuxiNL/cloudabi).
 ;;
-;; This is a `witx` file. See [here](https://github.com/WebAssembly/WASI/tree/master/docs/witx.md)
+;; This is a `witx` file. See [here](https://github.com/WebAssembly/WASI/tree/main/tools/witx-docs.md)
 ;; for an explanation of what that means.
 
 (use "typenames.witx")

--- a/phases/ephemeral/witx/wasi_ephemeral_random.witx
+++ b/phases/ephemeral/witx/wasi_ephemeral_random.witx
@@ -2,7 +2,7 @@
 ;;
 ;; Some content here is derived from [CloudABI](https://github.com/NuxiNL/cloudabi).
 ;;
-;; This is a `witx` file. See [here](https://github.com/WebAssembly/WASI/tree/master/docs/witx.md)
+;; This is a `witx` file. See [here](https://github.com/WebAssembly/WASI/tree/main/tools/witx-docs.md)
 ;; for an explanation of what that means.
 
 (use "typenames.witx")

--- a/phases/ephemeral/witx/wasi_ephemeral_sched.witx
+++ b/phases/ephemeral/witx/wasi_ephemeral_sched.witx
@@ -2,7 +2,7 @@
 ;;
 ;; Some content here is derived from [CloudABI](https://github.com/NuxiNL/cloudabi).
 ;;
-;; This is a `witx` file. See [here](https://github.com/WebAssembly/WASI/tree/master/docs/witx.md)
+;; This is a `witx` file. See [here](https://github.com/WebAssembly/WASI/tree/main/tools/witx-docs.md)
 ;; for an explanation of what that means.
 
 (use "typenames.witx")

--- a/phases/ephemeral/witx/wasi_ephemeral_sock.witx
+++ b/phases/ephemeral/witx/wasi_ephemeral_sock.witx
@@ -2,7 +2,7 @@
 ;;
 ;; Some content here is derived from [CloudABI](https://github.com/NuxiNL/cloudabi).
 ;;
-;; This is a `witx` file. See [here](https://github.com/WebAssembly/WASI/tree/master/docs/witx.md)
+;; This is a `witx` file. See [here](https://github.com/WebAssembly/WASI/tree/main/tools/witx-docs.md)
 ;; for an explanation of what that means.
 
 (use "typenames.witx")


### PR DESCRIPTION
Since the witx document is moved to `tools/witx-docs.md`, this PR fix all links to the new witx document.