### PR TITLE
Remove the `_initialize` function from the definition of reactors.

### DIFF
--- a/Proposals.md
+++ b/Proposals.md
@@ -30,10 +30,8 @@ You can learn more about contributing new proposals (and other ways to contribut
 | ------------------------------------------------------------------------------ | -------------------------------------- | -------- |
 | [I/O][wasi-io]                                                                 | Dan Gohman                             |          |
 | [Filesystem][wasi-filesystem]                                                  | Dan Gohman                             |          |
-| ["Classic" Command-Line][wasi-classic-command] (Legacy, to be deprecated in Q4 2022)| Dan Gohman                             |          |
 | [Clocks][wasi-clocks]                                                          | Dan Gohman                             |          |
 | [Random][wasi-random]                                                          | Dan Gohman                             |          |
-| [Handle Index][wasi-handle-index]                                              | Dan Gohman                             |          |
 | [Poll][wasi-poll]                                                              | Dan Gohman                             |          |
 | [Machine Learning (wasi-nn)][wasi-nn]                                          | Andrew Brown and Mingqiu Sun           |          |
 


### PR DESCRIPTION
The `_initialize` function was added to the concept of reactors in order to implement static initializers, such as in C++. It requires the outside environment to call the `_initialize` function before calling any other export.

However, this differs from how WebAssembly modules are used on the Web and other embedders outside of WASI. WebAssembly embedders in other environments are accustomed to just instantiating WebAssembly modules and accessing their exports.

One option would be to teach more environments how to load WASI reactors, specifically, to have them recognize and call the `_initialize` function autmatically. But at a high level, I think this would move us in the wrong direction. This would mean that more things need to treat WASI modules differently from regular WebAssembly modules.

Overall, I think it's better to work toward making WASI modules just be regular WebAssembly modules that just happen to import WASI APIs instead of other APIs.

I've now [posted a patch] which implements static initializers without using an `_initialize` function.

[posted a patch]: https://reviews.llvm.org/D135903