### PR TITLE
Remove the handle-index and classic-command proposals.

### DIFF
--- a/Proposals.md
+++ b/Proposals.md
@@ -30,10 +30,8 @@ You can learn more about contributing new proposals (and other ways to contribut
 | ------------------------------------------------------------------------------ | -------------------------------------- | -------- |
 | [I/O][wasi-io]                                                                 | Dan Gohman                             |          |
 | [Filesystem][wasi-filesystem]                                                  | Dan Gohman                             |          |
-| ["Classic" Command-Line][wasi-classic-command] (Legacy, to be deprecated in Q4 2022)| Dan Gohman                             |          |
 | [Clocks][wasi-clocks]                                                          | Dan Gohman                             |          |
 | [Random][wasi-random]                                                          | Dan Gohman                             |          |
-| [Handle Index][wasi-handle-index]                                              | Dan Gohman                             |          |
 | [Poll][wasi-poll]                                                              | Dan Gohman                             |          |
 | [Machine Learning (wasi-nn)][wasi-nn]                                          | Andrew Brown and Mingqiu Sun           |          |
 


### PR DESCRIPTION
It's now clear that wasi-handle-index is being subsumed by the component model definition of handles, so we no longer need a proposal repository for it.

wasi-classic-command will be replaced by an upcoming command proposal based on the new World concept in the component-model.