### PR TITLE
Explicitly document that Preview1's `fd_readdir` includes `.` and `..`.

### DIFF
--- a/legacy/preview1/witx/wasi_snapshot_preview1.witx
+++ b/legacy/preview1/witx/wasi_snapshot_preview1.witx
@@ -228,6 +228,9 @@
   ;;; truncating the last directory entry. This allows the caller to grow its
   ;;; read buffer size in case it's too small to fit a single large directory
   ;;; entry, or skip the oversized directory entry.
+  ;;;
+  ;;; Entries for the special `.` and `..` directory entries are included in the
+  ;;; sequence.
   (@interface func (export "fd_readdir")
     (param $fd $fd)
     ;;; The buffer where directory entries are stored


### PR DESCRIPTION
As discussed in the the 02-09 meeting, explicitly document that Preview1's `fd_readdir` includes the `.` and `..`.

This resolves WebAssembly/wasi-testsuite#52.