### PR TITLE
Add documentation about starting file descriptors in Preview1.

### DIFF
--- a/legacy/application-abi.md
+++ b/legacy/application-abi.md
@@ -52,7 +52,7 @@ with the name `__indirect_function_table`. Function pointers in WASI API calls
 are relative to this table's index space.
 
 When `_start` or `_initialize` is called, environments shall provide file
-descriptors with indices 0, 1, and 2 representing file-like resources for
+descriptors with indices 0, 1, and 2 representing stream resources for
 standard input, standard output, and standard error. Environments may provide
 additional "preopen" file descriptors that can be inspected with
 `fd_prestat_get` and `fd_prestat_dir_name`. These resources may be closed at

--- a/legacy/application-abi.md
+++ b/legacy/application-abi.md
@@ -51,6 +51,13 @@ Regardless of the kind, all modules accessing WASI APIs also export a table
 with the name `__indirect_function_table`. Function pointers in WASI API calls
 are relative to this table's index space.
 
+When `_start` or `_initialize` is called, environments shall provide file
+descriptors with indices 0, 1, and 2 representing file-like resources for
+standard input, standard output, and standard error. Environments may provide
+additional "preopen" file descriptors that can be inspected with
+`fd_prestat_get` and `fd_prestat_dir_name`. These resources may be closed at
+any time.
+
 Environments shall not access exports named `__heap_base` or `__data_end`.
 Toolchains are encouraged to avoid providing these exports.
 


### PR DESCRIPTION
Add documentation mentioning stdin, stdout, and stderr file descriptors, and also preopen file descriptors, and mention that preopen file descriptors can be closed.

Allowing preopen file descriptors to be closed is a change from how Wasmtime historically worked, but I think it's more clear now that it's ok to let preopens be closed. We'll change Wasmtime accordingly.

This addresses WebAssembly/wasi-testsuite#50.