### PR TITLE
Add documentation for return types and pointer types in witx.

### DIFF
--- a/legacy/tools/witx-docs.md
+++ b/legacy/tools/witx-docs.md
@@ -75,8 +75,7 @@ For example, the `poll_oneoff` function has these arguments:
 ```
 
 Pointer values are expected to be aligned, to the alignment of their pointee
-type. If a misaligned pointer is passed to a function, the function shall fail
-with an `errno::inval` error code.
+type. If a misaligned pointer is passed to a function, the function shall trap.
 
 [module linking proposal]: https://github.com/WebAssembly/module-linking/
 [interface types]: https://github.com/WebAssembly/interface-types/blob/main/proposals/interface-types/Explainer.md

--- a/legacy/tools/witx-docs.md
+++ b/legacy/tools/witx-docs.md
@@ -57,6 +57,27 @@ __wasi_errno_t __wasi_fd_read(
 );
 ```
 
+## Pointers
+
+Witx supports two pointer types, `pointer` and `const_pointer`, which represent
+pointers into the exported linear memory named "memory". `const_pointer` in a
+function declaration documents that the function does not use the pointer for
+mutating memory. Similar to C, they can point to either a single value or an
+contiguous array of values.
+
+Pointer arguments use the `@witx` syntax inspired by the [annotations proposal].
+
+For example, the `poll_oneoff` function has these arguments:
+
+```witx
+   (param $in (@witx const_pointer $subscription))
+   (param $out (@witx pointer $event))
+```
+
+Pointer values are expected to be aligned, to the alignment of their pointee
+type. If a misaligned pointer is passed to a function, the function shall fail
+with an `errno::inval` error code.
+
 [module linking proposal]: https://github.com/WebAssembly/module-linking/
 [interface types]: https://github.com/WebAssembly/interface-types/blob/main/proposals/interface-types/Explainer.md
 [wat format]: https://webassembly.github.io/spec/core/bikeshed/index.html#text-format%E2%91%A0
@@ -66,3 +87,4 @@ __wasi_errno_t __wasi_fd_read(
 [Wit language]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md
 [Canonical ABI]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md
 [migrating]: https://github.com/WebAssembly/wasi#important-note-wasi-is-in-transition
+[annotations proposal]: https://github.com/WebAssembly/annotations

--- a/legacy/tools/witx-docs.md
+++ b/legacy/tools/witx-docs.md
@@ -17,7 +17,7 @@ to existing APIs and proposing new APIs.
 The WASI Subgroup is [migrating] away from `witx` and toward [Wit], because
 Wit provides much better support for non-C-like languages, better support for
 API virtualization, it has a path to integrating async behavior into WASI
-APIs in a comprehensive way, and it supports much more expression APIs, such
+APIs in a comprehensive way, and it supports much more expressive APIs, such
 as the ability to have `string`s and other types as return types in addition
 to just argument types. At this point, the tooling for Wit is also a lot more
 sophisticated and the [Wit language] and [Canonical ABI] have much more


### PR DESCRIPTION
Document how return types, in particular `expected` return types, work in witx.

Also update the witx-docs.md file to describe the current status of witx and the transition to wit.