### PR TITLE
Advance wasi-sockets to phase 2

### DIFF
--- a/Proposals.md
+++ b/Proposals.md
@@ -33,6 +33,7 @@ You can learn more about contributing new proposals (and other ways to contribut
 | [Clocks][wasi-clocks]                                                          | Dan Gohman                             |          |
 | [Random][wasi-random]                                                          | Dan Gohman                             |          |
 | [Poll][wasi-poll]                                                              | Dan Gohman                             |          |
+| [Sockets][wasi-sockets]                                                        | Dave Bakker                            |          |
 | [Machine Learning (wasi-nn)][wasi-nn]                                          | Andrew Brown and Mingqiu Sun           |          |
 
 ### Phase 1 - Feature Proposal (CG)
@@ -49,7 +50,6 @@ You can learn more about contributing new proposals (and other ways to contribut
 | [Parallel][wasi-parallel]                                                      | Andrew Brown                           |          |
 | [Pub/sub][wasi-pubsub]                                                         | Jiaxiao Zhou, Dan Chiarlone, David Justice |          | 
 | [Runtime Config][wasi-runtime-config]                                          | Jiaxiao Zhou, Dan Chiarlone, David Justice |          | 
-| [Sockets][wasi-sockets]                                                        | Dave Bakker                            |          |
 | [SQL][wasi-sql]                                                                | Jiaxiao Zhou, Dan Chiarlone, David Justice |          |
 | [Threads][wasi-threads]                                                        | Alexandru Ene, Marcin Kolny, Andrew Brown |          |
 | [URL][wasi-url]                                                                | George Kulakowski and Radu Matei       |          |


### PR DESCRIPTION
I feel [the proposal](https://github.com/WebAssembly/wasi-sockets) is coming along quite nicely. It's slated to be included in Preview2.

Before scheduling a vote, I thought I'd test the waters here first. 
Are there any things you'd like me to do, to make the proposal Phase 2-worthy?