### PR TITLE
Remove WASI-Data as a proposal

### DIFF
--- a/Proposals.md
+++ b/Proposals.md
@@ -67,7 +67,6 @@ You can learn more about contributing new proposals (and other ways to contribut
 
 | Proposal                                                                       | Champion                               | Versions |
 | ------------------------------------------------------------------------------ | -------------------------------------- | -------- |
-| [singlestore-labs/wasi-data][wasi-data]                                        | Bailey Hayes                           |          |
 | [proxy-wasm/spec][wasi-proxy-wasm] (will advance as multiple, smaller proposals)    | Piotr Sikora                           |          |
 
 ## Versioning


### PR DESCRIPTION
SingleStore is no longer pursuing wasi-data and @ricochet, it's champion, has decided not to pursue it further independently.