### PR TITLE
add LICENSE.md, following the W3C CLA Deed

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,8 @@
+Copyright © 2019-2023 the Contributors to the WASI Specification, published
+by the [WebAssembly Community Group][cg] under the
+[W3C Community Contributor License Agreement (CLA)][cla]. A human-readable
+[summary][summary] is available.
+
+[cg]: https://www.w3.org/community/webassembly/
+[cla]: https://www.w3.org/community/about/agreements/cla/
+[summary]: https://www.w3.org/community/about/agreements/cla-deed/


### PR DESCRIPTION
This is a copyright and license description, which I have translated from HTML to Markdown, as found in https://www.w3.org/community/reports/reqs/ for use in draft reports.

I consulted with the Wasm CG chairs @dtig @dschuff @conrad-watt and we believe that this is an appropriate license to include in the WASI proposal repositories.