### PR TITLE
Add a definition for Preview 2.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,21 +4,23 @@
 
 ![WASI](WASI.png)
 
-The WebAssembly System Interface is not a monolithic standard system interface,
-but is instead a modular collection of standardized APIs. None of the APIs are
-required to be implemented to have a compliant runtime. Instead, host
-environments can choose which APIs make sense for their use cases.
+The WebAssembly System Interface (WASI) is a set of APIs for WASI being
+developed for eventual standardization by the WASI Subgroup, which is a
+subgroup of the WebAssembly Community Group.
 
----
-## Important Note: WASI is in transition
+WASI started with launching what is now called [Preview 1], an API using
+the witx IDL, and it is now widely used. Its major incluences are POSIX and
+CloudABI.
 
-WASI is transitioning away from the `witx` format and its early experimental ABI. We are transitioning to Interface Types using the `wit` format and the canonical ABI.
+[WASI Preview 2] is now in development, which is a modular collection of
+APIs defined with the [Wit IDL], and it incorporates many of the lessons
+learned from Preview 1, including adding support for a wider range of
+source languages, modularity, a more expressive type system,
+virtualizability, and more.
 
-All new API proposals should use the new format and the new repo structure that is shown in the [proposal template](https://github.com/WebAssembly/wasi-proposal-template).
-
-See the [Wit in WASI](docs/WitInWasi.md) document for more information about using Wit for WASI proposals.
-
----
+[Preview 1]: https://github.com/WebAssembly/WASI/tree/main/legacy/README.md
+[WASI Preview 2]: https://github.com/WebAssembly/WASI/tree/main/preview2/README.md
+[Wit IDL]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md
 
 ## Find the APIs
 
@@ -32,6 +34,10 @@ and high-level goals.
 
 If you would like to create a new proposal, get started with our
 [Contributing guide](Contributing.md).
+
+All new API proposals should use the new format and the new repo structure that is shown in the [proposal template](https://github.com/WebAssembly/wasi-proposal-template).
+
+See the [Wit in WASI](docs/WitInWasi.md) document for more information about using Wit for WASI proposals.
 
 ## WASI High Level Goals
 
@@ -129,3 +135,10 @@ API in WASI, so we don't need to exclude APIs just because some host
 environments can't implement them. We prefer APIs which can run across
 a wide variety of engines when feasible, but we'll ultimately decide
 whether something is "portable enough" on an API-by-API basis.
+
+### Modularity
+
+WASI will include many interfaces that are not appropriate for every host
+environment, so WASI uses the component model's worlds mechanism to allow
+specific sets of APIs to be described which meet the needs of different
+environments.

--- a/preview2/README.md
+++ b/preview2/README.md
@@ -1,0 +1,45 @@
+# WASI Preview 2
+
+At this time, Preview 2 is in development and has not yet launched.
+
+## Launch criteria
+
+WASI Preview 2 will be considered launched when at least two independent
+proposals which define worlds, and all their dependencies, have met the
+requirements for inclusion listed below, and the WASI Subgroup has voted
+to launch it.
+
+## Introduction
+
+*The following is a draft of an introduction for WASI Preview 2 when it launches.*
+
+WASI Preview 2 represents a major milestone for WASI. It marks the moment
+when WASI has fully rebased on the [Wit IDL] and the [component model]
+type system and semantics, making it modular, fully virtualizable, and
+accessible to a wide variety of source languages.
+
+[Wit IDL]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md
+[component model]: https://github.com/WebAssembly/component-model
+
+## WASI Preview 2 Contents
+
+WASI Preview 2 contains the following APIs:
+
+| Proposal                                                                       | Versions |
+| ------------------------------------------------------------------------------ | -------- |
+
+## Proposal requirements for inclusion in WASI Preview 2.
+
+To be included in Preview 2, a proposal must:
+
+ - Reach phase 3 in the [WASI Subgroup Phase Process]
+ - Satisfy its own [phase 4 acceptance criteria]
+ - Be voted for inclusion by the WASI Subgroup
+
+Proposals may be added to WASI Preview 2 at any time until WASI Preview 3
+is launched.
+
+[WASI Subgroup Phase Process]: https://github.com/WebAssembly/WASI/blob/main/Contributing.md#the-phase-process
+[phase 4 acceptance criteria]: https://github.com/WebAssembly/WASI/blob/main/Contributing.md#2-feature-description-available-wasi-subgroup
+[worlds]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md#wit-worlds
+[launch criteria]: #wasi-preview-2-launch-criteria


### PR DESCRIPTION
Add a document defining the criteria for including proposals in Preview 2, as well as defining when Preview 2 is considered launched.

And, update the top-level README.md to point to this new document and to reflect the updated Preview 2 plan.