### PR TITLE
Document behaviour of path_readlink when buf is too small

### DIFF
--- a/legacy/preview1/witx/wasi_snapshot_preview1.witx
+++ b/legacy/preview1/witx/wasi_snapshot_preview1.witx
@@ -386,7 +386,9 @@
   )
 
   ;;; Read the contents of a symbolic link.
-  ;;; Note: This is similar to `readlinkat` in POSIX.
+  ;;; Note: This is similar to `readlinkat` in POSIX. If `buf` is not large
+  ;;; enough to contain the contents of the link, the first `buf_len` bytes will be
+  ;;; be written to `buf`.
   (@interface func (export "path_readlink")
     (param $fd $fd)
     ;;; The path of the symbolic link from which to read.


### PR DESCRIPTION
`readlink` and `readlinkat` in POSIX specify that if the buffer is too small to contain the link content, the first `buf_len` bytes will be written. We already state the behaviour of this function is similar to `readlinkat` but explicitly clarifying this case removes any ambiguity.

I ran into this issue when [fixing the WASI tests for WAMR](https://github.com/WebAssembly/wasi-testsuite/pull/85/files#r1321869236). Alternatively, if we don't want to enforce this behaviour, I can modify the PR to state the behaviour is undefined when the buffer is too small (currently wasmtime returns an error in this case). Given the current docs mention `readlinkat`, I think it's reasonable to assume the behaviour is the same unless specified otherwise.

Please let me know if there any other concerns or suggestions.