### PR TITLE
Fix WITX docs links in legacy files

### DIFF
--- a/legacy/preview0/witx/typenames.witx
+++ b/legacy/preview0/witx/typenames.witx
@@ -2,7 +2,7 @@
 ;;
 ;; Some content here is derived from [CloudABI](https://github.com/NuxiNL/cloudabi).
 ;;
-;; This is a `witx` file. See [here](https://github.com/WebAssembly/WASI/tree/main/docs/witx.md)
+;; This is a `witx` file. See [here](https://github.com/WebAssembly/WASI/blob/main/legacy/tools/witx-docs.md)
 ;; for an explanation of what that means.
 
 (typename $size u32)

--- a/legacy/preview0/witx/wasi_unstable.witx
+++ b/legacy/preview0/witx/wasi_unstable.witx
@@ -3,7 +3,7 @@
 ;;
 ;; Some content here is derived from [CloudABI](https://github.com/NuxiNL/cloudabi).
 ;;
-;; This is a `witx` file. See [here](https://github.com/WebAssembly/WASI/tree/master/docs/witx.md)
+;; This is a `witx` file. See [here](https://github.com/WebAssembly/WASI/blob/main/legacy/tools/witx-docs.md)
 ;; for an explanation of what that means.
 
 (use "typenames.witx")

--- a/legacy/preview1/witx/typenames.witx
+++ b/legacy/preview1/witx/typenames.witx
@@ -2,7 +2,7 @@
 ;;
 ;; Some content here is derived from [CloudABI](https://github.com/NuxiNL/cloudabi).
 ;;
-;; This is a `witx` file. See [here](https://github.com/WebAssembly/WASI/tree/master/docs/witx.md)
+;; This is a `witx` file. See [here](https://github.com/WebAssembly/WASI/blob/main/legacy/tools/witx-docs.md)
 ;; for an explanation of what that means.
 
 (typename $size u32)

--- a/legacy/preview1/witx/wasi_snapshot_preview1.witx
+++ b/legacy/preview1/witx/wasi_snapshot_preview1.witx
@@ -3,7 +3,7 @@
 ;;
 ;; Some content here is derived from [CloudABI](https://github.com/NuxiNL/cloudabi).
 ;;
-;; This is a `witx` file. See [here](https://github.com/WebAssembly/WASI/tree/master/docs/witx.md)
+;; This is a `witx` file. See [here](https://github.com/WebAssembly/WASI/blob/main/legacy/tools/witx-docs.md)
 ;; for an explanation of what that means.
 
 (use "typenames.witx")


### PR DESCRIPTION
The https://github.com/WebAssembly/WASI/tree/main/docs/witx.md links in the legacy witx files are broken from files being moved in #451 moved docs/witx.md, so I updated them to the (currently) working link https://github.com/WebAssembly/WASI/blob/main/legacy/tools/witx-docs.md