### PR TITLE
wasi-i2c champion change

### DIFF
--- a/Proposals.md
+++ b/Proposals.md
@@ -45,7 +45,7 @@ You can learn more about contributing new proposals (and other ways to contribut
 | [Crypto][wasi-crypto]                                                          | Frank Denis and Daiki Ueno             |          |
 | [Digital I/O][wasi-digital-io]                      | Emiel Van Severen |          |
 | [Distributed Lock Service][wasi-distributed-lock-service]                      | Jiaxiao Zhou, Dan Chiarlone, David Justice |          |
-| [I2C][wasi-i2c]                      | Emiel Van Severen |          |
+| [I2C][wasi-i2c]                      | Friedrich Vandenberghe |          |
 | [Key-value Store][wasi-kv-store]                                               | Jiaxiao Zhou, Dan Chiarlone, David Justice |          |
 | [Logging][wasi-logging]                                               | Dan Gohman |          |
 | [Message Queue][wasi-message-queue]                                            | Jiaxiao Zhou, Dan Chiarlone, David Justice |          |


### PR DESCRIPTION
Emiel has passed championship of wasi-i2c to Friedrich Vendenberghe