### PR TITLE
[do not merge] Preview adding `@since` and `@unstable` gates to WASI 0.2

### DIFF
--- a/preview2/cli/command.wit
+++ b/preview2/cli/command.wit
@@ -1,7 +1,10 @@
 package wasi:cli@0.2.0;
 
+@since(version = 0.2.0)
 world command {
+  @since(version = 0.2.0)
   include imports;
 
+  @since(version = 0.2.0)
   export run;
 }

--- a/preview2/cli/environment.wit
+++ b/preview2/cli/environment.wit
@@ -1,3 +1,4 @@
+@since(version = 0.2.0)
 interface environment {
   /// Get the POSIX-style environment variables.
   ///
@@ -7,12 +8,15 @@ interface environment {
   /// Morally, these are a value import, but until value imports are available
   /// in the component model, this import function should return the same
   /// values each time it is called.
+  @since(version = 0.2.0)
   get-environment: func() -> list<tuple<string, string>>;
 
   /// Get the POSIX-style arguments to the program.
+  @since(version = 0.2.0)
   get-arguments: func() -> list<string>;
 
   /// Return a path that programs should use as their initial current working
   /// directory, interpreting `.` as shorthand for this.
+  @since(version = 0.2.0)
   initial-cwd: func() -> option<string>;
 }

--- a/preview2/cli/exit.wit
+++ b/preview2/cli/exit.wit
@@ -1,4 +1,6 @@
+@since(version = 0.2.0)
 interface exit {
   /// Exit the current instance and any linked instances.
+  @since(version = 0.2.0)
   exit: func(status: result);
 }

--- a/preview2/cli/imports.wit
+++ b/preview2/cli/imports.wit
@@ -1,20 +1,36 @@
 package wasi:cli@0.2.0;
 
+@since(version = 0.2.0)
 world imports {
+  @since(version = 0.2.0)
   include wasi:clocks/imports@0.2.0;
+  @since(version = 0.2.0)
   include wasi:filesystem/imports@0.2.0;
+  @since(version = 0.2.0)
   include wasi:sockets/imports@0.2.0;
+  @since(version = 0.2.0)
   include wasi:random/imports@0.2.0;
+  @since(version = 0.2.0)
   include wasi:io/imports@0.2.0;
 
+  @since(version = 0.2.0)
   import environment;
+  @since(version = 0.2.0)
   import exit;
+  @since(version = 0.2.0)
   import stdin;
+  @since(version = 0.2.0)
   import stdout;
+  @since(version = 0.2.0)
   import stderr;
+  @since(version = 0.2.0)
   import terminal-input;
+  @since(version = 0.2.0)
   import terminal-output;
+  @since(version = 0.2.0)
   import terminal-stdin;
+  @since(version = 0.2.0)
   import terminal-stdout;
+  @since(version = 0.2.0)
   import terminal-stderr;
 }

--- a/preview2/cli/run.wit
+++ b/preview2/cli/run.wit
@@ -1,4 +1,6 @@
+@since(version = 0.2.0)
 interface run {
   /// Run the program.
+  @since(version = 0.2.0)
   run: func() -> result;
 }

--- a/preview2/cli/stdio.wit
+++ b/preview2/cli/stdio.wit
@@ -1,17 +1,23 @@
+@since(version = 0.2.0)
 interface stdin {
   use wasi:io/streams@0.2.0.{input-stream};
 
+  @since(version = 0.2.0)
   get-stdin: func() -> input-stream;
 }
 
+@since(version = 0.2.0)
 interface stdout {
   use wasi:io/streams@0.2.0.{output-stream};
 
+  @since(version = 0.2.0)
   get-stdout: func() -> output-stream;
 }
 
+@since(version = 0.2.0)
 interface stderr {
   use wasi:io/streams@0.2.0.{output-stream};
 
+  @since(version = 0.2.0)
   get-stderr: func() -> output-stream;
 }

--- a/preview2/cli/terminal.wit
+++ b/preview2/cli/terminal.wit
@@ -3,8 +3,10 @@
 /// In the future, this may include functions for disabling echoing,
 /// disabling input buffering so that keyboard events are sent through
 /// immediately, querying supported features, and so on.
+@since(version = 0.2.0)
 interface terminal-input {
     /// The input side of a terminal.
+    @since(version = 0.2.0)
     resource terminal-input;
 }
 
@@ -13,37 +15,45 @@ interface terminal-input {
 /// In the future, this may include functions for querying the terminal
 /// size, being notified of terminal size changes, querying supported
 /// features, and so on.
+@since(version = 0.2.0)
 interface terminal-output {
     /// The output side of a terminal.
+    @since(version = 0.2.0)
     resource terminal-output;
 }
 
 /// An interface providing an optional `terminal-input` for stdin as a
 /// link-time authority.
+@since(version = 0.2.0)
 interface terminal-stdin {
     use terminal-input.{terminal-input};
 
     /// If stdin is connected to a terminal, return a `terminal-input` handle
     /// allowing further interaction with it.
+    @since(version = 0.2.0)
     get-terminal-stdin: func() -> option<terminal-input>;
 }
 
 /// An interface providing an optional `terminal-output` for stdout as a
 /// link-time authority.
+@since(version = 0.2.0)
 interface terminal-stdout {
     use terminal-output.{terminal-output};
 
     /// If stdout is connected to a terminal, return a `terminal-output` handle
     /// allowing further interaction with it.
+    @since(version = 0.2.0)
     get-terminal-stdout: func() -> option<terminal-output>;
 }
 
 /// An interface providing an optional `terminal-output` for stderr as a
 /// link-time authority.
+@since(version = 0.2.0)
 interface terminal-stderr {
     use terminal-output.{terminal-output};
 
     /// If stderr is connected to a terminal, return a `terminal-output` handle
     /// allowing further interaction with it.
+    @since(version = 0.2.0)
     get-terminal-stderr: func() -> option<terminal-output>;
 }

--- a/preview2/clocks/monotonic-clock.wit
+++ b/preview2/clocks/monotonic-clock.wit
@@ -9,29 +9,35 @@ package wasi:clocks@0.2.0;
 /// successive reads of the clock will produce non-decreasing values.
 ///
 /// It is intended for measuring elapsed time.
+@since(version = 0.2.0)
 interface monotonic-clock {
     use wasi:io/poll@0.2.0.{pollable};
 
     /// An instant in time, in nanoseconds. An instant is relative to an
     /// unspecified initial value, and can only be compared to instances from
     /// the same monotonic-clock.
+    @since(version = 0.2.0)
     type instant = u64;
 
     /// A duration of time, in nanoseconds.
+    @since(version = 0.2.0)
     type duration = u64;
 
     /// Read the current value of the clock.
     ///
     /// The clock is monotonic, therefore calling this function repeatedly will
     /// produce a sequence of non-decreasing values.
+    @since(version = 0.2.0)
     now: func() -> instant;
 
     /// Query the resolution of the clock. Returns the duration of time
     /// corresponding to a clock tick.
+    @since(version = 0.2.0)
     resolution: func() -> duration;
 
     /// Create a `pollable` which will resolve once the specified instant
     /// occured.
+    @since(version = 0.2.0)
     subscribe-instant: func(
         when: instant,
     ) -> pollable;
@@ -39,6 +45,7 @@ interface monotonic-clock {
     /// Create a `pollable` which will resolve once the given duration has
     /// elapsed, starting at the time at which this function was called.
     /// occured.
+    @since(version = 0.2.0)
     subscribe-duration: func(
         when: duration,
     ) -> pollable;

--- a/preview2/clocks/timezone.wit
+++ b/preview2/clocks/timezone.wit
@@ -1,0 +1,54 @@
+package wasi:clocks@0.2.0;
+
+@unstable(feature = timezone)
+interface timezone {
+    use wall-clock.{datetime};
+
+    /// Return information needed to display the given `datetime`. This includes
+    /// the UTC offset, the time zone name, and a flag indicating whether
+    /// daylight saving time is active.
+    ///
+    /// If the timezone cannot be determined for the given `datetime`, return a
+    /// `timezone-display` for `UTC` with a `utc-offset` of 0 and no daylight
+    /// saving time.
+    @unstable(feature = timezone)
+    display: func(when: datetime) -> timezone-display;
+
+    /// The same as `display`, but only return the UTC offset.
+    @unstable(feature = timezone)
+    utc-offset: func(when: datetime) -> s32;
+
+    /// Information useful for displaying the timezone of a specific `datetime`.
+    ///
+    /// This information may vary within a single `timezone` to reflect daylight
+    /// saving time adjustments.
+    @unstable(feature = timezone)
+    record timezone-display {
+        /// The number of seconds difference between UTC time and the local
+        /// time of the timezone.
+        ///
+        /// The returned value will always be less than 86400 which is the
+        /// number of seconds in a day (24*60*60).
+        ///
+        /// In implementations that do not expose an actual time zone, this
+        /// should return 0.
+        utc-offset: s32,
+
+        /// The abbreviated name of the timezone to display to a user. The name
+        /// `UTC` indicates Coordinated Universal Time. Otherwise, this should
+        /// reference local standards for the name of the time zone.
+        ///
+        /// In implementations that do not expose an actual time zone, this
+        /// should be the string `UTC`.
+        ///
+        /// In time zones that do not have an applicable name, a formatted
+        /// representation of the UTC offset may be returned, such as `-04:00`.
+        name: string,
+
+        /// Whether daylight saving time is active.
+        ///
+        /// In implementations that do not expose an actual time zone, this
+        /// should return false.
+        in-daylight-saving-time: bool,
+    }
+}

--- a/preview2/clocks/wall-clock.wit
+++ b/preview2/clocks/wall-clock.wit
@@ -13,8 +13,10 @@ package wasi:clocks@0.2.0;
 /// monotonic, making it unsuitable for measuring elapsed time.
 ///
 /// It is intended for reporting the current date and time for humans.
+@since(version = 0.2.0)
 interface wall-clock {
     /// A time and date in seconds plus nanoseconds.
+    @since(version = 0.2.0)
     record datetime {
         seconds: u64,
         nanoseconds: u32,
@@ -33,10 +35,12 @@ interface wall-clock {
     ///
     /// [POSIX's Seconds Since the Epoch]: https://pubs.opengroup.org/onlinepubs/9699919799/xrat/V4_xbd_chap04.html#tag_21_04_16
     /// [Unix Time]: https://en.wikipedia.org/wiki/Unix_time
+    @since(version = 0.2.0)
     now: func() -> datetime;
 
     /// Query the resolution of the clock.
     ///
     /// The nanoseconds field of the output is always less than 1000000000.
+    @since(version = 0.2.0)
     resolution: func() -> datetime;
 }

--- a/preview2/clocks/world.wit
+++ b/preview2/clocks/world.wit
@@ -1,6 +1,9 @@
 package wasi:clocks@0.2.0;
 
+@since(version = 0.2.0)
 world imports {
+    @since(version = 0.2.0)
     import monotonic-clock;
+    @since(version = 0.2.0)
     import wall-clock;
 }

--- a/preview2/clocks/world.wit
+++ b/preview2/clocks/world.wit
@@ -6,4 +6,6 @@ world imports {
     import monotonic-clock;
     @since(version = 0.2.0)
     import wall-clock;
+    @unstable(feature = timezone)
+    import timezone;
 }

--- a/preview2/filesystem/preopens.wit
+++ b/preview2/filesystem/preopens.wit
@@ -1,8 +1,10 @@
 package wasi:filesystem@0.2.0;
 
+@since(version = 0.2.0)
 interface preopens {
     use types.{descriptor};
 
     /// Return the set of preopened directories, and their path.
+    @since(version = 0.2.0)
     get-directories: func() -> list<tuple<descriptor, string>>;
 }

--- a/preview2/filesystem/types.wit
+++ b/preview2/filesystem/types.wit
@@ -23,16 +23,19 @@ package wasi:filesystem@0.2.0;
 /// [WASI filesystem path resolution].
 ///
 /// [WASI filesystem path resolution]: https://github.com/WebAssembly/wasi-filesystem/blob/main/path-resolution.md
+@since(version = 0.2.0)
 interface types {
     use wasi:io/streams@0.2.0.{input-stream, output-stream, error};
     use wasi:clocks/wall-clock@0.2.0.{datetime};
 
     /// File size or length of a region within a file.
+    @since(version = 0.2.0)
     type filesize = u64;
 
     /// The type of a filesystem object referenced by a descriptor.
     ///
     /// Note: This was called `filetype` in earlier versions of WASI.
+    @since(version = 0.2.0)
     enum descriptor-type {
         /// The type of the descriptor or file is unknown or is different from
         /// any of the other types specified.
@@ -56,6 +59,7 @@ interface types {
     /// Descriptor flags.
     ///
     /// Note: This was called `fdflags` in earlier versions of WASI.
+    @since(version = 0.2.0)
     flags descriptor-flags {
         /// Read mode: Data can be read.
         read,
@@ -99,6 +103,7 @@ interface types {
     /// File attributes.
     ///
     /// Note: This was called `filestat` in earlier versions of WASI.
+    @since(version = 0.2.0)
     record descriptor-stat {
         /// File type.
         %type: descriptor-type,
@@ -125,6 +130,7 @@ interface types {
     }
 
     /// Flags determining the method of how paths are resolved.
+    @since(version = 0.2.0)
     flags path-flags {
         /// As long as the resolved path corresponds to a symbolic link, it is
         /// expanded.
@@ -132,6 +138,7 @@ interface types {
     }
 
     /// Open flags used by `open-at`.
+    @since(version = 0.2.0)
     flags open-flags {
         /// Create file if it does not exist, similar to `O_CREAT` in POSIX.
         create,
@@ -144,9 +151,11 @@ interface types {
     }
 
     /// Number of hard links to an inode.
+    @since(version = 0.2.0)
     type link-count = u64;
 
     /// When setting a timestamp, this gives the value to set it to.
+    @since(version = 0.2.0)
     variant new-timestamp {
         /// Leave the timestamp set to its previous value.
         no-change,
@@ -248,6 +257,7 @@ interface types {
     }
 
     /// File or memory access pattern advisory information.
+    @since(version = 0.2.0)
     enum advice {
         /// The application has no advice to give on its behavior with respect
         /// to the specified data.
@@ -271,6 +281,7 @@ interface types {
 
     /// A 128-bit hash value, split into parts because wasm doesn't have a
     /// 128-bit integer type.
+    @since(version = 0.2.0)
     record metadata-hash-value {
        /// 64 bits of a 128-bit hash value.
        lower: u64,
@@ -281,6 +292,7 @@ interface types {
     /// A descriptor is a reference to a filesystem object, which may be a file,
     /// directory, named pipe, special file, or other object on which filesystem
     /// calls may be made.
+    @since(version = 0.2.0)
     resource descriptor {
         /// Return a stream for reading from a file, if available.
         ///
@@ -290,6 +302,7 @@ interface types {
         /// file and they do not interfere with each other.
         ///
         /// Note: This allows using `read-stream`, which is similar to `read` in POSIX.
+        @since(version = 0.2.0)
         read-via-stream: func(
             /// The offset within the file at which to start reading.
             offset: filesize,
@@ -301,6 +314,7 @@ interface types {
         ///
         /// Note: This allows using `write-stream`, which is similar to `write` in
         /// POSIX.
+        @since(version = 0.2.0)
         write-via-stream: func(
             /// The offset within the file at which to start writing.
             offset: filesize,
@@ -312,11 +326,13 @@ interface types {
         ///
         /// Note: This allows using `write-stream`, which is similar to `write` with
         /// `O_APPEND` in in POSIX.
+        @since(version = 0.2.0)
         append-via-stream: func() -> result<output-stream, error-code>;
 
         /// Provide file advisory information on a descriptor.
         ///
         /// This is similar to `posix_fadvise` in POSIX.
+        @since(version = 0.2.0)
         advise: func(
             /// The offset within the file to which the advisory applies.
             offset: filesize,
@@ -332,6 +348,7 @@ interface types {
         /// opened for writing.
         ///
         /// Note: This is similar to `fdatasync` in POSIX.
+        @since(version = 0.2.0)
         sync-data: func() -> result<_, error-code>;
 
         /// Get flags associated with a descriptor.
@@ -340,6 +357,7 @@ interface types {
         ///
         /// Note: This returns the value that was the `fs_flags` value returned
         /// from `fdstat_get` in earlier versions of WASI.
+        @since(version = 0.2.0)
         get-flags: func() -> result<descriptor-flags, error-code>;
 
         /// Get the dynamic type of a descriptor.
@@ -352,12 +370,14 @@ interface types {
         ///
         /// Note: This returns the value that was the `fs_filetype` value returned
         /// from `fdstat_get` in earlier versions of WASI.
+        @since(version = 0.2.0)
         get-type: func() -> result<descriptor-type, error-code>;
 
         /// Adjust the size of an open file. If this increases the file's size, the
         /// extra bytes are filled with zeros.
         ///
         /// Note: This was called `fd_filestat_set_size` in earlier versions of WASI.
+        @since(version = 0.2.0)
         set-size: func(size: filesize) -> result<_, error-code>;
 
         /// Adjust the timestamps of an open file or directory.
@@ -365,6 +385,7 @@ interface types {
         /// Note: This is similar to `futimens` in POSIX.
         ///
         /// Note: This was called `fd_filestat_set_times` in earlier versions of WASI.
+        @since(version = 0.2.0)
         set-times: func(
             /// The desired values of the data access timestamp.
             data-access-timestamp: new-timestamp,
@@ -383,6 +404,7 @@ interface types {
         /// In the future, this may change to return a `stream<u8, error-code>`.
         ///
         /// Note: This is similar to `pread` in POSIX.
+        @since(version = 0.2.0)
         read: func(
             /// The maximum number of bytes to read.
             length: filesize,
@@ -399,6 +421,7 @@ interface types {
         /// In the future, this may change to take a `stream<u8, error-code>`.
         ///
         /// Note: This is similar to `pwrite` in POSIX.
+        @since(version = 0.2.0)
         write: func(
             /// Data to write
             buffer: list<u8>,
@@ -415,6 +438,7 @@ interface types {
         /// This always returns a new stream which starts at the beginning of the
         /// directory. Multiple streams may be active on the same directory, and they
         /// do not interfere with each other.
+        @since(version = 0.2.0)
         read-directory: func() -> result<directory-entry-stream, error-code>;
 
         /// Synchronize the data and metadata of a file to disk.
@@ -423,11 +447,13 @@ interface types {
         /// opened for writing.
         ///
         /// Note: This is similar to `fsync` in POSIX.
+        @since(version = 0.2.0)
         sync: func() -> result<_, error-code>;
 
         /// Create a directory.
         ///
         /// Note: This is similar to `mkdirat` in POSIX.
+        @since(version = 0.2.0)
         create-directory-at: func(
             /// The relative path at which to create the directory.
             path: string,
@@ -442,6 +468,7 @@ interface types {
         /// modified, use `metadata-hash`.
         ///
         /// Note: This was called `fd_filestat_get` in earlier versions of WASI.
+        @since(version = 0.2.0)
         stat: func() -> result<descriptor-stat, error-code>;
 
         /// Return the attributes of a file or directory.
@@ -451,6 +478,7 @@ interface types {
         /// discussion of alternatives.
         ///
         /// Note: This was called `path_filestat_get` in earlier versions of WASI.
+        @since(version = 0.2.0)
         stat-at: func(
             /// Flags determining the method of how the path is resolved.
             path-flags: path-flags,
@@ -464,6 +492,7 @@ interface types {
         ///
         /// Note: This was called `path_filestat_set_times` in earlier versions of
         /// WASI.
+        @since(version = 0.2.0)
         set-times-at: func(
             /// Flags determining the method of how the path is resolved.
             path-flags: path-flags,
@@ -478,6 +507,7 @@ interface types {
         /// Create a hard link.
         ///
         /// Note: This is similar to `linkat` in POSIX.
+        @since(version = 0.2.0)
         link-at: func(
             /// Flags determining the method of how the path is resolved.
             old-path-flags: path-flags,
@@ -507,6 +537,7 @@ interface types {
         /// `error-code::read-only`.
         ///
         /// Note: This is similar to `openat` in POSIX.
+        @since(version = 0.2.0)
         open-at: func(
             /// Flags determining the method of how the path is resolved.
             path-flags: path-flags,
@@ -524,6 +555,7 @@ interface types {
         /// filesystem, this function fails with `error-code::not-permitted`.
         ///
         /// Note: This is similar to `readlinkat` in POSIX.
+        @since(version = 0.2.0)
         readlink-at: func(
             /// The relative path of the symbolic link from which to read.
             path: string,
@@ -534,6 +566,7 @@ interface types {
         /// Return `error-code::not-empty` if the directory is not empty.
         ///
         /// Note: This is similar to `unlinkat(fd, path, AT_REMOVEDIR)` in POSIX.
+        @since(version = 0.2.0)
         remove-directory-at: func(
             /// The relative path to a directory to remove.
             path: string,
@@ -542,6 +575,7 @@ interface types {
         /// Rename a filesystem object.
         ///
         /// Note: This is similar to `renameat` in POSIX.
+        @since(version = 0.2.0)
         rename-at: func(
             /// The relative source path of the file or directory to rename.
             old-path: string,
@@ -557,6 +591,7 @@ interface types {
         /// `error-code::not-permitted`.
         ///
         /// Note: This is similar to `symlinkat` in POSIX.
+        @since(version = 0.2.0)
         symlink-at: func(
             /// The contents of the symbolic link.
             old-path: string,
@@ -568,6 +603,7 @@ interface types {
         ///
         /// Return `error-code::is-directory` if the path refers to a directory.
         /// Note: This is similar to `unlinkat(fd, path, 0)` in POSIX.
+        @since(version = 0.2.0)
         unlink-file-at: func(
             /// The relative path to a file to unlink.
             path: string,
@@ -579,6 +615,7 @@ interface types {
         /// same device (`st_dev`) and inode (`st_ino` or `d_ino`) numbers.
         /// wasi-filesystem does not expose device and inode numbers, so this function
         /// may be used instead.
+        @since(version = 0.2.0)
         is-same-object: func(other: borrow<descriptor>) -> bool;
 
         /// Return a hash of the metadata associated with a filesystem object referred
@@ -600,12 +637,14 @@ interface types {
         ///    computed hash.
         ///
         /// However, none of these is required.
+        @since(version = 0.2.0)
         metadata-hash: func() -> result<metadata-hash-value, error-code>;
 
         /// Return a hash of the metadata associated with a filesystem object referred
         /// to by a directory descriptor and a relative path.
         ///
         /// This performs the same hash computation as `metadata-hash`.
+        @since(version = 0.2.0)
         metadata-hash-at: func(
             /// Flags determining the method of how the path is resolved.
             path-flags: path-flags,
@@ -615,8 +654,10 @@ interface types {
     }
 
     /// A stream of directory entries.
+    @since(version = 0.2.0)
     resource directory-entry-stream {
         /// Read a single directory entry from a `directory-entry-stream`.
+        @since(version = 0.2.0)
         read-directory-entry: func() -> result<option<directory-entry>, error-code>;
     }
 
@@ -630,5 +671,6 @@ interface types {
     ///
     /// Note that this function is fallible because not all stream-related
     /// errors are filesystem-related errors.
+    @since(version = 0.2.0)
     filesystem-error-code: func(err: borrow<error>) -> option<error-code>;
 }

--- a/preview2/filesystem/world.wit
+++ b/preview2/filesystem/world.wit
@@ -1,6 +1,9 @@
 package wasi:filesystem@0.2.0;
 
+@since(version = 0.2.0)
 world imports {
+    @since(version = 0.2.0)
     import types;
+    @since(version = 0.2.0)
     import preopens;
 }

--- a/preview2/http/handler.wit
+++ b/preview2/http/handler.wit
@@ -1,5 +1,6 @@
 /// This interface defines a handler of incoming HTTP Requests. It should
 /// be exported by components which can respond to HTTP Requests.
+@since(version = 0.2.0)
 interface incoming-handler {
   use types.{incoming-request, response-outparam};
 
@@ -13,6 +14,7 @@ interface incoming-handler {
   /// The implementor of this function must write a response to the
   /// `response-outparam` before returning, or else the caller will respond
   /// with an error on its behalf.
+  @since(version = 0.2.0)
   handle: func(
     request: incoming-request,
     response-out: response-outparam
@@ -21,6 +23,7 @@ interface incoming-handler {
 
 /// This interface defines a handler of outgoing HTTP Requests. It should be
 /// imported by components which wish to make HTTP Requests.
+@since(version = 0.2.0)
 interface outgoing-handler {
   use types.{
     outgoing-request, request-options, future-incoming-response, error-code
@@ -36,6 +39,7 @@ interface outgoing-handler {
   /// This function may return an error if the `outgoing-request` is invalid
   /// or not allowed to be made. Otherwise, protocol errors are reported
   /// through the `future-incoming-response`.
+  @since(version = 0.2.0)
   handle: func(
     request: outgoing-request,
     options: option<request-options>

--- a/preview2/http/proxy.wit
+++ b/preview2/http/proxy.wit
@@ -4,29 +4,37 @@ package wasi:http@0.2.0;
 /// hosts that includes HTTP forward and reverse proxies. Components targeting
 /// this world may concurrently stream in and out any number of incoming and
 /// outgoing HTTP requests.
+@since(version = 0.2.0)
 world proxy {
   /// HTTP proxies have access to time and randomness.
+  @since(version = 0.2.0)
   include wasi:clocks/imports@0.2.0;
+  @since(version = 0.2.0)
   import wasi:random/random@0.2.0;
 
   /// Proxies have standard output and error streams which are expected to
   /// terminate in a developer-facing console provided by the host.
+  @since(version = 0.2.0)
   import wasi:cli/stdout@0.2.0;
+  @since(version = 0.2.0)
   import wasi:cli/stderr@0.2.0;
 
   /// TODO: this is a temporary workaround until component tooling is able to
   /// gracefully handle the absence of stdin. Hosts must return an eof stream
   /// for this import, which is what wasi-libc + tooling will do automatically
   /// when this import is properly removed.
+  @since(version = 0.2.0)
   import wasi:cli/stdin@0.2.0;
 
   /// This is the default handler to use when user code simply wants to make an
   /// HTTP request (e.g., via `fetch()`).
+  @since(version = 0.2.0)
   import outgoing-handler;
 
   /// The host delivers incoming HTTP requests to a component by calling the
   /// `handle` function of this exported interface. A host may arbitrarily reuse
   /// or not reuse component instance when delivering incoming HTTP requests and
   /// thus a component must be able to handle 0..N calls to `handle`.
+  @since(version = 0.2.0)
   export incoming-handler;
 }

--- a/preview2/http/types.wit
+++ b/preview2/http/types.wit
@@ -1,6 +1,7 @@
 /// This interface defines all of the types and methods for implementing
 /// HTTP Requests and Responses, both incoming and outgoing, as well as
 /// their headers, trailers, and bodies.
+@since(version = 0.2.0)
 interface types {
   use wasi:clocks/monotonic-clock@0.2.0.{duration};
   use wasi:io/streams@0.2.0.{input-stream, output-stream};
@@ -8,6 +9,7 @@ interface types {
   use wasi:io/poll@0.2.0.{pollable};
 
   /// This type corresponds to HTTP standard Methods.
+  @since(version = 0.2.0)
   variant method {
     get,
     head,
@@ -22,6 +24,7 @@ interface types {
   }
 
   /// This type corresponds to HTTP standard Related Schemes.
+  @since(version = 0.2.0)
   variant scheme {
     HTTP,
     HTTPS,
@@ -30,6 +33,7 @@ interface types {
 
   /// These cases are inspired by the IANA HTTP Proxy Error Types:
   ///   https://www.iana.org/assignments/http-proxy-status/http-proxy-status.xhtml#table-http-proxy-error-types
+  @since(version = 0.2.0)
   variant error-code {
     DNS-timeout,
     DNS-error(DNS-error-payload),
@@ -78,18 +82,21 @@ interface types {
   }
 
   /// Defines the case payload type for `DNS-error` above:
+  @since(version = 0.2.0)
   record DNS-error-payload {
     rcode: option<string>,
     info-code: option<u16>
   }
 
   /// Defines the case payload type for `TLS-alert-received` above:
+  @since(version = 0.2.0)
   record TLS-alert-received-payload {
     alert-id: option<u8>,
     alert-message: option<string>
   }
 
   /// Defines the case payload type for `HTTP-response-{header,trailer}-size` above:
+  @since(version = 0.2.0)
   record field-size-payload {
     field-name: option<string>,
     field-size: option<u32>
@@ -106,10 +113,12 @@ interface types {
   ///
   /// Note that this function is fallible because not all io-errors are
   /// http-related errors.
+  @since(version = 0.2.0)
   http-error-code: func(err: borrow<io-error>) -> option<error-code>;
 
   /// This type enumerates the different kinds of errors that may occur when
   /// setting or appending to a `fields` resource.
+  @since(version = 0.2.0)
   variant header-error {
     /// This error indicates that a `field-key` or `field-value` was
     /// syntactically invalid when used with an operation that sets headers in a
@@ -126,11 +135,13 @@ interface types {
   }
 
   /// Field keys are always strings.
+  @since(version = 0.2.0)
   type field-key = string;
 
   /// Field values should always be ASCII strings. However, in
   /// reality, HTTP implementations often have to interpret malformed values,
   /// so they are provided as a list of bytes.
+  @since(version = 0.2.0)
   type field-value = list<u8>;
 
   /// This following block defines the `fields` resource which corresponds to
@@ -143,11 +154,13 @@ interface types {
   /// `incoming-request.headers`, `outgoing-request.headers`) might be be
   /// immutable. In an immutable fields, the `set`, `append`, and `delete`
   /// operations will fail with `header-error.immutable`.
+  @since(version = 0.2.0)
   resource fields {
 
     /// Construct an empty HTTP Fields.
     ///
     /// The resulting `fields` is mutable.
+    @since(version = 0.2.0)
     constructor();
 
     /// Construct an HTTP Fields.
@@ -165,6 +178,7 @@ interface types {
     ///
     /// An error result will be returned if any header or value was
     /// syntactically invalid, or if a header was forbidden.
+    @since(version = 0.2.0)
     from-list: static func(
       entries: list<tuple<field-key,field-value>>
     ) -> result<fields, header-error>;
@@ -173,28 +187,33 @@ interface types {
     /// in this `fields`, an empty list is returned. However, if the key is
     /// present but empty, this is represented by a list with one or more
     /// empty field-values present.
+    @since(version = 0.2.0)
     get: func(name: field-key) -> list<field-value>;
 
     /// Returns `true` when the key is present in this `fields`. If the key is
     /// syntactically invalid, `false` is returned.
+    @since(version = 0.2.0)
     has: func(name: field-key) -> bool;
 
     /// Set all of the values for a key. Clears any existing values for that
     /// key, if they have been set.
     ///
     /// Fails with `header-error.immutable` if the `fields` are immutable.
+    @since(version = 0.2.0)
     set: func(name: field-key, value: list<field-value>) -> result<_, header-error>;
 
     /// Delete all values for a key. Does nothing if no values for the key
     /// exist.
     ///
     /// Fails with `header-error.immutable` if the `fields` are immutable.
+    @since(version = 0.2.0)
     delete: func(name: field-key) -> result<_, header-error>;
 
     /// Append a value for a key. Does not change or delete any existing
     /// values for that key.
     ///
     /// Fails with `header-error.immutable` if the `fields` are immutable.
+    @since(version = 0.2.0)
     append: func(name: field-key, value: field-value) -> result<_, header-error>;
 
     /// Retrieve the full set of keys and values in the Fields. Like the
@@ -203,33 +222,42 @@ interface types {
     /// The outer list represents each key-value pair in the Fields. Keys
     /// which have multiple values are represented by multiple entries in this
     /// list with the same key.
+    @since(version = 0.2.0)
     entries: func() -> list<tuple<field-key,field-value>>;
 
     /// Make a deep copy of the Fields. Equivelant in behavior to calling the
     /// `fields` constructor on the return value of `entries`. The resulting
     /// `fields` is mutable.
+    @since(version = 0.2.0)
     clone: func() -> fields;
   }
 
   /// Headers is an alias for Fields.
+  @since(version = 0.2.0)
   type headers = fields;
 
   /// Trailers is an alias for Fields.
+  @since(version = 0.2.0)
   type trailers = fields;
 
   /// Represents an incoming HTTP Request.
+  @since(version = 0.2.0)
   resource incoming-request {
 
     /// Returns the method of the incoming request.
+    @since(version = 0.2.0)
     method: func() -> method;
 
     /// Returns the path with query parameters from the request, as a string.
+    @since(version = 0.2.0)
     path-with-query: func() -> option<string>;
 
     /// Returns the protocol scheme from the request.
+    @since(version = 0.2.0)
     scheme: func() -> option<scheme>;
 
     /// Returns the authority from the request, if it was present.
+    @since(version = 0.2.0)
     authority: func() -> option<string>;
 
     /// Get the `headers` associated with the request.
@@ -240,14 +268,17 @@ interface types {
     /// The `headers` returned are a child resource: it must be dropped before
     /// the parent `incoming-request` is dropped. Dropping this
     /// `incoming-request` before all children are dropped will trap.
+    @since(version = 0.2.0)
     headers: func() -> headers;
 
     /// Gives the `incoming-body` associated with this request. Will only
     /// return success at most once, and subsequent calls will return error.
+    @since(version = 0.2.0)
     consume: func() -> result<incoming-body>;
   }
 
   /// Represents an outgoing HTTP Request.
+  @since(version = 0.2.0)
   resource outgoing-request {
 
     /// Construct a new `outgoing-request` with a default `method` of `GET`, and
@@ -260,6 +291,7 @@ interface types {
     /// and `authority`, or `headers` which are not permitted to be sent.
     /// It is the obligation of the `outgoing-handler.handle` implementation
     /// to reject invalid constructions of `outgoing-request`.
+    @since(version = 0.2.0)
     constructor(
       headers: headers
     );
@@ -270,38 +302,47 @@ interface types {
     /// Returns success on the first call: the `outgoing-body` resource for
     /// this `outgoing-request` can be retrieved at most once. Subsequent
     /// calls will return error.
+    @since(version = 0.2.0)
     body: func() -> result<outgoing-body>;
 
     /// Get the Method for the Request.
+    @since(version = 0.2.0)
     method: func() -> method;
     /// Set the Method for the Request. Fails if the string present in a
     /// `method.other` argument is not a syntactically valid method.
+    @since(version = 0.2.0)
     set-method: func(method: method) -> result;
 
     /// Get the combination of the HTTP Path and Query for the Request.
     /// When `none`, this represents an empty Path and empty Query.
+    @since(version = 0.2.0)
     path-with-query: func() -> option<string>;
     /// Set the combination of the HTTP Path and Query for the Request.
     /// When `none`, this represents an empty Path and empty Query. Fails is the
     /// string given is not a syntactically valid path and query uri component.
+    @since(version = 0.2.0)
     set-path-with-query: func(path-with-query: option<string>) -> result;
 
     /// Get the HTTP Related Scheme for the Request. When `none`, the
     /// implementation may choose an appropriate default scheme.
+    @since(version = 0.2.0)
     scheme: func() -> option<scheme>;
     /// Set the HTTP Related Scheme for the Request. When `none`, the
     /// implementation may choose an appropriate default scheme. Fails if the
     /// string given is not a syntactically valid uri scheme.
+    @since(version = 0.2.0)
     set-scheme: func(scheme: option<scheme>) -> result;
 
     /// Get the HTTP Authority for the Request. A value of `none` may be used
     /// with Related Schemes which do not require an Authority. The HTTP and
     /// HTTPS schemes always require an authority.
+    @since(version = 0.2.0)
     authority: func() -> option<string>;
     /// Set the HTTP Authority for the Request. A value of `none` may be used
     /// with Related Schemes which do not require an Authority. The HTTP and
     /// HTTPS schemes always require an authority. Fails if the string given is
     /// not a syntactically valid uri authority.
+    @since(version = 0.2.0)
     set-authority: func(authority: option<string>) -> result;
 
     /// Get the headers associated with the Request.
@@ -312,6 +353,7 @@ interface types {
     /// This headers resource is a child: it must be dropped before the parent
     /// `outgoing-request` is dropped, or its ownership is transfered to
     /// another component by e.g. `outgoing-handler.handle`.
+    @since(version = 0.2.0)
     headers: func() -> headers;
   }
 
@@ -321,31 +363,39 @@ interface types {
   ///
   /// These timeouts are separate from any the user may use to bound a
   /// blocking call to `wasi:io/poll.poll`.
+  @since(version = 0.2.0)
   resource request-options {
     /// Construct a default `request-options` value.
+    @since(version = 0.2.0)
     constructor();
 
     /// The timeout for the initial connect to the HTTP Server.
+    @since(version = 0.2.0)
     connect-timeout: func() -> option<duration>;
 
     /// Set the timeout for the initial connect to the HTTP Server. An error
     /// return value indicates that this timeout is not supported.
+    @since(version = 0.2.0)
     set-connect-timeout: func(duration: option<duration>) -> result;
 
     /// The timeout for receiving the first byte of the Response body.
+    @since(version = 0.2.0)
     first-byte-timeout: func() -> option<duration>;
 
     /// Set the timeout for receiving the first byte of the Response body. An
     /// error return value indicates that this timeout is not supported.
+    @since(version = 0.2.0)
     set-first-byte-timeout: func(duration: option<duration>) -> result;
 
     /// The timeout for receiving subsequent chunks of bytes in the Response
     /// body stream.
+    @since(version = 0.2.0)
     between-bytes-timeout: func() -> option<duration>;
 
     /// Set the timeout for receiving subsequent chunks of bytes in the Response
     /// body stream. An error return value indicates that this timeout is not
     /// supported.
+    @since(version = 0.2.0)
     set-between-bytes-timeout: func(duration: option<duration>) -> result;
   }
 
@@ -354,6 +404,7 @@ interface types {
   /// This resource is used by the `wasi:http/incoming-handler` interface to
   /// allow a Response to be sent corresponding to the Request provided as the
   /// other argument to `incoming-handler.handle`.
+  @since(version = 0.2.0)
   resource response-outparam {
 
     /// Set the value of the `response-outparam` to either send a response,
@@ -365,6 +416,7 @@ interface types {
     ///
     /// The user may provide an `error` to `response` to allow the
     /// implementation determine how to respond with an HTTP error response.
+    @since(version = 0.2.0)
     set: static func(
       param: response-outparam,
       response: result<outgoing-response, error-code>,
@@ -372,12 +424,15 @@ interface types {
   }
 
   /// This type corresponds to the HTTP standard Status Code.
+  @since(version = 0.2.0)
   type status-code = u16;
 
   /// Represents an incoming HTTP Response.
+  @since(version = 0.2.0)
   resource incoming-response {
 
     /// Returns the status code from the incoming response.
+    @since(version = 0.2.0)
     status: func() -> status-code;
 
     /// Returns the headers from the incoming response.
@@ -387,10 +442,12 @@ interface types {
     ///
     /// This headers resource is a child: it must be dropped before the parent
     /// `incoming-response` is dropped.
+    @since(version = 0.2.0)
     headers: func() -> headers;
 
     /// Returns the incoming body. May be called at most once. Returns error
     /// if called additional times.
+    @since(version = 0.2.0)
     consume: func() -> result<incoming-body>;
   }
 
@@ -402,6 +459,7 @@ interface types {
   /// an `input-stream` and the delivery of trailers as a `future-trailers`,
   /// and ensures that the user of this interface may only be consuming either
   /// the body contents or waiting on trailers at any given time.
+  @since(version = 0.2.0)
   resource incoming-body {
 
     /// Returns the contents of the body, as a stream of bytes.
@@ -419,10 +477,12 @@ interface types {
     /// backpressure is to be applied when the user is consuming the body,
     /// and for that backpressure to not inhibit delivery of the trailers if
     /// the user does not read the entire body.
+    @since(version = 0.2.0)
     %stream: func() -> result<input-stream>;
 
     /// Takes ownership of `incoming-body`, and returns a `future-trailers`.
     /// This function will trap if the `input-stream` child is still alive.
+    @since(version = 0.2.0)
     finish: static func(this: incoming-body) -> future-trailers;
   }
 
@@ -431,11 +491,13 @@ interface types {
   /// In the case that the incoming HTTP Request or Response did not have any
   /// trailers, this future will resolve to the empty set of trailers once the
   /// complete Request or Response body has been received.
+  @since(version = 0.2.0)
   resource future-trailers {
 
     /// Returns a pollable which becomes ready when either the trailers have
     /// been received, or an error has occured. When this pollable is ready,
     /// the `get` method will return `some`.
+    @since(version = 0.2.0)
     subscribe: func() -> pollable;
 
     /// Returns the contents of the trailers, or an error which occured,
@@ -457,10 +519,12 @@ interface types {
     /// resource is immutable, and a child. Use of the `set`, `append`, or
     /// `delete` methods will return an error, and the resource must be
     /// dropped before the parent `future-trailers` is dropped.
+    @since(version = 0.2.0)
     get: func() -> option<result<result<option<trailers>, error-code>>>;
   }
 
   /// Represents an outgoing HTTP Response.
+  @since(version = 0.2.0)
   resource outgoing-response {
 
     /// Construct an `outgoing-response`, with a default `status-code` of `200`.
@@ -468,13 +532,16 @@ interface types {
     /// `set-status-code` method.
     ///
     /// * `headers` is the HTTP Headers for the Response.
+    @since(version = 0.2.0)
     constructor(headers: headers);
 
     /// Get the HTTP Status Code for the Response.
+    @since(version = 0.2.0)
     status-code: func() -> status-code;
 
     /// Set the HTTP Status Code for the Response. Fails if the status-code
     /// given is not a valid http status code.
+    @since(version = 0.2.0)
     set-status-code: func(status-code: status-code) -> result;
 
     /// Get the headers associated with the Request.
@@ -485,6 +552,7 @@ interface types {
     /// This headers resource is a child: it must be dropped before the parent
     /// `outgoing-request` is dropped, or its ownership is transfered to
     /// another component by e.g. `outgoing-handler.handle`.
+    @since(version = 0.2.0)
     headers: func() -> headers;
 
     /// Returns the resource corresponding to the outgoing Body for this Response.
@@ -492,6 +560,7 @@ interface types {
     /// Returns success on the first call: the `outgoing-body` resource for
     /// this `outgoing-response` can be retrieved at most once. Subsequent
     /// calls will return error.
+    @since(version = 0.2.0)
     body: func() -> result<outgoing-body>;
   }
 
@@ -511,6 +580,7 @@ interface types {
   /// error to the HTTP protocol by whatever means it has available,
   /// including: corrupting the body on the wire, aborting the associated
   /// Request, or sending a late status code for the Response.
+  @since(version = 0.2.0)
   resource outgoing-body {
 
     /// Returns a stream for writing the body contents.
@@ -522,6 +592,7 @@ interface types {
     /// Returns success on the first call: the `output-stream` resource for
     /// this `outgoing-body` may be retrieved at most once. Subsequent calls
     /// will return error.
+    @since(version = 0.2.0)
     write: func() -> result<output-stream>;
 
     /// Finalize an outgoing body, optionally providing trailers. This must be
@@ -533,6 +604,7 @@ interface types {
     /// constructed with a Content-Length header, and the contents written
     /// to the body (via `write`) does not match the value given in the
     /// Content-Length.
+    @since(version = 0.2.0)
     finish: static func(
       this: outgoing-body,
       trailers: option<trailers>
@@ -544,10 +616,12 @@ interface types {
   ///
   /// This resource is returned by the `wasi:http/outgoing-handler` interface to
   /// provide the HTTP Response corresponding to the sent Request.
+  @since(version = 0.2.0)
   resource future-incoming-response {
     /// Returns a pollable which becomes ready when either the Response has
     /// been received, or an error has occured. When this pollable is ready,
     /// the `get` method will return `some`.
+    @since(version = 0.2.0)
     subscribe: func() -> pollable;
 
     /// Returns the incoming HTTP Response, or an error, once one is ready.
@@ -564,7 +638,7 @@ interface types {
     /// occured. Errors may also occur while consuming the response body,
     /// but those will be reported by the `incoming-body` and its
     /// `output-stream` child.
+    @since(version = 0.2.0)
     get: func() -> option<result<result<incoming-response, error-code>>>;
-
   }
 }

--- a/preview2/io/error.wit
+++ b/preview2/io/error.wit
@@ -1,6 +1,6 @@
 package wasi:io@0.2.0;
 
-
+@since(version = 0.2.0)
 interface error {
     /// A resource which represents some error information.
     ///
@@ -21,6 +21,7 @@ interface error {
     ///
     /// The set of functions which can "downcast" an `error` into a more
     /// concrete type is open.
+    @since(version = 0.2.0)
     resource error {
         /// Returns a string that is suitable to assist humans in debugging
         /// this error.
@@ -29,6 +30,7 @@ interface error {
         /// It may change across platforms, hosts, or other implementation
         /// details. Parsing this string is a major platform-compatibility
         /// hazard.
+        @since(version = 0.2.0)
         to-debug-string: func() -> string;
     }
 }

--- a/preview2/io/poll.wit
+++ b/preview2/io/poll.wit
@@ -2,13 +2,16 @@ package wasi:io@0.2.0;
 
 /// A poll API intended to let users wait for I/O events on multiple handles
 /// at once.
+@since(version = 0.2.0)
 interface poll {
     /// `pollable` represents a single I/O event which may be ready, or not.
+    @since(version = 0.2.0)
     resource pollable {
 
       /// Return the readiness of a pollable. This function never blocks.
       ///
       /// Returns `true` when the pollable is ready, and `false` otherwise.
+      @since(version = 0.2.0)
       ready: func() -> bool;
 
       /// `block` returns immediately if the pollable is ready, and otherwise
@@ -16,6 +19,7 @@ interface poll {
       ///
       /// This function is equivalent to calling `poll.poll` on a list
       /// containing only this pollable.
+      @since(version = 0.2.0)
       block: func();
     }
 
@@ -37,5 +41,6 @@ interface poll {
     /// do any I/O so it doesn't fail. If any of the I/O sources identified by
     /// the pollables has an error, it is indicated by marking the source as
     /// being reaedy for I/O.
+    @since(version = 0.2.0)
     poll: func(in: list<borrow<pollable>>) -> list<u32>;
 }

--- a/preview2/io/streams.wit
+++ b/preview2/io/streams.wit
@@ -5,19 +5,23 @@ package wasi:io@0.2.0;
 ///
 /// In the future, the component model is expected to add built-in stream types;
 /// when it does, they are expected to subsume this API.
+@since(version = 0.2.0)
 interface streams {
     use error.{error};
     use poll.{pollable};
 
     /// An error for input-stream and output-stream operations.
+    @since(version = 0.2.0)
     variant stream-error {
         /// The last operation (a write or flush) failed before completion.
         ///
         /// More information is available in the `error` payload.
+        @since(version = 0.2.0)
         last-operation-failed(error),
         /// The stream is closed: no more input will be accepted by the
         /// stream. A closed output-stream will return this error on all
         /// future operations.
+        @since(version = 0.2.0)
         closed
     }
 
@@ -29,6 +33,7 @@ interface streams {
     /// available, which could even be zero. To wait for data to be available,
     /// use the `subscribe` function to obtain a `pollable` which can be polled
     /// for using `wasi:io/poll`.
+    @since(version = 0.2.0)
     resource input-stream {
         /// Perform a non-blocking read from the stream.
         ///
@@ -56,6 +61,7 @@ interface streams {
         /// is not possible to allocate in wasm32, or not desirable to allocate as
         /// as a return value by the callee. The callee may return a list of bytes
         /// less than `len` in size while more bytes are available for reading.
+        @since(version = 0.2.0)
         read: func(
             /// The maximum number of bytes to read
             len: u64
@@ -63,6 +69,7 @@ interface streams {
 
         /// Read bytes from a stream, after blocking until at least one byte can
         /// be read. Except for blocking, behavior is identical to `read`.
+        @since(version = 0.2.0)
         blocking-read: func(
             /// The maximum number of bytes to read
             len: u64
@@ -72,6 +79,7 @@ interface streams {
         ///
         /// Behaves identical to `read`, except instead of returning a list
         /// of bytes, returns the number of bytes consumed from the stream.
+        @since(version = 0.2.0)
         skip: func(
             /// The maximum number of bytes to skip.
             len: u64,
@@ -79,6 +87,7 @@ interface streams {
 
         /// Skip bytes from a stream, after blocking until at least one byte
         /// can be skipped. Except for blocking behavior, identical to `skip`.
+        @since(version = 0.2.0)
         blocking-skip: func(
             /// The maximum number of bytes to skip.
             len: u64,
@@ -90,6 +99,7 @@ interface streams {
         /// The created `pollable` is a child resource of the `input-stream`.
         /// Implementations may trap if the `input-stream` is dropped before
         /// all derived `pollable`s created with this function are dropped.
+        @since(version = 0.2.0)
         subscribe: func() -> pollable;
     }
 
@@ -102,6 +112,7 @@ interface streams {
     /// promptly, which could even be zero. To wait for the stream to be ready to
     /// accept data, the `subscribe` function to obtain a `pollable` which can be
     /// polled for using `wasi:io/poll`.
+    @since(version = 0.2.0)
     resource output-stream {
         /// Check readiness for writing. This function never blocks.
         ///
@@ -112,6 +123,7 @@ interface streams {
         /// When this function returns 0 bytes, the `subscribe` pollable will
         /// become ready when this function will report at least 1 byte, or an
         /// error.
+        @since(version = 0.2.0)
         check-write: func() -> result<u64, stream-error>;
 
         /// Perform a write. This function never blocks.
@@ -127,6 +139,7 @@ interface streams {
         ///
         /// returns Err(closed) without writing if the stream has closed since
         /// the last call to check-write provided a permit.
+        @since(version = 0.2.0)
         write: func(
             contents: list<u8>
         ) -> result<_, stream-error>;
@@ -155,6 +168,7 @@ interface streams {
         /// // Check for any errors that arose during `flush`
         /// let _ = this.check-write();         // eliding error handling
         /// ```
+        @since(version = 0.2.0)
         blocking-write-and-flush: func(
             contents: list<u8>
         ) -> result<_, stream-error>;
@@ -169,10 +183,12 @@ interface streams {
         /// writes (`check-write` will return `ok(0)`) until the flush has
         /// completed. The `subscribe` pollable will become ready when the
         /// flush has completed and the stream can accept more writes.
+        @since(version = 0.2.0)
         flush: func() -> result<_, stream-error>;
 
         /// Request to flush buffered output, and block until flush completes
         /// and stream is ready for writing again.
+        @since(version = 0.2.0)
         blocking-flush: func() -> result<_, stream-error>;
 
         /// Create a `pollable` which will resolve once the output-stream
@@ -193,6 +209,7 @@ interface streams {
         /// preconditions (must use check-write first), but instead of
         /// passing a list of bytes, you simply pass the number of zero-bytes
         /// that should be written.
+        @since(version = 0.2.0)
         write-zeroes: func(
             /// The number of zero-bytes to write
             len: u64
@@ -222,6 +239,7 @@ interface streams {
         /// // Check for any errors that arose during `flush`
         /// let _ = this.check-write();         // eliding error handling
         /// ```
+        @since(version = 0.2.0)
         blocking-write-zeroes-and-flush: func(
             /// The number of zero-bytes to write
             len: u64
@@ -240,6 +258,7 @@ interface streams {
         ///
         /// This function returns the number of bytes transferred; it may be less
         /// than `len`.
+        @since(version = 0.2.0)
         splice: func(
             /// The stream to read from
             src: borrow<input-stream>,
@@ -252,6 +271,7 @@ interface streams {
         /// This is similar to `splice`, except that it blocks until the
         /// `output-stream` is ready for writing, and the `input-stream`
         /// is ready for reading, before performing the `splice`.
+        @since(version = 0.2.0)
         blocking-splice: func(
             /// The stream to read from
             src: borrow<input-stream>,

--- a/preview2/io/streams.wit
+++ b/preview2/io/streams.wit
@@ -16,12 +16,10 @@ interface streams {
         /// The last operation (a write or flush) failed before completion.
         ///
         /// More information is available in the `error` payload.
-        @since(version = 0.2.0)
         last-operation-failed(error),
         /// The stream is closed: no more input will be accepted by the
         /// stream. A closed output-stream will return this error on all
         /// future operations.
-        @since(version = 0.2.0)
         closed
     }
 

--- a/preview2/io/world.wit
+++ b/preview2/io/world.wit
@@ -1,6 +1,10 @@
 package wasi:io@0.2.0;
 
+@since(version = 0.2.0)
 world imports {
+    @since(version = 0.2.0)
     import streams;
+
+    @since(version = 0.2.0)
     import poll;
 }

--- a/preview2/random/insecure-seed.wit
+++ b/preview2/random/insecure-seed.wit
@@ -3,6 +3,7 @@ package wasi:random@0.2.0;
 ///
 /// It is intended to be portable at least between Unix-family platforms and
 /// Windows.
+@since(version = 0.2.0)
 interface insecure-seed {
     /// Return a 128-bit value that may contain a pseudo-random value.
     ///
@@ -21,5 +22,6 @@ interface insecure-seed {
     /// This will likely be changed to a value import, to prevent it from being
     /// called multiple times and potentially used for purposes other than DoS
     /// protection.
+    @since(version = 0.2.0)
     insecure-seed: func() -> tuple<u64, u64>;
 }

--- a/preview2/random/insecure.wit
+++ b/preview2/random/insecure.wit
@@ -3,6 +3,7 @@ package wasi:random@0.2.0;
 ///
 /// It is intended to be portable at least between Unix-family platforms and
 /// Windows.
+@since(version = 0.2.0)
 interface insecure {
     /// Return `len` insecure pseudo-random bytes.
     ///
@@ -12,11 +13,13 @@ interface insecure {
     /// There are no requirements on the values of the returned bytes, however
     /// implementations are encouraged to return evenly distributed values with
     /// a long period.
+    @since(version = 0.2.0)
     get-insecure-random-bytes: func(len: u64) -> list<u8>;
 
     /// Return an insecure pseudo-random `u64` value.
     ///
     /// This function returns the same type of pseudo-random data as
     /// `get-insecure-random-bytes`, represented as a `u64`.
+    @since(version = 0.2.0)
     get-insecure-random-u64: func() -> u64;
 }

--- a/preview2/random/random.wit
+++ b/preview2/random/random.wit
@@ -3,6 +3,7 @@ package wasi:random@0.2.0;
 ///
 /// It is intended to be portable at least between Unix-family platforms and
 /// Windows.
+@since(version = 0.2.0)
 interface random {
     /// Return `len` cryptographically-secure random or pseudo-random bytes.
     ///
@@ -16,11 +17,13 @@ interface random {
     /// This function must always return fresh data. Deterministic environments
     /// must omit this function, rather than implementing it with deterministic
     /// data.
+    @since(version = 0.2.0)
     get-random-bytes: func(len: u64) -> list<u8>;
 
     /// Return a cryptographically-secure random or pseudo-random `u64` value.
     ///
     /// This function returns the same type of data as `get-random-bytes`,
     /// represented as a `u64`.
+    @since(version = 0.2.0)
     get-random-u64: func() -> u64;
 }

--- a/preview2/random/world.wit
+++ b/preview2/random/world.wit
@@ -1,7 +1,13 @@
 package wasi:random@0.2.0;
 
+@since(version = 0.2.0)
 world imports {
+    @since(version = 0.2.0)
     import random;
+
+    @since(version = 0.2.0)
     import insecure;
+
+    @since(version = 0.2.0)
     import insecure-seed;
 }

--- a/preview2/sockets/instance-network.wit
+++ b/preview2/sockets/instance-network.wit
@@ -1,9 +1,10 @@
 
 /// This interface provides a value-export of the default network handle..
+@since(version = 0.2.0)
 interface instance-network {
     use network.{network};
 
     /// Get a handle to the default network.
+    @since(version = 0.2.0)
     instance-network: func() -> network;
-
 }

--- a/preview2/sockets/ip-name-lookup.wit
+++ b/preview2/sockets/ip-name-lookup.wit
@@ -1,8 +1,7 @@
-
+@since(version = 0.2.0)
 interface ip-name-lookup {
     use wasi:io/poll@0.2.0.{pollable};
     use network.{network, error-code, ip-address};
-
 
     /// Resolve an internet host name to a list of IP addresses.
     ///
@@ -24,8 +23,10 @@ interface ip-name-lookup {
     /// - <https://man7.org/linux/man-pages/man3/getaddrinfo.3.html>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/ws2tcpip/nf-ws2tcpip-getaddrinfo>
     /// - <https://man.freebsd.org/cgi/man.cgi?query=getaddrinfo&sektion=3>
+    @since(version = 0.2.0)
     resolve-addresses: func(network: borrow<network>, name: string) -> result<resolve-address-stream, error-code>;
 
+    @since(version = 0.2.0)
     resource resolve-address-stream {
         /// Returns the next address from the resolver.
         ///
@@ -40,12 +41,14 @@ interface ip-name-lookup {
         /// - `temporary-resolver-failure`: A temporary failure in name resolution occurred. (EAI_AGAIN)
         /// - `permanent-resolver-failure`: A permanent failure in name resolution occurred. (EAI_FAIL)
         /// - `would-block`:                A result is not available yet. (EWOULDBLOCK, EAGAIN)
+        @since(version = 0.2.0)
         resolve-next-address: func() -> result<option<ip-address>, error-code>;
 
         /// Create a `pollable` which will resolve once the stream is ready for I/O.
         ///
         /// Note: this function is here for WASI Preview2 only.
         /// It's planned to be removed when `future` is natively supported in Preview3.
+        @since(version = 0.2.0)
         subscribe: func() -> pollable;
     }
 }

--- a/preview2/sockets/network.wit
+++ b/preview2/sockets/network.wit
@@ -1,8 +1,9 @@
-
+@since(version = 0.2.0)
 interface network {
     /// An opaque resource that represents access to (a subset of) the network.
     /// This enables context-based security for networking.
     /// There is no need for this to map 1:1 to a physical network interface.
+    @since(version = 0.2.0)
     resource network;
 
     /// Error codes.
@@ -17,6 +18,7 @@ interface network {
     /// - `concurrency-conflict`
     ///
     /// See each individual API for what the POSIX equivalents are. They sometimes differ per API.
+    @since(version = 0.2.0)
     enum error-code {
         /// Unknown error
         unknown,
@@ -103,6 +105,7 @@ interface network {
         permanent-resolver-failure,
     }
 
+    @since(version = 0.2.0)
     enum ip-address-family {
         /// Similar to `AF_INET` in POSIX.
         ipv4,
@@ -111,14 +114,18 @@ interface network {
         ipv6,
     }
 
+    @since(version = 0.2.0)
     type ipv4-address = tuple<u8, u8, u8, u8>;
+    @since(version = 0.2.0)
     type ipv6-address = tuple<u16, u16, u16, u16, u16, u16, u16, u16>;
 
+    @since(version = 0.2.0)
     variant ip-address {
         ipv4(ipv4-address),
         ipv6(ipv6-address),
     }
 
+    @since(version = 0.2.0)
     record ipv4-socket-address {
         /// sin_port
         port: u16,
@@ -126,6 +133,7 @@ interface network {
         address: ipv4-address,
     }
 
+    @since(version = 0.2.0)
     record ipv6-socket-address {
         /// sin6_port
         port: u16,
@@ -137,9 +145,9 @@ interface network {
         scope-id: u32,
     }
 
+    @since(version = 0.2.0)
     variant ip-socket-address {
         ipv4(ipv4-socket-address),
         ipv6(ipv6-socket-address),
     }
-
 }

--- a/preview2/sockets/tcp-create-socket.wit
+++ b/preview2/sockets/tcp-create-socket.wit
@@ -1,4 +1,4 @@
-
+@since(version = 0.2.0)
 interface tcp-create-socket {
     use network.{network, error-code, ip-address-family};
     use tcp.{tcp-socket};
@@ -23,5 +23,6 @@ interface tcp-create-socket {
     /// - <https://man7.org/linux/man-pages/man2/socket.2.html>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasocketw>
     /// - <https://man.freebsd.org/cgi/man.cgi?query=socket&sektion=2>
+    @since(version = 0.2.0)
     create-tcp-socket: func(address-family: ip-address-family) -> result<tcp-socket, error-code>;
 }

--- a/preview2/sockets/tcp.wit
+++ b/preview2/sockets/tcp.wit
@@ -1,10 +1,11 @@
-
+@since(version = 0.2.0)
 interface tcp {
     use wasi:io/streams@0.2.0.{input-stream, output-stream};
     use wasi:io/poll@0.2.0.{pollable};
     use wasi:clocks/monotonic-clock@0.2.0.{duration};
     use network.{network, error-code, ip-socket-address, ip-address-family};
 
+    @since(version = 0.2.0)
     enum shutdown-type {
         /// Similar to `SHUT_RD` in POSIX.
         receive,
@@ -37,6 +38,7 @@ interface tcp {
     /// In addition to the general error codes documented on the
     /// `network::error-code` type, TCP socket methods may always return
     /// `error(invalid-state)` when in the `closed` state.
+    @since(version = 0.2.0)
     resource tcp-socket {
         /// Bind the socket to a specific network on the provided IP address and port.
         ///
@@ -76,7 +78,9 @@ interface tcp {
         /// - <https://man7.org/linux/man-pages/man2/bind.2.html>
         /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-bind>
         /// - <https://man.freebsd.org/cgi/man.cgi?query=bind&sektion=2&format=html>
+        @since(version = 0.2.0)
         start-bind: func(network: borrow<network>, local-address: ip-socket-address) -> result<_, error-code>;
+        @since(version = 0.2.0)
         finish-bind: func() -> result<_, error-code>;
 
         /// Connect to a remote endpoint.
@@ -121,7 +125,9 @@ interface tcp {
         /// - <https://man7.org/linux/man-pages/man2/connect.2.html>
         /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-connect>
         /// - <https://man.freebsd.org/cgi/man.cgi?connect>
+        @since(version = 0.2.0)
         start-connect: func(network: borrow<network>, remote-address: ip-socket-address) -> result<_, error-code>;
+        @since(version = 0.2.0)
         finish-connect: func() -> result<tuple<input-stream, output-stream>, error-code>;
 
         /// Start listening for new connections.
@@ -149,7 +155,9 @@ interface tcp {
         /// - <https://man7.org/linux/man-pages/man2/listen.2.html>
         /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-listen>
         /// - <https://man.freebsd.org/cgi/man.cgi?query=listen&sektion=2>
+        @since(version = 0.2.0)
         start-listen: func() -> result<_, error-code>;
+        @since(version = 0.2.0)
         finish-listen: func() -> result<_, error-code>;
 
         /// Accept a new client socket.
@@ -178,6 +186,7 @@ interface tcp {
         /// - <https://man7.org/linux/man-pages/man2/accept.2.html>
         /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-accept>
         /// - <https://man.freebsd.org/cgi/man.cgi?query=accept&sektion=2>
+        @since(version = 0.2.0)
         accept: func() -> result<tuple<tcp-socket, input-stream, output-stream>, error-code>;
 
         /// Get the bound local address.
@@ -196,6 +205,7 @@ interface tcp {
         /// - <https://man7.org/linux/man-pages/man2/getsockname.2.html>
         /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getsockname>
         /// - <https://man.freebsd.org/cgi/man.cgi?getsockname>
+        @since(version = 0.2.0)
         local-address: func() -> result<ip-socket-address, error-code>;
 
         /// Get the remote address.
@@ -208,16 +218,19 @@ interface tcp {
         /// - <https://man7.org/linux/man-pages/man2/getpeername.2.html>
         /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getpeername>
         /// - <https://man.freebsd.org/cgi/man.cgi?query=getpeername&sektion=2&n=1>
+        @since(version = 0.2.0)
         remote-address: func() -> result<ip-socket-address, error-code>;
 
         /// Whether the socket is in the `listening` state.
         ///
         /// Equivalent to the SO_ACCEPTCONN socket option.
+        @since(version = 0.2.0)
         is-listening: func() -> bool;
 
         /// Whether this is a IPv4 or IPv6 socket.
         ///
         /// Equivalent to the SO_DOMAIN socket option.
+        @since(version = 0.2.0)
         address-family: func() -> ip-address-family;
 
         /// Hints the desired listen queue size. Implementations are free to ignore this.
@@ -229,6 +242,7 @@ interface tcp {
         /// - `not-supported`:        (set) The platform does not support changing the backlog size after the initial listen.
         /// - `invalid-argument`:     (set) The provided value was 0.
         /// - `invalid-state`:        (set) The socket is in the `connect-in-progress` or `connected` state.
+        @since(version = 0.2.0)
         set-listen-backlog-size: func(value: u64) -> result<_, error-code>;
 
         /// Enables or disables keepalive.
@@ -240,7 +254,9 @@ interface tcp {
         /// These properties can be configured while `keep-alive-enabled` is false, but only come into effect when `keep-alive-enabled` is true.
         ///
         /// Equivalent to the SO_KEEPALIVE socket option.
+        @since(version = 0.2.0)
         keep-alive-enabled: func() -> result<bool, error-code>;
+        @since(version = 0.2.0)
         set-keep-alive-enabled: func(value: bool) -> result<_, error-code>;
 
         /// Amount of time the connection has to be idle before TCP starts sending keepalive packets.
@@ -253,7 +269,9 @@ interface tcp {
         ///
         /// # Typical errors
         /// - `invalid-argument`:     (set) The provided value was 0.
+        @since(version = 0.2.0)
         keep-alive-idle-time: func() -> result<duration, error-code>;
+        @since(version = 0.2.0)
         set-keep-alive-idle-time: func(value: duration) -> result<_, error-code>;
 
         /// The time between keepalive packets.
@@ -266,7 +284,9 @@ interface tcp {
         ///
         /// # Typical errors
         /// - `invalid-argument`:     (set) The provided value was 0.
+        @since(version = 0.2.0)
         keep-alive-interval: func() -> result<duration, error-code>;
+        @since(version = 0.2.0)
         set-keep-alive-interval: func(value: duration) -> result<_, error-code>;
 
         /// The maximum amount of keepalive packets TCP should send before aborting the connection.
@@ -279,7 +299,9 @@ interface tcp {
         ///
         /// # Typical errors
         /// - `invalid-argument`:     (set) The provided value was 0.
+        @since(version = 0.2.0)
         keep-alive-count: func() -> result<u32, error-code>;
+        @since(version = 0.2.0)
         set-keep-alive-count: func(value: u32) -> result<_, error-code>;
 
         /// Equivalent to the IP_TTL & IPV6_UNICAST_HOPS socket options.
@@ -288,7 +310,9 @@ interface tcp {
         ///
         /// # Typical errors
         /// - `invalid-argument`:     (set) The TTL value must be 1 or higher.
+        @since(version = 0.2.0)
         hop-limit: func() -> result<u8, error-code>;
+        @since(version = 0.2.0)
         set-hop-limit: func(value: u8) -> result<_, error-code>;
 
         /// The kernel buffer space reserved for sends/receives on this socket.
@@ -301,9 +325,13 @@ interface tcp {
         ///
         /// # Typical errors
         /// - `invalid-argument`:     (set) The provided value was 0.
+        @since(version = 0.2.0)
         receive-buffer-size: func() -> result<u64, error-code>;
+        @since(version = 0.2.0)
         set-receive-buffer-size: func(value: u64) -> result<_, error-code>;
+        @since(version = 0.2.0)
         send-buffer-size: func() -> result<u64, error-code>;
+        @since(version = 0.2.0)
         set-send-buffer-size: func(value: u64) -> result<_, error-code>;
 
         /// Create a `pollable` which can be used to poll for, or block on,
@@ -323,6 +351,7 @@ interface tcp {
         ///
         /// Note: this function is here for WASI Preview2 only.
         /// It's planned to be removed when `future` is natively supported in Preview3.
+        @since(version = 0.2.0)
         subscribe: func() -> pollable;
 
         /// Initiate a graceful shutdown.
@@ -348,6 +377,7 @@ interface tcp {
         /// - <https://man7.org/linux/man-pages/man2/shutdown.2.html>
         /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-shutdown>
         /// - <https://man.freebsd.org/cgi/man.cgi?query=shutdown&sektion=2>
+        @since(version = 0.2.0)
         shutdown: func(shutdown-type: shutdown-type) -> result<_, error-code>;
     }
 }

--- a/preview2/sockets/udp-create-socket.wit
+++ b/preview2/sockets/udp-create-socket.wit
@@ -1,4 +1,4 @@
-
+@since(version = 0.2.0)
 interface udp-create-socket {
     use network.{network, error-code, ip-address-family};
     use udp.{udp-socket};
@@ -23,5 +23,6 @@ interface udp-create-socket {
     /// - <https://man7.org/linux/man-pages/man2/socket.2.html>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasocketw>
     /// - <https://man.freebsd.org/cgi/man.cgi?query=socket&sektion=2>
+    @since(version = 0.2.0)
     create-udp-socket: func(address-family: ip-address-family) -> result<udp-socket, error-code>;
 }

--- a/preview2/sockets/udp.wit
+++ b/preview2/sockets/udp.wit
@@ -1,9 +1,10 @@
-
+@since(version = 0.2.0)
 interface udp {
     use wasi:io/poll@0.2.0.{pollable};
     use network.{network, error-code, ip-socket-address, ip-address-family};
 
     /// A received datagram.
+    @since(version = 0.2.0)
     record incoming-datagram {
         /// The payload.
         /// 
@@ -19,6 +20,7 @@ interface udp {
     }
 
     /// A datagram to be sent out.
+    @since(version = 0.2.0)
     record outgoing-datagram {
         /// The payload.
         data: list<u8>,
@@ -33,9 +35,8 @@ interface udp {
         remote-address: option<ip-socket-address>,
     }
 
-
-
     /// A UDP socket handle.
+    @since(version = 0.2.0)
     resource udp-socket {
         /// Bind the socket to a specific network on the provided IP address and port.
         ///
@@ -63,7 +64,9 @@ interface udp {
         /// - <https://man7.org/linux/man-pages/man2/bind.2.html>
         /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-bind>
         /// - <https://man.freebsd.org/cgi/man.cgi?query=bind&sektion=2&format=html>
+        @since(version = 0.2.0)
         start-bind: func(network: borrow<network>, local-address: ip-socket-address) -> result<_, error-code>;
+        @since(version = 0.2.0)
         finish-bind: func() -> result<_, error-code>;
 
         /// Set up inbound & outbound communication channels, optionally to a specific peer.
@@ -106,6 +109,7 @@ interface udp {
         /// - <https://man7.org/linux/man-pages/man2/connect.2.html>
         /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-connect>
         /// - <https://man.freebsd.org/cgi/man.cgi?connect>
+        @since(version = 0.2.0)
         %stream: func(remote-address: option<ip-socket-address>) -> result<tuple<incoming-datagram-stream, outgoing-datagram-stream>, error-code>;
 
         /// Get the current bound address.
@@ -124,6 +128,7 @@ interface udp {
         /// - <https://man7.org/linux/man-pages/man2/getsockname.2.html>
         /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getsockname>
         /// - <https://man.freebsd.org/cgi/man.cgi?getsockname>
+        @since(version = 0.2.0)
         local-address: func() -> result<ip-socket-address, error-code>;
 
         /// Get the address the socket is currently streaming to.
@@ -136,11 +141,13 @@ interface udp {
         /// - <https://man7.org/linux/man-pages/man2/getpeername.2.html>
         /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getpeername>
         /// - <https://man.freebsd.org/cgi/man.cgi?query=getpeername&sektion=2&n=1>
+        @since(version = 0.2.0)
         remote-address: func() -> result<ip-socket-address, error-code>;
 
         /// Whether this is a IPv4 or IPv6 socket.
         ///
         /// Equivalent to the SO_DOMAIN socket option.
+        @since(version = 0.2.0)
         address-family: func() -> ip-address-family;
 
         /// Equivalent to the IP_TTL & IPV6_UNICAST_HOPS socket options.
@@ -149,7 +156,9 @@ interface udp {
         ///
         /// # Typical errors
         /// - `invalid-argument`:     (set) The TTL value must be 1 or higher.
+        @since(version = 0.2.0)
         unicast-hop-limit: func() -> result<u8, error-code>;
+        @since(version = 0.2.0)
         set-unicast-hop-limit: func(value: u8) -> result<_, error-code>;
 
         /// The kernel buffer space reserved for sends/receives on this socket.
@@ -162,18 +171,24 @@ interface udp {
         ///
         /// # Typical errors
         /// - `invalid-argument`:     (set) The provided value was 0.
+        @since(version = 0.2.0)
         receive-buffer-size: func() -> result<u64, error-code>;
+        @since(version = 0.2.0)
         set-receive-buffer-size: func(value: u64) -> result<_, error-code>;
+        @since(version = 0.2.0)
         send-buffer-size: func() -> result<u64, error-code>;
+        @since(version = 0.2.0)
         set-send-buffer-size: func(value: u64) -> result<_, error-code>;
 
         /// Create a `pollable` which will resolve once the socket is ready for I/O.
         ///
         /// Note: this function is here for WASI Preview2 only.
         /// It's planned to be removed when `future` is natively supported in Preview3.
+        @since(version = 0.2.0)
         subscribe: func() -> pollable;
     }
 
+    @since(version = 0.2.0)
     resource incoming-datagram-stream {
         /// Receive messages on the socket.
         ///
@@ -198,15 +213,18 @@ interface udp {
         /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-recvfrom>
         /// - <https://learn.microsoft.com/en-us/previous-versions/windows/desktop/legacy/ms741687(v=vs.85)>
         /// - <https://man.freebsd.org/cgi/man.cgi?query=recv&sektion=2>
+        @since(version = 0.2.0)
         receive: func(max-results: u64) -> result<list<incoming-datagram>, error-code>;
 
         /// Create a `pollable` which will resolve once the stream is ready to receive again.
         ///
         /// Note: this function is here for WASI Preview2 only.
         /// It's planned to be removed when `future` is natively supported in Preview3.
+        @since(version = 0.2.0)
         subscribe: func() -> pollable;
     }
 
+    @since(version = 0.2.0)
     resource outgoing-datagram-stream {
         /// Check readiness for sending. This function never blocks.
         ///
@@ -255,12 +273,14 @@ interface udp {
         /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-sendto>
         /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasendmsg>
         /// - <https://man.freebsd.org/cgi/man.cgi?query=send&sektion=2>
+        @since(version = 0.2.0)
         send: func(datagrams: list<outgoing-datagram>) -> result<u64, error-code>;
         
         /// Create a `pollable` which will resolve once the stream is ready to send again.
         ///
         /// Note: this function is here for WASI Preview2 only.
         /// It's planned to be removed when `future` is natively supported in Preview3.
+        @since(version = 0.2.0)
         subscribe: func() -> pollable;
     }
 }

--- a/preview2/sockets/world.wit
+++ b/preview2/sockets/world.wit
@@ -1,11 +1,19 @@
 package wasi:sockets@0.2.0;
 
+@since(version = 0.2.0)
 world imports {
+    @since(version = 0.2.0)
     import instance-network;
+    @since(version = 0.2.0)
     import network;
+    @since(version = 0.2.0)
     import udp;
+    @since(version = 0.2.0)
     import udp-create-socket;
+    @since(version = 0.2.0)
     import tcp;
+    @since(version = 0.2.0)
     import tcp-create-socket;
+    @since(version = 0.2.0)
     import ip-name-lookup;
 }


### PR DESCRIPTION
In order to help create confidence in the implementation of [`@since` and `@feature`](https://github.com/WebAssembly/component-model/pull/332) in [wasm-tools](https://github.com/bytecodealliance/wasm-tools/pull/1508), this PR adds `@since` gates to the entirety of the WASI 0.2 API surface area. As well as bringing in the `wit:clocks` timezone surface area introduced in https://github.com/WebAssembly/wasi-clocks/pull/61 under an `@unstable` attribute.

This PR is not intended to be merged, but to mainly to validate the implementation and to give an idea of what the resulting semantics of that will be in practice.

### Validating the implementation

Using a local build of the `wasm-tools` branch, do:

```bash
for d in $(ls preview2);
   do wasm-tools component wit "./preview2/$d";
done;
```

This will warn `wasm-tools` not knowing where to find `wasi:io`, but it will not throw any errors about `@since` or `@feature` gates not parsing.

## Next steps

Speaking concretely about the implementation: I'll split this PR up into several
sub-PRs on the correct sub-repositories. Those can't be merged until the
`@since` and `@feature` gate functionality is merged - but hopefully with this
draft PR we can get one step closer in building confidence that it will work out
as expected.