### PR TITLE
Add `Clocks: Timezone` as a stage 0 proposal

### DIFF
--- a/Proposals.md
+++ b/Proposals.md
@@ -68,6 +68,7 @@ You can learn more about contributing new proposals (and other ways to contribut
 | Proposal                                                                       | Champion                               | Versions |
 | ------------------------------------------------------------------------------ | -------------------------------------- | -------- |
 | [proxy-wasm/spec][wasi-proxy-wasm] (will advance as multiple, smaller proposals)    | Piotr Sikora                           |          |
+| [Clocks: Timezone][wasi-clocks]                                                     | Dan Gohman                             |          |
 
 ## Versioning
 


### PR DESCRIPTION
This adds a stage 0 proposal to extend `wasi:clocks` with basic timezone support. @sunfishcode is the current champion for `wasi:clocks` and has volunteered to also be the champion for this extension. The related PR for this on the `wasi:clocks` side are: https://github.com/WebAssembly/wasi-clocks/pull/61 and https://github.com/cdmurph32/wasi-clocks/pull/1.

This proposal is a little different from the other proposals so far: rather than introducing something new, this *extends* an existing stage 3 proposal. The expectation is that we will want to advance this independently from `wasi:clocks` through the phase process, and will be voted on by the SG. Tracking this independently gives us the flexibility we need for that.

Additionally, this also gives the `timezone` proposal a concrete name. Now that [`@unstable`](https://github.com/WebAssembly/component-model/pull/332) has landed in the component model, we can use the name of the proposal as the name of the feature gate. In this case that would mean we would gate this extension using the `clocks-timezone` feature name.

I hope this all makes sense. I've also filed https://github.com/WebAssembly/meetings/pull/1594 to discuss this all in more detail in tomorrow's SG meeting. Thanks!