### PR TITLE
Re-file the `wasi:clocks` timezone extension as phase 2

### DIFF
--- a/Proposals.md
+++ b/Proposals.md
@@ -36,6 +36,7 @@ You can learn more about contributing new proposals (and other ways to contribut
 | Proposal                                                                       | Champion                               | Versions |
 | ------------------------------------------------------------------------------ | -------------------------------------- | -------- |
 | [Machine Learning (wasi-nn)][wasi-nn]                                          | Andrew Brown and Mingqiu Sun           |          |
+| [Clocks: Timezone][wasi-clocks]                                                | Dan Gohman                             |          |
 
 ### Phase 1 - Feature Proposal (CG)
 
@@ -68,7 +69,6 @@ You can learn more about contributing new proposals (and other ways to contribut
 | Proposal                                                                       | Champion                               | Versions |
 | ------------------------------------------------------------------------------ | -------------------------------------- | -------- |
 | [proxy-wasm/spec][wasi-proxy-wasm] (will advance as multiple, smaller proposals)    | Piotr Sikora                           |          |
-| [Clocks: Timezone][wasi-clocks]                                                     | Dan Gohman                             |          |
 
 ## Versioning
 


### PR DESCRIPTION
As per the 2024-06-13 WASI SG meeting: the timezone extension to `wasi:clocks` already meets the phase 2 criteria by virtue of being part of an existing phase 3 proposal. It should have been introduced at phase 2, not phase 0. This allows it to be introduced as `@unstable` and be implemented by runtimes, but still needs a vote before it can be stabilized behind an `@since` gate.

I'll file a follow-up PR to clarify the process changes to existing proposals should go through, so we can follow this same process for other changes too.