### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/Proposals.md
+++ b/Proposals.md
@@ -79,7 +79,7 @@ Proposals remain in the 0.x semver range until they reach Phase 5 and are fully 
 
 For some APIs, it makes sense to add new features after the API itself has reached Phase 5. These feature additions should go through the same standardization process. Once they have reached Phase 5, the minor version number of the release should be incremented.
 
-Some APIs may require backwards-incompatible changes over time. In these cases, we allow proposals to increment the major version number _only if_ the old API can be implmented in terms of the new API. As part of the new version, champions are expected to provide a tool that enables this backwards-compatibility. If that is not possible, then a new API proposal with a new name should be started. The original API can then be deprecated over time if it makes sense to do so.
+Some APIs may require backwards-incompatible changes over time. In these cases, we allow proposals to increment the major version number _only if_ the old API can be implemented in terms of the new API. As part of the new version, champions are expected to provide a tool that enables this backwards-compatibility. If that is not possible, then a new API proposal with a new name should be started. The original API can then be deprecated over time if it makes sense to do so.
 
 [WebAssembly CG Phases process]: https://github.com/WebAssembly/meetings/blob/master/process/phases.md
 [witx]: https://github.com/WebAssembly/WASI/blob/main/tools/witx-docs.md

--- a/wasip2/http/handler.wit
+++ b/wasip2/http/handler.wit
@@ -12,7 +12,7 @@ interface incoming-handler {
   /// sent. This enables both streaming to the response body, and performing other
   /// work.
   ///
-  /// The implementor of this function must write a response to the
+  /// The implementer of this function must write a response to the
   /// `response-outparam` before returning, or else the caller will respond
   /// with an error on its behalf.
   @since(version = 0.2.0)

--- a/wasip2/sockets/tcp.wit
+++ b/wasip2/sockets/tcp.wit
@@ -66,7 +66,7 @@ interface tcp {
         /// - `not-in-progress`:           A `bind` operation is not in progress.
         /// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
         /// 
-        /// # Implementors note
+        /// # Implementers note
         /// When binding to a non-zero port, this bind operation shouldn't be affected by the TIME_WAIT
         /// state of a recently closed socket on the same local address. In practice this means that the SO_REUSEADDR 
         /// socket option should be set implicitly on all platforms, except on Windows where this is the default behavior
@@ -115,7 +115,7 @@ interface tcp {
         /// - `not-in-progress`:           A connect operation is not in progress.
         /// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
         ///
-        /// # Implementors note
+        /// # Implementers note
         /// The POSIX equivalent of `start-connect` is the regular `connect` syscall.
         /// Because all WASI sockets are non-blocking this is expected to return
         /// EINPROGRESS, which should be translated to `ok()` in WASI.
@@ -148,7 +148,7 @@ interface tcp {
         /// - `not-in-progress`:           A listen operation is not in progress.
         /// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
         ///
-        /// # Implementors note
+        /// # Implementers note
         /// Unlike in POSIX, in WASI the listen operation is async. This enables
         /// interactive WASI hosts to inject permission prompts. Runtimes that
         /// don't want to make use of this ability can simply call the native

--- a/wasip2/sockets/udp.wit
+++ b/wasip2/sockets/udp.wit
@@ -55,7 +55,7 @@ interface udp {
         /// - `not-in-progress`:           A `bind` operation is not in progress.
         /// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
         ///
-        /// # Implementors note
+        /// # Implementers note
         /// Unlike in POSIX, in WASI the bind operation is async. This enables
         /// interactive WASI hosts to inject permission prompts. Runtimes that
         /// don't want to make use of this ability can simply call the native


### PR DESCRIPTION
https://pypi.org/project/codespell

% `codespell --ignore-words-list=wit --skip="./legacy/*" --write-changes`

This assumes that we should not modify the files in the `legacy` directory.