### PR TITLE
[proposal update] Moving wasi-messaging to Phase 2

### DIFF
--- a/Proposals.md
+++ b/Proposals.md
@@ -33,13 +33,14 @@ You can learn more about contributing new proposals (and other ways to contribut
 
 ### Phase 2 - Proposed Spec Text Available (CG + WG)
 
-| Proposal                                                                       | Champion                                   | Versions |
-| ------------------------------------------------------------------------------ | ------------------------------------------ | -------- |
+| Proposal                                                                       | Champion                                                      | Versions |
+| ------------------------------------------------------------------------------ |---------------------------------------------------------------| -------- |
 | [I2C][wasi-i2c]                                                                | Friedrich Vandenberghe, Merlijn Sebrechts, Maximilian Seidler |          |
-| [Key-value Store][wasi-kv-store]                                               | Jiaxiao Zhou, Dan Chiarlone, David Justice |          |
-| [Machine Learning (wasi-nn)][wasi-nn]                                          | Andrew Brown and Mingqiu Sun               |          |
-| [Runtime Config][wasi-runtime-config]                                          | Jiaxiao Zhou, Dan Chiarlone, David Justice |          |
-| [GFX][wasi-gfx]                                                                | Mendy Berger, Sean Isom                    |          |
+| [Key-value Store][wasi-kv-store]                                               | Jiaxiao Zhou, Dan Chiarlone, David Justice                    |          |
+| [Machine Learning (wasi-nn)][wasi-nn]                                          | Andrew Brown and Mingqiu Sun                                  |          |
+| [Runtime Config][wasi-runtime-config]                                          | Jiaxiao Zhou, Dan Chiarlone, David Justice                    |          |
+| [GFX][wasi-gfx]                                                                | Mendy Berger, Sean Isom                                       |          |
+| [Messaging][wasi-messaging]                                            | Jiaxiao Zhou, Dan Chiarlone, David Justice, Taylor Thomas     |          |
 
 ### Phase 1 - Feature Proposal (CG)
 
@@ -50,7 +51,6 @@ You can learn more about contributing new proposals (and other ways to contribut
 | [Digital I/O][wasi-digital-io]                      | Emiel Van Severen |          |
 | [Distributed Lock Service][wasi-distributed-lock-service]                      | Jiaxiao Zhou, Dan Chiarlone, David Justice |          |
 | [Logging][wasi-logging]                                               | Dan Gohman |          |
-| [Messaging][wasi-messaging]                                            | Jiaxiao Zhou, Dan Chiarlone, David Justice |          |
 | [Observe][wasi-observe]    | Caleb Schoepp                           |          |
 | [Parallel][wasi-parallel]                                                      | Andrew Brown                           |          |
 | [Pattern Match][wasi-pattern-match]                                                      | Jianjun Zhu                           |          |


### PR DESCRIPTION
wasi-messaging was approved to move to Phase 2 during the WASI Subgroup Video Meeting of November 14th. This PR updates the status of wasi-messaging in the Proposals.md document.