### PR TITLE
Revert accidental stabilization in the proposal tracker of unstable sub-proposals

### DIFF
--- a/Proposals.md
+++ b/Proposals.md
@@ -35,6 +35,8 @@ You can learn more about contributing new proposals (and other ways to contribut
 
 | Proposal                                                                       | Champion                                                      | Versions |
 | ------------------------------------------------------------------------------ |---------------------------------------------------------------| -------- |
+| [Clocks: Timezone][wasi-clocks]                                                | Dan Gohman                                                    |          |
+| [CLI: Exit With Code][wasi-cli]                                                | Dan Gohman                                                    |          |
 | [I2C][wasi-i2c]                                                                | Friedrich Vandenberghe, Merlijn Sebrechts, Maximilian Seidler |          |
 | [Key-value Store][wasi-kv-store]                                               | Jiaxiao Zhou, Dan Chiarlone, David Justice                    |          |
 | [Machine Learning (wasi-nn)][wasi-nn]                                          | Andrew Brown and Mingqiu Sun                                  |          |

--- a/Proposals.md
+++ b/Proposals.md
@@ -37,6 +37,7 @@ You can learn more about contributing new proposals (and other ways to contribut
 | ------------------------------------------------------------------------------ |---------------------------------------------------------------| -------- |
 | [Clocks: Timezone][wasi-clocks]                                                | Dan Gohman                                                    |          |
 | [CLI: Exit With Code][wasi-cli]                                                | Dan Gohman                                                    |          |
+| [HTTP: Informational Outbound Response][wasi-http]                             | Piotr Sikora, Jiaxiao Zhou, Dan Chiarlone, David Justice, Luke Wagner |          |
 | [I2C][wasi-i2c]                                                                | Friedrich Vandenberghe, Merlijn Sebrechts, Maximilian Seidler |          |
 | [Key-value Store][wasi-kv-store]                                               | Jiaxiao Zhou, Dan Chiarlone, David Justice                    |          |
 | [Machine Learning (wasi-nn)][wasi-nn]                                          | Andrew Brown and Mingqiu Sun                                  |          |


### PR DESCRIPTION
This is a reversal of https://github.com/WebAssembly/WASI/pull/632 which was filed in response to https://github.com/WebAssembly/WASI/issues/631. The issue asserts that both the `@unstable` "timezones" (clocks) and "exit with status" (cli) features are at phase 3. To reach phase 3 these proposals would need to have gone through a WASI SG vote, after which they can be changed from `@unstable` to be marked `@since` instead. This vote was never held, and so the proposals cannot be at phase 3.

Here are the relevant sections from [the phase process documentation](https://github.com/WebAssembly/WASI/blob/main/Contributing.md#filing-changes-to-existing-phase-3-proposals):

> 3. Once the champion is ready to merge the proposal, they will submit a PR to the WASI repository (this repository) to file for a new phase 2 feature.
> 4. [...]
> 5. [...] The goal at this phase is to implement and iterate on the extension until it is ready to advance to phase 3.
> 6. Once the champion believes the phase 3 advancement criteria are met, they should bring it to the WASI SG for a vote.
> 7. Once the proposal is voted to advance to phase 3, the `@unstable` gate should be replaced with a `@since` gate containing the version of the next WASI release. [...]


On reviewing this I also discovered that we weren't tracking the unstable feature introduced in https://github.com/WebAssembly/wasi-http/pull/139, which I've included in the list of tracked features as part of this PR.
