### PR TITLE
Update to v0.2.5

### DIFF
--- a/wasip2/cli/command.wit
+++ b/wasip2/cli/command.wit
@@ -1,4 +1,4 @@
-package wasi:cli@0.2.4;
+package wasi:cli@0.2.5;
 
 @since(version = 0.2.0)
 world command {

--- a/wasip2/cli/imports.wit
+++ b/wasip2/cli/imports.wit
@@ -1,17 +1,17 @@
-package wasi:cli@0.2.4;
+package wasi:cli@0.2.5;
 
 @since(version = 0.2.0)
 world imports {
   @since(version = 0.2.0)
-  include wasi:clocks/imports@0.2.4;
+  include wasi:clocks/imports@0.2.5;
   @since(version = 0.2.0)
-  include wasi:filesystem/imports@0.2.4;
+  include wasi:filesystem/imports@0.2.5;
   @since(version = 0.2.0)
-  include wasi:sockets/imports@0.2.4;
+  include wasi:sockets/imports@0.2.5;
   @since(version = 0.2.0)
-  include wasi:random/imports@0.2.4;
+  include wasi:random/imports@0.2.5;
   @since(version = 0.2.0)
-  include wasi:io/imports@0.2.4;
+  include wasi:io/imports@0.2.5;
 
   @since(version = 0.2.0)
   import environment;

--- a/wasip2/cli/stdio.wit
+++ b/wasip2/cli/stdio.wit
@@ -1,7 +1,7 @@
 @since(version = 0.2.0)
 interface stdin {
   @since(version = 0.2.0)
-  use wasi:io/streams@0.2.4.{input-stream};
+  use wasi:io/streams@0.2.5.{input-stream};
 
   @since(version = 0.2.0)
   get-stdin: func() -> input-stream;
@@ -10,7 +10,7 @@ interface stdin {
 @since(version = 0.2.0)
 interface stdout {
   @since(version = 0.2.0)
-  use wasi:io/streams@0.2.4.{output-stream};
+  use wasi:io/streams@0.2.5.{output-stream};
 
   @since(version = 0.2.0)
   get-stdout: func() -> output-stream;
@@ -19,7 +19,7 @@ interface stdout {
 @since(version = 0.2.0)
 interface stderr {
   @since(version = 0.2.0)
-  use wasi:io/streams@0.2.4.{output-stream};
+  use wasi:io/streams@0.2.5.{output-stream};
 
   @since(version = 0.2.0)
   get-stderr: func() -> output-stream;

--- a/wasip2/clocks/monotonic-clock.wit
+++ b/wasip2/clocks/monotonic-clock.wit
@@ -1,4 +1,4 @@
-package wasi:clocks@0.2.4;
+package wasi:clocks@0.2.5;
 /// WASI Monotonic Clock is a clock API intended to let users measure elapsed
 /// time.
 ///
@@ -10,7 +10,7 @@ package wasi:clocks@0.2.4;
 @since(version = 0.2.0)
 interface monotonic-clock {
     @since(version = 0.2.0)
-    use wasi:io/poll@0.2.4.{pollable};
+    use wasi:io/poll@0.2.5.{pollable};
 
     /// An instant in time, in nanoseconds. An instant is relative to an
     /// unspecified initial value, and can only be compared to instances from

--- a/wasip2/clocks/timezone.wit
+++ b/wasip2/clocks/timezone.wit
@@ -1,4 +1,4 @@
-package wasi:clocks@0.2.4;
+package wasi:clocks@0.2.5;
 
 @unstable(feature = clocks-timezone)
 interface timezone {

--- a/wasip2/clocks/wall-clock.wit
+++ b/wasip2/clocks/wall-clock.wit
@@ -1,4 +1,4 @@
-package wasi:clocks@0.2.4;
+package wasi:clocks@0.2.5;
 /// WASI Wall Clock is a clock API intended to let users query the current
 /// time. The name "wall" makes an analogy to a "clock on the wall", which
 /// is not necessarily monotonic as it may be reset.

--- a/wasip2/clocks/world.wit
+++ b/wasip2/clocks/world.wit
@@ -1,4 +1,4 @@
-package wasi:clocks@0.2.4;
+package wasi:clocks@0.2.5;
 
 @since(version = 0.2.0)
 world imports {

--- a/wasip2/filesystem/preopens.wit
+++ b/wasip2/filesystem/preopens.wit
@@ -1,4 +1,4 @@
-package wasi:filesystem@0.2.4;
+package wasi:filesystem@0.2.5;
 
 @since(version = 0.2.0)
 interface preopens {

--- a/wasip2/filesystem/types.wit
+++ b/wasip2/filesystem/types.wit
@@ -1,4 +1,4 @@
-package wasi:filesystem@0.2.4;
+package wasi:filesystem@0.2.5;
 /// WASI filesystem is a filesystem API primarily intended to let users run WASI
 /// programs that access their files on their existing filesystems, without
 /// significant overhead.
@@ -26,9 +26,9 @@ package wasi:filesystem@0.2.4;
 @since(version = 0.2.0)
 interface types {
     @since(version = 0.2.0)
-    use wasi:io/streams@0.2.4.{input-stream, output-stream, error};
+    use wasi:io/streams@0.2.5.{input-stream, output-stream, error};
     @since(version = 0.2.0)
-    use wasi:clocks/wall-clock@0.2.4.{datetime};
+    use wasi:clocks/wall-clock@0.2.5.{datetime};
 
     /// File size or length of a region within a file.
     @since(version = 0.2.0)

--- a/wasip2/filesystem/world.wit
+++ b/wasip2/filesystem/world.wit
@@ -1,4 +1,4 @@
-package wasi:filesystem@0.2.4;
+package wasi:filesystem@0.2.5;
 
 @since(version = 0.2.0)
 world imports {

--- a/wasip2/http/proxy.wit
+++ b/wasip2/http/proxy.wit
@@ -1,4 +1,4 @@
-package wasi:http@0.2.3;
+package wasi:http@0.2.5;
 
 /// The `wasi:http/imports` world imports all the APIs for HTTP proxies.
 /// It is intended to be `include`d in other worlds.
@@ -6,25 +6,25 @@ package wasi:http@0.2.3;
 world imports {
   /// HTTP proxies have access to time and randomness.
   @since(version = 0.2.0)
-  import wasi:clocks/monotonic-clock@0.2.3;
+  import wasi:clocks/monotonic-clock@0.2.5;
   @since(version = 0.2.0)
-  import wasi:clocks/wall-clock@0.2.3;
+  import wasi:clocks/wall-clock@0.2.5;
   @since(version = 0.2.0)
-  import wasi:random/random@0.2.3;
+  import wasi:random/random@0.2.5;
 
   /// Proxies have standard output and error streams which are expected to
   /// terminate in a developer-facing console provided by the host.
   @since(version = 0.2.0)
-  import wasi:cli/stdout@0.2.3;
+  import wasi:cli/stdout@0.2.5;
   @since(version = 0.2.0)
-  import wasi:cli/stderr@0.2.3;
+  import wasi:cli/stderr@0.2.5;
 
   /// TODO: this is a temporary workaround until component tooling is able to
   /// gracefully handle the absence of stdin. Hosts must return an eof stream
   /// for this import, which is what wasi-libc + tooling will do automatically
   /// when this import is properly removed.
   @since(version = 0.2.0)
-  import wasi:cli/stdin@0.2.3;
+  import wasi:cli/stdin@0.2.5;
 
   /// This is the default handler to use when user code simply wants to make an
   /// HTTP request (e.g., via `fetch()`).

--- a/wasip2/http/types.wit
+++ b/wasip2/http/types.wit
@@ -4,13 +4,13 @@
 @since(version = 0.2.0)
 interface types {
   @since(version = 0.2.0)
-  use wasi:clocks/monotonic-clock@0.2.3.{duration};
+  use wasi:clocks/monotonic-clock@0.2.5.{duration};
   @since(version = 0.2.0)
-  use wasi:io/streams@0.2.3.{input-stream, output-stream};
+  use wasi:io/streams@0.2.5.{input-stream, output-stream};
   @since(version = 0.2.0)
-  use wasi:io/error@0.2.3.{error as io-error};
+  use wasi:io/error@0.2.5.{error as io-error};
   @since(version = 0.2.0)
-  use wasi:io/poll@0.2.3.{pollable};
+  use wasi:io/poll@0.2.5.{pollable};
 
   /// This type corresponds to HTTP standard Methods.
   @since(version = 0.2.0)

--- a/wasip2/io/error.wit
+++ b/wasip2/io/error.wit
@@ -1,4 +1,4 @@
-package wasi:io@0.2.4;
+package wasi:io@0.2.5;
 
 @since(version = 0.2.0)
 interface error {

--- a/wasip2/io/poll.wit
+++ b/wasip2/io/poll.wit
@@ -1,4 +1,4 @@
-package wasi:io@0.2.4;
+package wasi:io@0.2.5;
 
 /// A poll API intended to let users wait for I/O events on multiple handles
 /// at once.

--- a/wasip2/io/streams.wit
+++ b/wasip2/io/streams.wit
@@ -1,4 +1,4 @@
-package wasi:io@0.2.4;
+package wasi:io@0.2.5;
 
 /// WASI I/O is an I/O abstraction API which is currently focused on providing
 /// stream types.

--- a/wasip2/io/world.wit
+++ b/wasip2/io/world.wit
@@ -1,4 +1,4 @@
-package wasi:io@0.2.4;
+package wasi:io@0.2.5;
 
 @since(version = 0.2.0)
 world imports {

--- a/wasip2/random/insecure-seed.wit
+++ b/wasip2/random/insecure-seed.wit
@@ -1,4 +1,4 @@
-package wasi:random@0.2.4;
+package wasi:random@0.2.5;
 /// The insecure-seed interface for seeding hash-map DoS resistance.
 ///
 /// It is intended to be portable at least between Unix-family platforms and

--- a/wasip2/random/insecure.wit
+++ b/wasip2/random/insecure.wit
@@ -1,4 +1,4 @@
-package wasi:random@0.2.4;
+package wasi:random@0.2.5;
 /// The insecure interface for insecure pseudo-random numbers.
 ///
 /// It is intended to be portable at least between Unix-family platforms and

--- a/wasip2/random/random.wit
+++ b/wasip2/random/random.wit
@@ -1,4 +1,4 @@
-package wasi:random@0.2.4;
+package wasi:random@0.2.5;
 /// WASI Random is a random data API.
 ///
 /// It is intended to be portable at least between Unix-family platforms and

--- a/wasip2/random/world.wit
+++ b/wasip2/random/world.wit
@@ -1,4 +1,4 @@
-package wasi:random@0.2.4;
+package wasi:random@0.2.5;
 
 @since(version = 0.2.0)
 world imports {

--- a/wasip2/sockets/ip-name-lookup.wit
+++ b/wasip2/sockets/ip-name-lookup.wit
@@ -1,7 +1,7 @@
 @since(version = 0.2.0)
 interface ip-name-lookup {
     @since(version = 0.2.0)
-    use wasi:io/poll@0.2.4.{pollable};
+    use wasi:io/poll@0.2.5.{pollable};
     @since(version = 0.2.0)
     use network.{network, error-code, ip-address};
 

--- a/wasip2/sockets/network.wit
+++ b/wasip2/sockets/network.wit
@@ -1,7 +1,7 @@
 @since(version = 0.2.0)
 interface network {
     @unstable(feature = network-error-code)
-    use wasi:io/error@0.2.4.{error};
+    use wasi:io/error@0.2.5.{error};
 
     /// An opaque resource that represents access to (a subset of) the network.
     /// This enables context-based security for networking.

--- a/wasip2/sockets/tcp.wit
+++ b/wasip2/sockets/tcp.wit
@@ -1,11 +1,11 @@
 @since(version = 0.2.0)
 interface tcp {
     @since(version = 0.2.0)
-    use wasi:io/streams@0.2.4.{input-stream, output-stream};
+    use wasi:io/streams@0.2.5.{input-stream, output-stream};
     @since(version = 0.2.0)
-    use wasi:io/poll@0.2.4.{pollable};
+    use wasi:io/poll@0.2.5.{pollable};
     @since(version = 0.2.0)
-    use wasi:clocks/monotonic-clock@0.2.4.{duration};
+    use wasi:clocks/monotonic-clock@0.2.5.{duration};
     @since(version = 0.2.0)
     use network.{network, error-code, ip-socket-address, ip-address-family};
 

--- a/wasip2/sockets/udp.wit
+++ b/wasip2/sockets/udp.wit
@@ -1,7 +1,7 @@
 @since(version = 0.2.0)
 interface udp {
     @since(version = 0.2.0)
-    use wasi:io/poll@0.2.4.{pollable};
+    use wasi:io/poll@0.2.5.{pollable};
     @since(version = 0.2.0)
     use network.{network, error-code, ip-socket-address, ip-address-family};
 

--- a/wasip2/sockets/world.wit
+++ b/wasip2/sockets/world.wit
@@ -1,4 +1,4 @@
-package wasi:sockets@0.2.4;
+package wasi:sockets@0.2.5;
 
 @since(version = 0.2.0)
 world imports {


### PR DESCRIPTION
Pulls in the latest WASI WIT definitions (v0.2.5). This was mechanically generated by running the following command:

```bash
echo 'io = "https://github.com/WebAssembly/wasi-io/archive/v0.2.5.tar.gz"
random = "https://github.com/WebAssembly/wasi-random/archive/v0.2.5.tar.gz"
clocks = "https://github.com/WebAssembly/wasi-clocks/archive/v0.2.5.tar.gz"
filesystem = "https://github.com/WebAssembly/wasi-filesystem/archive/v0.2.5.tar.gz"
sockets = "https://github.com/WebAssembly/wasi-sockets/archive/v0.2.5.tar.gz"
cli = "https://github.com/WebAssembly/wasi-cli/archive/v0.2.5.tar.gz"
http = "https://github.com/WebAssembly/wasi-http/archive/v0.2.5.tar.gz"' > deps.toml
wit-deps -d wasip2 -m deps.toml -l deps.lock
rm deps.toml
rm deps.lock
```

Thanks!