### PR TITLE
Remove Preview1's advice about random-number generators.

### DIFF
--- a/legacy/preview0/docs.md
+++ b/legacy/preview0/docs.md
@@ -2394,9 +2394,6 @@ Note: This is similar to [`sched_yield`](#sched_yield) in POSIX.
 Write high-quality random data into a buffer.
 This function blocks when the implementation is unable to immediately
 provide sufficient high-quality random data.
-This function may execute slowly, so when large mounts of random data are
-required, it's advisable to use this function to seed a pseudo-random
-number generator, rather than to provide the random data directly.
 
 ##### Params
 - <a href="#random_get.buf" name="random_get.buf"></a> `buf`: `Pointer<u8>`

--- a/legacy/preview0/witx/wasi_unstable.witx
+++ b/legacy/preview0/witx/wasi_unstable.witx
@@ -466,9 +466,6 @@
   ;;; Write high-quality random data into a buffer.
   ;;; This function blocks when the implementation is unable to immediately
   ;;; provide sufficient high-quality random data.
-  ;;; This function may execute slowly, so when large mounts of random data are
-  ;;; required, it's advisable to use this function to seed a pseudo-random
-  ;;; number generator, rather than to provide the random data directly.
   (@interface func (export "random_get")
     ;;; The buffer to fill with random data.
     (param $buf (@witx pointer u8))

--- a/legacy/preview1/docs.html
+++ b/legacy/preview1/docs.html
@@ -1211,7 +1211,7 @@ Information about a pre-opened capability.<br>Size: 8<br>Alignment: 4<h3 id="uni
 </ul>
 <hr>
 <h4 id="a-href-random_get-name-random_get-a-random_get-buf-pointeru8-buf_len-size-errno">&lt;a href=&quot;#random_get&quot; name=&quot;random_get&quot;&gt;&lt;/a&gt; <code>random_get(buf: Pointer&lt;u8&gt;, buf_len: size) -&gt; errno</code></h4>
-<p>Write high-quality random data into a buffer.<br>This function blocks when the implementation is unable to immediately<br>provide sufficient high-quality random data.<br>This function may execute slowly, so when large mounts of random data are<br>required, it&#39;s advisable to use this function to seed a pseudo-random<br>number generator, rather than to provide the random data directly.</p>
+<p>Write high-quality random data into a buffer.<br>This function blocks when the implementation is unable to immediately<br>provide sufficient high-quality random data.</p>
 <h5 id="params">Params</h5>
 <ul>
 <li><p>&lt;a href=&quot;#random_get.buf&quot; name=&quot;random_get.buf&quot;&gt;&lt;/a&gt; <code>buf</code>: <code>Pointer&lt;u8&gt;</code><br>The buffer to fill with random data.</p>

--- a/legacy/preview1/docs.md
+++ b/legacy/preview1/docs.md
@@ -2422,9 +2422,6 @@ Note: This is similar to [`sched_yield`](#sched_yield) in POSIX.
 Write high-quality random data into a buffer.
 This function blocks when the implementation is unable to immediately
 provide sufficient high-quality random data.
-This function may execute slowly, so when large mounts of random data are
-required, it's advisable to use this function to seed a pseudo-random
-number generator, rather than to provide the random data directly.
 
 ##### Params
 - <a href="#random_get.buf" name="random_get.buf"></a> `buf`: `Pointer<u8>`

--- a/legacy/preview1/witx/wasi_snapshot_preview1.witx
+++ b/legacy/preview1/witx/wasi_snapshot_preview1.witx
@@ -485,9 +485,6 @@
   ;;; Write high-quality random data into a buffer.
   ;;; This function blocks when the implementation is unable to immediately
   ;;; provide sufficient high-quality random data.
-  ;;; This function may execute slowly, so when large mounts of random data are
-  ;;; required, it's advisable to use this function to seed a pseudo-random
-  ;;; number generator, rather than to provide the random data directly.
   (@interface func (export "random_get")
     ;;; The buffer to fill with random data.
     (param $buf (@witx pointer u8))


### PR DESCRIPTION
Previously, the preview1 documentation for the `random_get` function said:

> This function may execute slowly, so when large mounts of random data are
> required, it's advisable to use this function to seed a pseudo-random
> number generator, rather than to provide the random data directly.

However, Wasm guest code is unaware of VM forks in any VMs might be running in, as well as snapshot/resume features offered by some Wasm engines and tools, so in practice, WASI use cases have tended toward using `random_get` in place of guest PRNGs, and thus to relying on `random_get` executing quickly.

This pattern seems sufficiently widely applicable to motivate updating WASIp1 to reflect it. To be sure, this is not a behavior change; it's just removing what we now understand to be bad advice in general.

WASIp2 for its part has already made a similar change.