### PR TITLE
Initialize a `specifications/` directory

### DIFF
--- a/specifications/wasi-0.2.0/Overview.md
+++ b/specifications/wasi-0.2.0/Overview.md
@@ -1,0 +1,22 @@
+# WASI Specification v0.2.0
+
+This is version 0.2.0 of the WASI specification, based on the [WebAssembly
+Component Model][cm].
+
+## Proposals
+
+The [WebAssembly Interface Type (WIT)][wit] definitions for the proposals included in this
+version of the specification are pushed to OCI based on the [Wasm OCI Artifact
+layout][wasm-oci]:
+
+- [wasi:io@0.2.0](https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Fio?tag=0.2.0)
+- [wasi:random@0.2.0](https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Frandom?tag=0.2.0)
+- [wasi:clocks@0.2.0](https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Fclocks?tag=0.2.0)
+- [wasi:sockets@0.2.0](https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Fsockets?tag=0.2.0)
+- [wasi:filesystem@0.2.0](https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Ffilesystem?tag=0.2.0)
+- [wasi:cli@0.2.0](https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Fcli?tag=0.2.0)
+- [wasi:http@0.2.0](https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Fhttp?tag=0.2.0)
+
+[cm]: https://github.com/WebAssembly/component-model
+[wit]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md
+[wasm-oci]: https://tag-runtime.cncf.io/wgs/wasm/deliverables/wasm-oci-artifact

--- a/specifications/wasi-0.2.1/Overview.md
+++ b/specifications/wasi-0.2.1/Overview.md
@@ -1,0 +1,22 @@
+# WASI Specification v0.2.1
+
+This is version 0.2.1 of the WASI specification, based on the [WebAssembly
+Component Model][cm].
+
+## Proposals
+
+The [WebAssembly Interface Type (WIT)][wit] definitions for the proposals included in this
+version of the specification are pushed to OCI based on the [Wasm OCI Artifact
+layout][wasm-oci]:
+
+- [wasi:io@0.2.1](https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Fio?tag=0.2.1)
+- [wasi:random@0.2.1](https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Frandom?tag=0.2.1)
+- [wasi:clocks@0.2.1](https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Fclocks?tag=0.2.1)
+- [wasi:sockets@0.2.1](https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Fsockets?tag=0.2.1)
+- [wasi:filesystem@0.2.1](https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Ffilesystem?tag=0.2.1)
+- [wasi:cli@0.2.1](https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Fcli?tag=0.2.1)
+- [wasi:http@0.2.1](https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Fhttp?tag=0.2.1)
+
+[cm]: https://github.com/WebAssembly/component-model
+[wit]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md
+[wasm-oci]: https://tag-runtime.cncf.io/wgs/wasm/deliverables/wasm-oci-artifact

--- a/specifications/wasi-0.2.2/Overview.md
+++ b/specifications/wasi-0.2.2/Overview.md
@@ -1,0 +1,22 @@
+# WASI Specification v0.2.2
+
+This is version 0.2.2 of the WASI specification, based on the [WebAssembly
+Component Model][cm].
+
+## Proposals
+
+The [WebAssembly Interface Type (WIT)][wit] definitions for the proposals included in this
+version of the specification are pushed to OCI based on the [Wasm OCI Artifact
+layout][wasm-oci]:
+
+- [wasi:io@0.2.2](https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Fio?tag=0.2.2)
+- [wasi:random@0.2.2](https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Frandom?tag=0.2.2)
+- [wasi:clocks@0.2.2](https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Fclocks?tag=0.2.2)
+- [wasi:sockets@0.2.2](https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Fsockets?tag=0.2.2)
+- [wasi:filesystem@0.2.2](https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Ffilesystem?tag=0.2.2)
+- [wasi:cli@0.2.2](https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Fcli?tag=0.2.2)
+- [wasi:http@0.2.2](https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Fhttp?tag=0.2.2)
+
+[cm]: https://github.com/WebAssembly/component-model
+[wit]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md
+[wasm-oci]: https://tag-runtime.cncf.io/wgs/wasm/deliverables/wasm-oci-artifact

--- a/specifications/wasi-0.2.3/Overview.md
+++ b/specifications/wasi-0.2.3/Overview.md
@@ -1,0 +1,22 @@
+# WASI Specification v0.2.3
+
+This is version 0.2.3 of the WASI specification, based on the [WebAssembly
+Component Model][cm].
+
+## Proposals
+
+The [WebAssembly Interface Type (WIT)][wit] definitions for the proposals included in this
+version of the specification are pushed to OCI based on the [Wasm OCI Artifact
+layout][wasm-oci]:
+
+- [wasi:io@0.2.3](https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Fio?tag=0.2.3)
+- [wasi:random@0.2.3](https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Frandom?tag=0.2.3)
+- [wasi:clocks@0.2.3](https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Fclocks?tag=0.2.3)
+- [wasi:sockets@0.2.3](https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Fsockets?tag=0.2.3)
+- [wasi:filesystem@0.2.3](https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Ffilesystem?tag=0.2.3)
+- [wasi:cli@0.2.3](https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Fcli?tag=0.2.3)
+- [wasi:http@0.2.3](https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Fhttp?tag=0.2.3)
+
+[cm]: https://github.com/WebAssembly/component-model
+[wit]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md
+[wasm-oci]: https://tag-runtime.cncf.io/wgs/wasm/deliverables/wasm-oci-artifact

--- a/specifications/wasi-0.2.4/Overview.md
+++ b/specifications/wasi-0.2.4/Overview.md
@@ -1,0 +1,22 @@
+# WASI Specification v0.2.4
+
+This is version 0.2.4 of the WASI specification, based on the [WebAssembly
+Component Model][cm].
+
+## Proposals
+
+The [WebAssembly Interface Type (WIT)][wit] definitions for the proposals included in this
+version of the specification are pushed to OCI based on the [Wasm OCI Artifact
+layout][wasm-oci]:
+
+- [wasi:io@0.2.4](https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Fio?tag=0.2.4)
+- [wasi:random@0.2.4](https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Frandom?tag=0.2.4)
+- [wasi:clocks@0.2.4](https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Fclocks?tag=0.2.4)
+- [wasi:sockets@0.2.4](https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Fsockets?tag=0.2.4)
+- [wasi:filesystem@0.2.4](https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Ffilesystem?tag=0.2.4)
+- [wasi:cli@0.2.4](https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Fcli?tag=0.2.4)
+- [wasi:http@0.2.4](https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Fhttp?tag=0.2.4)
+
+[cm]: https://github.com/WebAssembly/component-model
+[wit]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md
+[wasm-oci]: https://tag-runtime.cncf.io/wgs/wasm/deliverables/wasm-oci-artifact

--- a/specifications/wasi-0.2.5/Overview.md
+++ b/specifications/wasi-0.2.5/Overview.md
@@ -1,0 +1,22 @@
+# WASI Specification v0.2.5
+
+This is version 0.2.5 of the WASI specification, based on the [WebAssembly
+Component Model][cm].
+
+## Proposals
+
+The [WebAssembly Interface Type (WIT)][wit] definitions for the proposals included in this
+version of the specification are pushed to OCI based on the [Wasm OCI Artifact
+layout][wasm-oci]:
+
+- [wasi:io@0.2.5](https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Fio?tag=0.2.5)
+- [wasi:random@0.2.5](https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Frandom?tag=0.2.5)
+- [wasi:clocks@0.2.5](https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Fclocks?tag=0.2.5)
+- [wasi:sockets@0.2.5](https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Fsockets?tag=0.2.5)
+- [wasi:filesystem@0.2.5](https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Ffilesystem?tag=0.2.5)
+- [wasi:cli@0.2.5](https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Fcli?tag=0.2.5)
+- [wasi:http@0.2.5](https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Fhttp?tag=0.2.5)
+
+[cm]: https://github.com/WebAssembly/component-model
+[wit]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md
+[wasm-oci]: https://tag-runtime.cncf.io/wgs/wasm/deliverables/wasm-oci-artifact

--- a/specifications/wasi-0.2.6/Overview.md
+++ b/specifications/wasi-0.2.6/Overview.md
@@ -1,0 +1,22 @@
+# WASI Specification v0.2.6
+
+This is version 0.2.6 of the WASI specification, based on the [WebAssembly
+Component Model][cm].
+
+## Proposals
+
+The [WebAssembly Interface Type (WIT)][wit] definitions for the proposals included in this
+version of the specification are pushed to OCI based on the [Wasm OCI Artifact
+layout][wasm-oci]:
+
+- [wasi:io@0.2.6](https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Fio?tag=0.2.6)
+- [wasi:random@0.2.6](https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Frandom?tag=0.2.6)
+- [wasi:clocks@0.2.6](https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Fclocks?tag=0.2.6)
+- [wasi:sockets@0.2.6](https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Fsockets?tag=0.2.6)
+- [wasi:filesystem@0.2.6](https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Ffilesystem?tag=0.2.6)
+- [wasi:cli@0.2.6](https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Fcli?tag=0.2.6)
+- [wasi:http@0.2.6](https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Fhttp?tag=0.2.6)
+
+[cm]: https://github.com/WebAssembly/component-model
+[wit]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md
+[wasm-oci]: https://tag-runtime.cncf.io/wgs/wasm/deliverables/wasm-oci-artifact

--- a/specifications/wasi-0.2.7/Overview.md
+++ b/specifications/wasi-0.2.7/Overview.md
@@ -1,0 +1,22 @@
+# WASI Specification v0.2.7
+
+This is version 0.2.7 of the WASI specification, based on the [WebAssembly
+Component Model][cm].
+
+## Proposals
+
+The [WebAssembly Interface Type (WIT)][wit] definitions for the proposals included in this
+version of the specification are pushed to OCI based on the [Wasm OCI Artifact
+layout][wasm-oci]:
+
+- [wasi:io@0.2.7](https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Fio?tag=0.2.7)
+- [wasi:random@0.2.7](https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Frandom?tag=0.2.7)
+- [wasi:clocks@0.2.7](https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Fclocks?tag=0.2.7)
+- [wasi:sockets@0.2.7](https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Fsockets?tag=0.2.7)
+- [wasi:filesystem@0.2.7](https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Ffilesystem?tag=0.2.7)
+- [wasi:cli@0.2.7](https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Fcli?tag=0.2.7)
+- [wasi:http@0.2.7](https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Fhttp?tag=0.2.7)
+
+[cm]: https://github.com/WebAssembly/component-model
+[wit]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md
+[wasm-oci]: https://tag-runtime.cncf.io/wgs/wasm/deliverables/wasm-oci-artifact

--- a/specifications/wasi-0.2.8/Overview.md
+++ b/specifications/wasi-0.2.8/Overview.md
@@ -1,0 +1,22 @@
+# WASI Specification v0.2.8
+
+This is version 0.2.8 of the WASI specification, based on the [WebAssembly
+Component Model][cm].
+
+## Proposals
+
+The [WebAssembly Interface Type (WIT)][wit] definitions for the proposals included in this
+version of the specification are pushed to OCI based on the [Wasm OCI Artifact
+layout][wasm-oci]:
+
+- [wasi:io@0.2.8](https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Fio?tag=0.2.8)
+- [wasi:random@0.2.8](https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Frandom?tag=0.2.8)
+- [wasi:clocks@0.2.8](https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Fclocks?tag=0.2.8)
+- [wasi:sockets@0.2.8](https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Fsockets?tag=0.2.8)
+- [wasi:filesystem@0.2.8](https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Ffilesystem?tag=0.2.8)
+- [wasi:cli@0.2.8](https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Fcli?tag=0.2.8)
+- [wasi:http@0.2.8](https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Fhttp?tag=0.2.8)
+
+[cm]: https://github.com/WebAssembly/component-model
+[wit]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md
+[wasm-oci]: https://tag-runtime.cncf.io/wgs/wasm/deliverables/wasm-oci-artifact


### PR DESCRIPTION
This initializes a basic structure for our previously published specifications, starting with WASI 0.2.0. For the moment all we do is link to the published WIT files, but in the future this will be helpful to clarify which Wasm and/or Wasm Component Model features are required. As well as include additional prose and spec text present that is not necessarily captured by the WIT interfaces.

This is the same model followed by the core WebAssembly specification. The main difference being that the core Wasm spec is mainly defined in spectec, while our specification is mainly defined in WIT. We should have further discussion on what exactly specifications should contain and entail, but I'd like to propose doing that as an iterative step after merging the most basic version possible (e.g. this PR).

Thanks!