### PR TITLE
Improve visual rhythm in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4323447.svg)](https://doi.org/10.5281/zenodo.4323447)
-    
+<img width="100px" src="assets/WASI.png">
+
 # WebAssembly System Interface
 
-![WASI](assets/WASI.png)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4323447.svg)](https://doi.org/10.5281/zenodo.4323447)
+    
 
 The WebAssembly System Interface (WASI) is a set of APIs for WASI being
 developed for eventual standardization by the WASI Subgroup, which is a


### PR DESCRIPTION
Currently the logo in the README takes up most of the area above the fold. Just by shrinking it down a little and putting it above the heading, I feel like it makes a big difference in the overall rhythm and legibility of the repo.

There are probably bigger changes we could make to further improve the README, but those would probably require more design and contemplation. All this PR does is move some items around and resize them a bit, which seemed like pretty good value for the effort involved.

Thanks!

## Screenshots

<details>
<summary>Screenshot of the current README</summary>
<img width="1842" height="1682" alt="Screenshot 2025-11-27 at 12 56 36" src="https://github.com/user-attachments/assets/3e3a9f93-547c-4203-8211-bff5633887e4" />

</details>

<details>
<summary>Screenshot of the proposed README</summary>
<img width="1866" height="1204" alt="Screenshot 2025-11-27 at 12 57 21" src="https://github.com/user-attachments/assets/9e22191d-2438-4b6d-82bb-b865a1d106b9" />

</summary>
