### PR TITLE
fix(readme): point to preview2 under docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ source languages, modularity, a more expressive type system,
 virtualizability, and more.
 
 [Preview 1]: https://github.com/WebAssembly/WASI/tree/main/legacy/README.md
-[WASI Preview 2]: https://github.com/WebAssembly/WASI/blob/main/wasip2/README.md
+[WASI Preview 2]: https://github.com/WebAssembly/WASI/blob/main/docs/Preview2.md
 [Wit IDL]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md
 
 ## Find the APIs


### PR DESCRIPTION
wasip2 directory was deleted recently, breaking the link for preview 2.

I'm pointing to preview 2 doc under `/docs` :P