### PR TITLE
Update documentation for `wasi:filesystem:descriptor#link-at`.

### DIFF
--- a/proposals/filesystem/wit-0.3.0-draft/types.wit
+++ b/proposals/filesystem/wit-0.3.0-draft/types.wit
@@ -492,9 +492,8 @@ interface types {
         /// Behavior is as described by [POSIX
         /// `linkat`](https://pubs.opengroup.org/onlinepubs/9699919799/functions/link.html).
         ///
-        /// Note: some platforms return `error-code::access` instead of
-        /// `error-code::not-permitted` when attempting to hard-link a
-        /// directory.
+        /// Hard links between directories are forbidden, and produce either
+        /// `error-code::access` or `error-code::not-permitted` error results.
         @since(version = 0.3.0-rc-2025-09-16)
         link-at: async func(
             /// Flags determining the method of how the path is resolved.


### PR DESCRIPTION
It would have been nice for `linkat` to do just what POSIX does, but Windows includes the case of hard-linking a directory in EACCESS instead of the POSIX-prescribed EPERM.