### PR TITLE
Specify unlink-file-at in terms of POSIX.

### DIFF
--- a/proposals/filesystem/wit-0.3.0-draft/types.wit
+++ b/proposals/filesystem/wit-0.3.0-draft/types.wit
@@ -595,9 +595,14 @@ interface types {
 
         /// Unlink a filesystem object that is not a directory.
         ///
-        /// Return `error-code::is-directory` if the path refers to a directory.
-        /// Note: This is similar to `unlinkat(fd, path, 0)` in POSIX.
-        @since(version = 0.3.0-rc-2026-02-09)
+        /// This is similar to `unlinkat(fd, path, 0)` in POSIX.
+        ///
+        /// Error returns are as specified by POSIX.
+        ///
+        /// If the filesystem object is a directory, `error-code::access` or
+        /// `error-code::is-directory` may be returned instead of the
+        /// POSIX-specified `error-code::not-permitted`.
+        @since(version = 0.3.0-rc-2025-02-09)
         unlink-file-at: async func(
             /// The relative path to a file to unlink.
             path: string,


### PR DESCRIPTION
Unfortunately only MacOS has the POSIX behavior of returning EPERM when unlinking a directory; Linux returns EISDIR, and Windows returns EACCESS.  Because EACCESS may arise for other reasons but which are outside the purview of WASI, we map all EACCESS to EPERM.