### PR TITLE
List new WASI co-champions in Proposals.md

### DIFF
--- a/docs/Proposals.md
+++ b/docs/Proposals.md
@@ -24,19 +24,19 @@ You can learn more about contributing new proposals (and other ways to contribut
 | Proposal                      | Champion                                                              | Versions |
 | ----------------------------- | --------------------------------------------------------------------- | -------- |
 | [I/O][wasi-io]                | Dan Gohman                                                            |          |
-| [Clocks][wasi-clocks]         | Dan Gohman                                                            |          |
-| [Random][wasi-random]         | Dan Gohman                                                            |          |
-| [Filesystem][wasi-filesystem] | Dan Gohman                                                            |          |
+| [Clocks][wasi-clocks]         | Dan Gohman, Colin Murphy                                              |          |
+| [Random][wasi-random]         | Dan Gohman, Roman Volosatovs                                          |          |
+| [Filesystem][wasi-filesystem] | Dan Gohman, Victor Adossi                                             |          |
 | [Sockets][wasi-sockets]       | Dave Bakker                                                           |          |
-| [CLI][wasi-cli]               | Dan Gohman                                                            |          |
+| [CLI][wasi-cli]               | Dan Gohman, Lann Martin                                               |          |
 | [HTTP][wasi-http]             | Piotr Sikora, Jiaxiao Zhou, Dan Chiarlone, David Justice, Luke Wagner |          |
 
 ### Phase 2 - Proposed Spec Text Available (CG + WG)
 
 | Proposal                                           | Champion                                                              | Versions |
 | -------------------------------------------------- | --------------------------------------------------------------------- | -------- |
-| [Clocks: Timezone][wasi-clocks]                    | Dan Gohman                                                            |          |
-| [CLI: Exit With Code][wasi-cli]                    | Dan Gohman                                                            |          |
+| [Clocks: Timezone][wasi-clocks]                    | Dan Gohman, Colin Murphy                                              |          |
+| [CLI: Exit With Code][wasi-cli]                    | Dan Gohman, Lann Martin                                               |          |
 | [HTTP: Informational Outbound Response][wasi-http] | Piotr Sikora, Jiaxiao Zhou, Dan Chiarlone, David Justice, Luke Wagner |          |
 | [I2C][wasi-i2c]                                    | Friedrich Vandenberghe, Merlijn Sebrechts, Maximilian Seidler         |          |
 | [Key-value Store][wasi-kv-store]                   | Jiaxiao Zhou, Dan Chiarlone, David Justice                            |          |


### PR DESCRIPTION
This adds new co-champions to a number of existing proposals, as decided in the [2024-09-04 WASI meeting](https://github.com/WebAssembly/meetings/blob/e52b81995e63d640cd441615b096da22ebba3b23/wasi/2025/WASI-09-04.md):

- @lann is now a co-champion of `wasi:cli` (@WebAssembly/wasi-cli-champions)
- @vados-cosmonic is now a co-champion of `wasi:filesystem` (@WebAssembly/wasi-filesystem-champions)
- @rvolosatovs is now a co-champion of `wasi:random` (@WebAssembly/wasi-random-champions)
- @cdmurph32 is now a co-champion of `wasi:clocks` (@WebAssembly/wasi-clocks-champions)

This PR updates the listed champions in Proposals.md to match. I've already gone ahead and updated the team membership on GitHub to reflect these changes. We should have gotten ahead to making these changes sooner, but I'm glad we're getting to this now.

Congratulations again on being voted in champions, and we look forward to working with you!