### PR TITLE
Clarify the implicit bind behavior observed on Windows.

### DIFF
--- a/proposals/sockets/wit-0.3.0-draft/types.wit
+++ b/proposals/sockets/wit-0.3.0-draft/types.wit
@@ -276,6 +276,12 @@ interface types {
         /// In either case, the stream returned by this `listen` method remains
         /// operational.
         ///
+        /// WASI requires `listen` to perform an implicit bind if the socket
+        /// has not already been bound. Not all platforms (notably Windows)
+        /// exhibit this behavior out of the box. On platforms that require it,
+        /// the WASI implementation can emulate this behavior by performing
+        /// the bind itself if the guest hasn't already done so.
+        ///
         /// # References
         /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/listen.html>
         /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/accept.html>


### PR DESCRIPTION
The documentation of [`tcp-socket::listen`](https://github.com/WebAssembly/WASI/blob/7e643518a4bf9767ca799d7aa776c560a2fc0351/proposals/sockets/wit-0.3.0-draft/types.wit#L229-L230) mentions:
> If the socket is not already explicitly bound, this function will implicitly bind the socket to a random free port.

I've recently added [tests for this in wasmtime](https://github.com/bytecodealliance/wasmtime/pull/12225).
The tests ran fine on Linux and MacOS but failed on Windows. Apparently, Windows does not perform an implicit bind as part of `listen`.
I've updated wasmtime to perform the bind explicitly if the guest hasn't already done so. This makes it behave the same on all platforms.

This PR adds a note on `listen` clarifying the expected WASI behavior and observed OS behavior.
