### PR TITLE
Update links in wasi-sockets documentation to point to WASI

### DIFF
--- a/proposals/sockets/Posix-compatibility.md
+++ b/proposals/sockets/Posix-compatibility.md
@@ -598,11 +598,11 @@ Legend:
 [79]: https://github.com/WebAssembly/wasi-sockets/issues/79
 [80]: https://github.com/WebAssembly/wasi-sockets/issues/80
 [81]: https://github.com/WebAssembly/wasi-sockets/issues/81
-[ip-name-lookup]: https://github.com/WebAssembly/wasi-sockets/blob/main/wit/ip-name-lookup.wit
-[tcp-create-socket]: https://github.com/WebAssembly/wasi-sockets/blob/main/wit/tcp-create-socket.wit
-[tcp]: https://github.com/WebAssembly/wasi-sockets/blob/main/wit/tcp.wit
-[udp-create-socket]: https://github.com/WebAssembly/wasi-sockets/blob/main/wit/udp-create-socket.wit
-[udp]: https://github.com/WebAssembly/wasi-sockets/blob/main/wit/udp.wit
+[ip-name-lookup]: https://github.com/WebAssembly/WASI/blob/main/proposals/sockets/wit/ip-name-lookup.wit
+[tcp-create-socket]: https://github.com/WebAssembly/WASI/blob/main/proposals/sockets/wit/tcp-create-socket.wit
+[tcp]: https://github.com/WebAssembly/WASI/blob/main/proposals/sockets/wit/tcp.wit
+[udp-create-socket]: https://github.com/WebAssembly/WASI/blob/main/proposals/sockets/wit/udp-create-socket.wit
+[udp]: https://github.com/WebAssembly/WASI/blob/main/proposals/sockets/wit/udp.wit
 [poll]: https://github.com/WebAssembly/wasi-poll/blob/main/wit/poll.wit
 [streams]: https://github.com/WebAssembly/wasi-io/blob/main/wit/streams.wit
 ****

--- a/proposals/sockets/README.md
+++ b/proposals/sockets/README.md
@@ -142,7 +142,7 @@ IPv6 sockets returned by this proposal are never dualstack because that can't ea
 
 This behaviour is deemed acceptable because all existing applications that are truly cross-platform must already handle this scenario. Dualstack support can be part of a future proposal adding it as an opt-in feature.
 
-Related issue: [Emulate dualstack sockets in userspace](https://github.com/WebAssembly/wasi-sockets/issues/1)
+Related issue: [Emulate dualstack sockets in userspace](https://github.com/WebAssembly/WASI/issues/747)
 
 #### Modularity
 

--- a/proposals/sockets/imports.md
+++ b/proposals/sockets/imports.md
@@ -1211,7 +1211,7 @@ elapsed from the time this function is invoked.</p>
 <li><code>connect-in-progress</code></li>
 <li><code>connected</code></li>
 <li><code>closed</code>
-See <a href="https://github.com/WebAssembly/wasi-sockets/blob/main/TcpSocketOperationalSemantics.md">https://github.com/WebAssembly/wasi-sockets/blob/main/TcpSocketOperationalSemantics.md</a>
+See <a href="https://github.com/WebAssembly/WASI/blob/main/proposals/sockets/TcpSocketOperationalSemantics.md">https://github.com/WebAssembly/WASI/blob/main/proposals/sockets/TcpSocketOperationalSemantics.md</a>
 for more information.</li>
 </ul>
 <p>Note: Except where explicitly mentioned, whenever this documentation uses
@@ -1701,7 +1701,7 @@ their success or failure, after which the method can be retried.</p>
 in progress at the time of calling <code>subscribe</code> (if any). Theoretically,
 <code>subscribe</code> only has to be called once per socket and can then be
 (re)used for the remainder of the socket's lifetime.</p>
-<p>See <a href="https://github.com/WebAssembly/wasi-sockets/blob/main/TcpSocketOperationalSemantics.md#pollable-readiness">https://github.com/WebAssembly/wasi-sockets/blob/main/TcpSocketOperationalSemantics.md#pollable-readiness</a>
+<p>See <a href="https://github.com/WebAssembly/WASI/blob/main/proposals/sockets/TcpSocketOperationalSemantics.md#pollable-readiness">https://github.com/WebAssembly/WASI/blob/main/proposals/sockets/TcpSocketOperationalSemantics.md#pollable-readiness</a>
 for more information.</p>
 <p>Note: this function is here for WASI 0.2 only.
 It's planned to be removed when <code>future</code> is natively supported in Preview3.</p>

--- a/proposals/sockets/wit-0.3.0-draft/types.wit
+++ b/proposals/sockets/wit-0.3.0-draft/types.wit
@@ -125,7 +125,7 @@ interface types {
     /// - `connecting`
     /// - `connected`
     /// - `closed`
-    /// See <https://github.com/WebAssembly/wasi-sockets/blob/main/TcpSocketOperationalSemantics-0.3.0-draft.md>
+    /// See <https://github.com/WebAssembly/WASI/blob/main/proposals/sockets/TcpSocketOperationalSemantics-0.3.0-draft.md>
     /// for more information.
     ///
     /// Note: Except where explicitly mentioned, whenever this documentation uses

--- a/proposals/sockets/wit/tcp.wit
+++ b/proposals/sockets/wit/tcp.wit
@@ -32,7 +32,7 @@ interface tcp {
     /// - `connect-in-progress`
     /// - `connected`
     /// - `closed`
-    /// See <https://github.com/WebAssembly/wasi-sockets/blob/main/TcpSocketOperationalSemantics.md>
+    /// See <https://github.com/WebAssembly/WASI/blob/main/proposals/sockets/TcpSocketOperationalSemantics.md>
     /// for more information.
     ///
     /// Note: Except where explicitly mentioned, whenever this documentation uses
@@ -350,7 +350,7 @@ interface tcp {
         /// `subscribe` only has to be called once per socket and can then be
         /// (re)used for the remainder of the socket's lifetime.
         ///
-        /// See <https://github.com/WebAssembly/wasi-sockets/blob/main/TcpSocketOperationalSemantics.md#pollable-readiness>
+        /// See <https://github.com/WebAssembly/WASI/blob/main/proposals/sockets/TcpSocketOperationalSemantics.md#pollable-readiness>
         /// for more information.
         ///
         /// Note: this function is here for WASI 0.2 only.


### PR DESCRIPTION
Just a driveby fix; leaving the task of updating links to issues for future work though.