### PR TITLE
sockets: Add error code for EPIPE (and ECONNABORTED on Windows)

### DIFF
--- a/proposals/sockets/wit-0.3.0-draft/types.wit
+++ b/proposals/sockets/wit-0.3.0-draft/types.wit
@@ -70,7 +70,12 @@ interface types {
         ///
         /// POSIX equivalent: ECONNREFUSED
         connection-refused,
-        
+
+        /// A write failed because the connection was broken.
+        ///
+        /// POSIX equivalent: EPIPE
+        connection-broken,
+
         /// The connection was reset.
         ///
         /// POSIX equivalent: ECONNRESET
@@ -349,6 +354,7 @@ interface types {
         /// # Typical errors
         /// - `invalid-state`:             The socket is not in the `connected` state. (ENOTCONN)
         /// - `invalid-state`:             `send` has already been called on this socket.
+        /// - `connection-broken`:         The connection is not writable anymore. (EPIPE, ECONNABORTED on Windows)
         /// - `connection-reset`:          The connection was reset. (ECONNRESET)
         /// - `remote-unreachable`:        The remote address is not reachable. (EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN, ENONET)
         ///


### PR DESCRIPTION
WASI sockets currently has no error code corresponding to `EPIPE`. When writing to a closed/broken socket:
- POSIX systems return `EPIPE`
- Windows returns `ECONNABORTED`

After searching around, this Windows-specific discrepancy is well-known:
- [Android ADB](https://android.googlesource.com/platform/system/core/+/eaae97e/adb/sysdeps_win32.cpp#644), [Mio](https://github.com/tokio-rs/mio/blob/66ac9fab79bf191218488c4f35c99d13935b7e12/tests/tcp_stream.rs#L404), and [OpenJDK](https://github.com/openjdk/jdk/blob/6b576235b84f51e273da44158bfcadbb48f51baa/src/java.base/share/classes/sun/security/ssl/NewSessionTicket.java#L406-L410) treat it as `EPIPE`.
- [libuv](https://github.com/libuv/libuv/blob/12d0dd48e3c6baf1e2f0d9f85f11f0ef58285d6f/src/win/tcp.c#L1059) and [nginx](https://github.com/nginx/nginx/blob/edb4d2ffa746ba30bcae90e9527d5512b3de2c5b/src/core/ngx_connection.c#L1573) treat it as `ECONNRESET`.

---

WASI doesn't have a good solution for it now:
- By the time the OS reports `EPIPE`, previously acknowledged writes may have been lost and and the guest should be informed about that. So swallowing the error is not right.
- Mapping it to `ECONNRESET` isn't right either, beause that implies that the peer actively reset the connection.
- Mapping (or: _leaving_) it as `ECONNABORTED` isn't optimal either, because that error code is usually only returned by `accept` and sometimes `connect` on Unix-like systems.

I think this warrants a new error code. I've called it `connection-broken`. I expect wasi-libc to map this to `EPIPE`.

---

Wasmtime currently maps [EPIPE to `ok(())`](https://github.com/bytecodealliance/wasmtime/blob/2e3d0ecb5e6b761d2b6424031c69770c5105eddd/crates/wasi/src/p3/sockets/host/types/tcp.rs#L229-L231). With the new error code in place, [this test](https://github.com/bytecodealliance/wasmtime/blob/2e3d0ecb5e6b761d2b6424031c69770c5105eddd/crates/test-programs/src/bin/p3_sockets_tcp_streams.rs#L104) can be updated to consistently expect an error cross platform.