### PR TITLE
feat(cli): exit-with-code function stable

### DIFF
--- a/proposals/cli/wit/exit.wit
+++ b/proposals/cli/wit/exit.wit
@@ -12,6 +12,6 @@ interface exit {
   ///
   /// This function does not return; the effect is analogous to a trap, but
   /// without the connotation that something bad has happened.
-  @unstable(feature = cli-exit-with-code)
+  @since(version = 0.2.12)
   exit-with-code: func(status-code: u8);
 }


### PR DESCRIPTION
Remove the feature gate for stabilized feature `exit-with-code function`