### PR TITLE
Adjust WASIp3 exit-with-code to "stable"

### DIFF
--- a/proposals/cli/wit-0.3.0-draft/exit.wit
+++ b/proposals/cli/wit-0.3.0-draft/exit.wit
@@ -12,6 +12,6 @@ interface exit {
   ///
   /// This function does not return; the effect is analogous to a trap, but
   /// without the connotation that something bad has happened.
-  @unstable(feature = cli-exit-with-code)
+  @since(version = 0.3.0-rc-2026-03-15)
   exit-with-code: func(status-code: u8);
 }


### PR DESCRIPTION
The intention is that this'll ride the next snapshot/stable release just like the 0.2.12 counterpart.