### PR TITLE
Add .gitattributes to normalize line endings to LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Normalize line endings to LF in the repository for all text files.
+# Binary files are auto-detected and left untouched.
+* text=auto eol=lf


### PR DESCRIPTION
Enforce LF line endings repo-wide for all text files so contributors' local git config and editors can't introduce CRLF. A recent edit to proposals/http/wit-0.3.0-draft/worlds.wit was committed with CRLF endings, which made the entire file appear changed in diffs even on untouched lines.