### PR TITLE
Clarify `consume-body` error propagation for middleware

### DIFF
--- a/proposals/http/wit/types.wit
+++ b/proposals/http/wit/types.wit
@@ -370,6 +370,11 @@ interface types {
     /// This function takes a `res` future as a parameter, which can be used to
     /// communicate an error in handling of the request.
     ///
+    /// Middleware that forwards the request along a chain of handlers will
+    /// typically want to connect this `res` future to the future returned by
+    /// `request.new`, so that the originator of the `request` is notified of
+    /// errors that occur further down the chain.
+    ///
     /// Note that function will move the `request`, but references to headers or
     /// request options acquired from it previously will remain valid.
     consume-body: static func(this: request, res: future<result<_, error-code>>) -> tuple<stream<u8>, future<result<option<trailers>, error-code>>>;
@@ -465,6 +470,11 @@ interface types {
     ///
     /// This function takes a `res` future as a parameter, which can be used to
     /// communicate an error in handling of the response.
+    ///
+    /// Middleware that forwards the response along a chain of handlers will
+    /// typically want to connect this `res` future to the future returned by
+    /// `response.new`, so that the originator of the `response` is notified of
+    /// errors that occur further down the chain.
     ///
     /// Note that function will move the `response`, but references to headers
     /// acquired from it previously will remain valid.


### PR DESCRIPTION
Add wording to the `consume-body` docs noting that middleware forwarding along a handler chain will typically want to connect the `res` future it passes in to the future returned by `request.new` / `response.new`, so the originator of the `request` or `response` is notified of errors that occur further down the chain.

The current docs for `{request, response}.new` say
> The returned future resolves to result of transmission of this request.

and the docs for `consume-body` state
> This function takes a `res` future as a parameter, which can be used to communicate an error in handling of the request.

I think with this wording it's natural for a middleware author to pass `Ok` as long as they are able to successfully hand the request/response to the next layer and to do so without being aware that the originator of the request/response now can't see the result of transmission to the destination (here is [an example](https://github.com/bytecodealliance/wasmtime/blob/5f060a2a4ec7d6018c47d752fb4e23ad90817aee/crates/test-programs/src/bin/p3_http_middleware.rs#L70)).

This change should make the situation clearer.