### PR TITLE
Remove David Justice as a WASI proposal champion

### DIFF
--- a/docs/Proposals.md
+++ b/docs/Proposals.md
@@ -28,35 +28,35 @@ You can learn more about contributing new proposals (and other ways to contribut
 | [Filesystem][wasi-filesystem] | Dan Gohman, Victor Adossi                                             |          |
 | [Sockets][wasi-sockets]       | Dave Bakker                                                           |          |
 | [CLI][wasi-cli]               | Dan Gohman, Lann Martin                                               |          |
-| [HTTP][wasi-http]             | Piotr Sikora, Jiaxiao Zhou, Dan Chiarlone, David Justice, Luke Wagner |          |
+| [HTTP][wasi-http]             | Piotr Sikora, Jiaxiao Zhou, Dan Chiarlone, Luke Wagner                |          |
 
 ### Phase 2 - Proposed Spec Text Available (CG + WG)
 
 | Proposal                                           | Champion                                                              | Versions |
 | -------------------------------------------------- | --------------------------------------------------------------------- | -------- |
 | [Clocks: Timezone][wasi-clocks]                    | Dan Gohman, Colin Murphy                                              |          |
-| [HTTP: Informational Outbound Response][wasi-http] | Piotr Sikora, Jiaxiao Zhou, Dan Chiarlone, David Justice, Luke Wagner |          |
+| [HTTP: Informational Outbound Response][wasi-http] | Piotr Sikora, Jiaxiao Zhou, Dan Chiarlone, Luke Wagner                |          |
 | [I2C][wasi-i2c]                                    | Friedrich Vandenberghe, Merlijn Sebrechts, Maximilian Seidler         |          |
-| [Key-value Store][wasi-kv-store]                   | Jiaxiao Zhou, Dan Chiarlone, David Justice                            |          |
+| [Key-value Store][wasi-kv-store]                   | Jiaxiao Zhou, Dan Chiarlone                                           |          |
 | [Machine Learning (wasi-nn)][wasi-nn]              | Andrew Brown and Mingqiu Sun                                          |          |
-| [Runtime Config][wasi-runtime-config]              | Jiaxiao Zhou, Dan Chiarlone, David Justice                            |          |
+| [Runtime Config][wasi-runtime-config]              | Jiaxiao Zhou, Dan Chiarlone                                           |          |
 | [WebGPU][wasi-webgpu]                              | Mendy Berger, Sean Isom                                               |          |
-| [Messaging][wasi-messaging]                        | Jiaxiao Zhou, Dan Chiarlone, David Justice, Taylor Thomas             |          |
+| [Messaging][wasi-messaging]                        | Jiaxiao Zhou, Dan Chiarlone, Taylor Thomas.                           |          |
 
 ### Phase 1 - Feature Proposal (CG)
 
 | Proposal                                                  | Champion                                         | Versions |
 | --------------------------------------------------------- | ------------------------------------------------ | -------- |
-| [Blob Store][wasi-blob-store]                             | Jiaxiao Zhou, Dan Chiarlone, David Justice       |          |
+| [Blob Store][wasi-blob-store]                             | Jiaxiao Zhou, Dan Chiarlone.                     |          |
 | [Crypto][wasi-crypto]                                     | Frank Denis and Daiki Ueno                       |          |
 | [GPIO][wasi-gpio]                                         | Merlijn Sebrechts, Maximilian Seidler            |          |
-| [Distributed Lock Service][wasi-distributed-lock-service] | Jiaxiao Zhou, Dan Chiarlone, David Justice       |          |
+| [Distributed Lock Service][wasi-distributed-lock-service] | Jiaxiao Zhou, Dan Chiarlone.                     |          |
 | [Logging][wasi-logging]                                   | Dan Gohman                                       |          |
 | [Observe][wasi-observe]                                   | Caleb Schoepp                                    |          |
 | [Parallel][wasi-parallel]                                 | Andrew Brown                                     |          |
 | [Pattern Match][wasi-pattern-match]                       | Jianjun Zhu                                      |          |
 | [SPI][wasi-spi]                                           | Merlijn Sebrechts                                |          |
-| [SQL][wasi-sql]                                           | Jiaxiao Zhou, Dan Chiarlone, David Justice       |          |
+| [SQL][wasi-sql]                                           | Jiaxiao Zhou, Dan Chiarlone.                     |          |
 | [SQL Embed][wasi-sql-embed]                               | Robin Brown                                      |          |
 | [Threads][wasi-threads]                                   | Alexandru Ene, Marcin Kolny, Andrew Brown        |          |
 | [TLS][wasi-tls]                                           | Joel Dice, Dave Bakker, James Sturtevant         |          |

--- a/proposals/http/README.md
+++ b/proposals/http/README.md
@@ -11,7 +11,6 @@ wasi-http is currently in [Phase 3](https://github.com/WebAssembly/WASI/blob/mai
 * Piotr Sikora
 * Jiaxiao Zhou
 * Dan Chiarlone
-* David Justice
 * Luke Wagner
 
 ### Portability Criteria


### PR DESCRIPTION
I am stepping down as a proposal champion since I have not been active for a bit and would like to make way for others to drive this work. 

I won't be too far and will help in the future in any way I can.