### PR TITLE
Update WASI HTTP champions

### DIFF
--- a/docs/Proposals.md
+++ b/docs/Proposals.md
@@ -28,14 +28,14 @@ You can learn more about contributing new proposals (and other ways to contribut
 | [Filesystem][wasi-filesystem] | Dan Gohman, Victor Adossi                                             |          |
 | [Sockets][wasi-sockets]       | Dave Bakker                                                           |          |
 | [CLI][wasi-cli]               | Dan Gohman, Lann Martin                                               |          |
-| [HTTP][wasi-http]             | Jiaxiao Zhou, Dan Chiarlone, Luke Wagner                              |          |
+| [HTTP][wasi-http]             | Dan Chiarlone, Pat Hickey, Lann Martin, John VanEnk                   |          |
 
 ### Phase 2 - Proposed Spec Text Available (CG + WG)
 
 | Proposal                                           | Champion                                                              | Versions |
 | -------------------------------------------------- | --------------------------------------------------------------------- | -------- |
 | [Clocks: Timezone][wasi-clocks]                    | Dan Gohman, Colin Murphy                                              |          |
-| [HTTP: Informational Outbound Response][wasi-http] | Piotr Sikora, Jiaxiao Zhou, Dan Chiarlone, Luke Wagner                |          |
+| [HTTP: Informational Outbound Response][wasi-http] | Dan Chiarlone, Pat Hickey, Lann Martin, John VanEnk                   |          |
 | [I2C][wasi-i2c]                                    | Friedrich Vandenberghe, Merlijn Sebrechts, Maximilian Seidler         |          |
 | [Key-value Store][wasi-kv-store]                   | Jiaxiao Zhou, Dan Chiarlone                                           |          |
 | [Machine Learning (wasi-nn)][wasi-nn]              | Andrew Brown and Mingqiu Sun                                          |          |

--- a/docs/Proposals.md
+++ b/docs/Proposals.md
@@ -28,14 +28,14 @@ You can learn more about contributing new proposals (and other ways to contribut
 | [Filesystem][wasi-filesystem] | Dan Gohman, Victor Adossi                                             |          |
 | [Sockets][wasi-sockets]       | Dave Bakker                                                           |          |
 | [CLI][wasi-cli]               | Dan Gohman, Lann Martin                                               |          |
-| [HTTP][wasi-http]             | Dan Chiarlone, Pat Hickey, Lann Martin, John VanEnk                   |          |
+| [HTTP][wasi-http]             | Pat Hickey, Lann Martin, John VanEnk                                  |          |
 
 ### Phase 2 - Proposed Spec Text Available (CG + WG)
 
 | Proposal                                           | Champion                                                              | Versions |
 | -------------------------------------------------- | --------------------------------------------------------------------- | -------- |
 | [Clocks: Timezone][wasi-clocks]                    | Dan Gohman, Colin Murphy                                              |          |
-| [HTTP: Informational Outbound Response][wasi-http] | Dan Chiarlone, Pat Hickey, Lann Martin, John VanEnk                   |          |
+| [HTTP: Informational Outbound Response][wasi-http] | Pat Hickey, Lann Martin, John VanEnk                                  |          |
 | [I2C][wasi-i2c]                                    | Friedrich Vandenberghe, Merlijn Sebrechts, Maximilian Seidler         |          |
 | [Key-value Store][wasi-kv-store]                   | Jiaxiao Zhou, Dan Chiarlone                                           |          |
 | [Machine Learning (wasi-nn)][wasi-nn]              | Andrew Brown and Mingqiu Sun                                          |          |

--- a/proposals/http/README.md
+++ b/proposals/http/README.md
@@ -8,9 +8,10 @@ wasi-http is currently in [Phase 3](https://github.com/WebAssembly/WASI/blob/mai
 
 ### Champions
 
-* Jiaxiao Zhou
 * Dan Chiarlone
-* Luke Wagner
+* Pat Hickey
+* Lann Martin
+* John VanEnk
 
 ### Portability Criteria
 

--- a/proposals/http/README.md
+++ b/proposals/http/README.md
@@ -8,7 +8,6 @@ wasi-http is currently in [Phase 3](https://github.com/WebAssembly/WASI/blob/mai
 
 ### Champions
 
-* Dan Chiarlone
 * Pat Hickey
 * Lann Martin
 * John VanEnk


### PR DESCRIPTION
This PR updates the WASI HTTP champions to replace myself, @Mossaka and @devigned with @pchickey, @lann and @sw17ch, as voted in by the SG in [WASI-09-03](https://github.com/WebAssembly/meetings/blob/main/wasi/2026/WASI-09-03.md).  cc @danbugs as an HTTP champion before and after this change.